### PR TITLE
.configs: enabled hestiaGO and hestiaRUST package and release CI jobs

### DIFF
--- a/.configs/monteur/package/jobs/zip-hestiaGO.toml
+++ b/.configs/monteur/package/jobs/zip-hestiaGO.toml
@@ -1,7 +1,7 @@
 [Metadata]
-Name = 'Tar-GZip HestiaRUST'
+Name = 'Zip HestiaGO'
 Description = """
-Package application into a single .tar.gz package.
+Package application into a single .zip package.
 """
 Type = 'manual'
 
@@ -9,16 +9,28 @@ Type = 'manual'
 
 
 [Variables]
-Product = 'hestiaRUST'
+Product = 'hestiaGO'
 LicenseSourcePath = 'licenses/hestia-software-license.pdf'
 
 [FMTVariables]
 LicenseSourceDir = '{{- .RootDir -}}/docs/content'
 PackageDir = '{{- .WorkingDir -}}/{{- .Product -}}'
-PackagePath = '{{- .WorkingDir -}}/{{- .Product -}}-{{- .App.Version -}}-pack.tar.gz'
+
+
 
 
 [[Dependencies]]
+Name = 'Zip Program for Archive and Compression'
+Conditions = 'all-all'
+Type = 'command'
+Command = 'zip'
+
+
+[[Dependencies]]
+Name = 'GPG Program for Cryptography Certificate Generation'
+Conditions = 'all-all'
+Type = 'command'
+Command = 'gpg'
 
 
 
@@ -53,18 +65,10 @@ Source = '{{ .PackageDir -}}'
 
 
 [[CMD]]
-Name = 'Clean Rust Target Directory if Exists'
-Type = 'delete-recursive'
-Condition = [ 'all-all' ]
-Source = '{{- .RootDir -}}/{{- .Product -}}/target'
-
-
-[[CMD]]
 Name = 'Copy Source Product into Packaging Directory'
-Type = 'copy'
+Type = 'command'
 Condition = [ 'all-all' ]
-Source = '{{- .RootDir -}}/{{- .Product -}}'
-Target = '{{- .PackageDir -}}/hestia'
+Source = 'cp -r "{{- .RootDir -}}/{{- .Product -}}" "{{- .PackageDir -}}/{{- .Product -}}"'
 
 
 [[CMD]]
@@ -72,7 +76,7 @@ Name = 'Copy English License File into Packaging Directory'
 Type = 'copy'
 Condition = [ 'all-all' ]
 Source = '{{- .LicenseSourceDir -}}/en/{{- .LicenseSourcePath -}}'
-Target = '{{- .PackageDir -}}/hestia/License-Code-en.pdf'
+Target = '{{- .PackageDir -}}/License-en.pdf'
 
 
 [[CMD]]
@@ -80,11 +84,25 @@ Name = 'Copy English License Signature File into Packaging Directory'
 Type = 'copy'
 Condition = [ 'all-all' ]
 Source = '{{- .LicenseSourceDir -}}/en/{{- .LicenseSourcePath -}}.asc'
-Target = '{{- .PackageDir -}}/hestia/License-Code-en.pdf.asc'
+Target = '{{- .PackageDir -}}/License-en.pdf.asc'
 
 
 [[CMD]]
-Name = 'Compress into TarGz'
+Name = 'Compress into Zip'
 Type = 'command'
 Condition = [ 'all-all' ]
-Source = 'tar cfzv "{{- .PackagePath -}}" "{{- .PackageDir -}}"'
+Location = '{{- .WorkingDir -}}'
+Source = 'zip -r "{{- .Product -}}-{{- .App.Version -}}.zip" "{{- .Product -}}"'
+
+
+[[CMD]]
+Name = 'Generate GPG Certificate'
+Type = 'command'
+Condition = [ 'all-all' ]
+Location = '{{- .WorkingDir -}}'
+Source = '''gpg \
+--local-user hello@zoralab.com \
+--armor \
+--detach-sign \
+"{{- .Product -}}-{{- .App.Version -}}.zip" \
+'''

--- a/.configs/monteur/package/jobs/zip-hestiaRUST.toml
+++ b/.configs/monteur/package/jobs/zip-hestiaRUST.toml
@@ -1,7 +1,7 @@
 [Metadata]
-Name = 'Tar-GZip HestiaGO'
+Name = 'Zip HestiaRUST'
 Description = """
-Package application into a single .tar.gz package.
+Package application into a single .zip package.
 """
 Type = 'manual'
 
@@ -9,16 +9,28 @@ Type = 'manual'
 
 
 [Variables]
-Product = 'hestiaGO'
+Product = 'hestiaRUST'
 LicenseSourcePath = 'licenses/hestia-software-license.pdf'
 
 [FMTVariables]
 LicenseSourceDir = '{{- .RootDir -}}/docs/content'
 PackageDir = '{{- .WorkingDir -}}/{{- .Product -}}'
-PackagePath = '{{- .WorkingDir -}}/{{- .Product -}}-{{- .App.Version -}}-pack.tar.gz'
+
+
 
 
 [[Dependencies]]
+Name = 'Zip Program for Archive and Compression'
+Conditions = 'all-all'
+Type = 'command'
+Command = 'zip'
+
+
+[[Dependencies]]
+Name = 'GPG Program for Cryptography Certificate Generation'
+Conditions = 'all-all'
+Type = 'command'
+Command = 'gpg'
 
 
 
@@ -40,7 +52,7 @@ BuildSource = false
 
 [[CMD]]
 Name = 'Delete Existing Packaging Directory if Exists'
-Type = 'delete-quiet'
+Type = 'delete-recursive-quiet'
 Condition = [ 'all-all' ]
 Source = '{{ .PackageDir -}}'
 
@@ -54,10 +66,9 @@ Source = '{{ .PackageDir -}}'
 
 [[CMD]]
 Name = 'Copy Source Product into Packaging Directory'
-Type = 'copy'
+Type = 'command'
 Condition = [ 'all-all' ]
-Source = '{{- .RootDir -}}/{{- .Product -}}'
-Target = '{{- .PackageDir -}}/hestia'
+Source = 'cp -r "{{- .RootDir -}}/{{- .Product -}}" "{{- .PackageDir -}}/{{- .Product -}}"'
 
 
 [[CMD]]
@@ -65,7 +76,7 @@ Name = 'Copy English License File into Packaging Directory'
 Type = 'copy'
 Condition = [ 'all-all' ]
 Source = '{{- .LicenseSourceDir -}}/en/{{- .LicenseSourcePath -}}'
-Target = '{{- .PackageDir -}}/hestia/License-Code-en.pdf'
+Target = '{{- .PackageDir -}}/License-en.pdf'
 
 
 [[CMD]]
@@ -73,11 +84,25 @@ Name = 'Copy English License Signature File into Packaging Directory'
 Type = 'copy'
 Condition = [ 'all-all' ]
 Source = '{{- .LicenseSourceDir -}}/en/{{- .LicenseSourcePath -}}.asc'
-Target = '{{- .PackageDir -}}/hestia/License-Code-en.pdf.asc'
+Target = '{{- .PackageDir -}}/License-en.pdf.asc'
 
 
 [[CMD]]
-Name = 'Compress into TarGz'
+Name = 'Compress into Zip'
 Type = 'command'
 Condition = [ 'all-all' ]
-Source = 'tar cfzv "{{- .PackagePath -}}" "{{- .PackageDir -}}"'
+Location = '{{- .WorkingDir -}}'
+Source = 'zip -r "{{- .Product -}}-{{- .App.Version -}}.zip" "{{- .Product -}}"'
+
+
+[[CMD]]
+Name = 'Generate GPG Certificate'
+Type = 'command'
+Condition = [ 'all-all' ]
+Location = '{{- .WorkingDir -}}'
+Source = '''gpg \
+--local-user hello@zoralab.com \
+--armor \
+--detach-sign \
+"{{- .Product -}}-{{- .App.Version -}}.zip" \
+'''

--- a/.configs/monteur/release/jobs/archive.toml
+++ b/.configs/monteur/release/jobs/archive.toml
@@ -38,6 +38,26 @@ OS = [ "all" ]
 Arch = [ "all" ]
 Source = '{{- .PackageDir -}}/hestiaHUGO-{{- .App.Version -}}.zip.asc'
 
+[Releases.Packages.all-all-hestiaGO]
+OS = [ "all" ]
+Arch = [ "all" ]
+Source = '{{- .PackageDir -}}/hestiaGO-{{- .App.Version -}}.zip'
+
+[Releases.Packages.all-all-hestiaGO-GPG]
+OS = [ "all" ]
+Arch = [ "all" ]
+Source = '{{- .PackageDir -}}/hestiaGO-{{- .App.Version -}}.zip.asc'
+
+[Releases.Packages.all-all-hestiaRUST]
+OS = [ "all" ]
+Arch = [ "all" ]
+Source = '{{- .PackageDir -}}/hestiaRUST-{{- .App.Version -}}.zip'
+
+[Releases.Packages.all-all-hestiaRUST-GPG]
+OS = [ "all" ]
+Arch = [ "all" ]
+Source = '{{- .PackageDir -}}/hestiaRUST-{{- .App.Version -}}.zip.asc'
+
 
 
 

--- a/docs/content/en/__content.html
+++ b/docs/content/en/__content.html
@@ -96,9 +96,9 @@
 					<h3>Simple To Install</h3>
 					<p>
 						<b>Simple and basic
-						<code>zip</code>/<code>.tar.gz</code>
-						packaging and distribution</b>;
-						Easy to setup and easy to share.
+						<code>zip</code> packaging and
+						distribution</b>; Easy to setup
+						and easy to share.
 					</p>
 					<br/>
 					<p>


### PR DESCRIPTION
Since we are now in phase 2, we should continue working on hestiaGO and hestiaRUST in a focused manner. Hence, let's start with their CI jobs for packaging and release tasks.

This patch enables hestiaGO and hestiaRUST package and release CI jobs in .configs/ directory.

Signed-off-by: (Holloway) Chew, Kean Ho <kean.ho.chew@zoralab.com>