### PR TITLE
sites: added /licenses/ generic URL link

### DIFF
--- a/sites/content/licenses/__assets.toml
+++ b/sites/content/licenses/__assets.toml
@@ -1,0 +1,122 @@
+# PAGE SPECIFIC ASSETS
+# ====================
+# You can include or inline CSS assets into this specific page only by listing
+# out their .URL or relative file .PATH sources respectively.
+#
+# All .CSS.Inline artifacts shall only be provided with Hugo's virtual pathing
+# only.
+#
+# As For .CSS.Include artifacts, Hestia's URL processing is available for
+# dynamic relative pathing constructions. As long as the URL is accessible,
+# storing location is not restricted to any single location.
+#
+# Example, for the artifact placed in:
+#          assets storage directory =    assets/
+#          artifact location        =    assets/css/my-site.min.css
+#          .Inline value            =    assets/css/my-site.min.css
+#          .Include value           =    NOT APPLICABLE
+#
+#          page storage directory   =    en/my-page-here/
+#          artifact location        =    en/my-page-here/my-page.min.css
+#          .Inline value            =    en/my-page-here/my-page.min.css
+#          .Include value           =    /en/my-page-here/my-page.min.css
+#
+#          static storage directory =    static/css/
+#          artifact location        =    static/css/my-page.min.css
+#          .Inline value            =    NOT APPLICABLE
+#          .Include value           =    /css/my-page.min.css
+#
+# The data structure pattern is as follows:
+#                  [[CSS.Inline]]
+#                  Path = '{{ .Inline }}'
+#
+#                         OR
+#
+#                  [[CSS.Include]]
+#                  URL = '{{ .Include }}'
+#                  Media = '{{ .Include.Media }}'
+#                  OnLoad = '{{ .Include.OnLoad }}'
+#
+# To add more entries into either list, simply append new data structure below.
+# The position of the entries dictates the rendering sequence of its statement.
+#
+# For .Include list, should .Media or .Onload is used for asynchonous loading,
+# there is no guarentee for the actual CSS loading sequences (see:
+# https://web.dev/critical-rendering-path-render-blocking-css/). When in doubt,
+# leaving them blank.
+#
+# NOTE:
+# The '__content.hestiaCSS', the page-specific CSS control file will be
+# automatically appended into .CSS.Inline as the last item (demmed the most
+# powerful among all when operating in .Include leading the .Inline mode). You
+# DO NOT need to manually add it in.
+[[CSS.Inline]]
+Path = ''
+
+
+[[CSS.Include]]
+URL = ''
+Media = ''
+OnLoad = ''
+
+
+
+
+# You can include or inline JS assets into this specific page only by listing
+# out their .URL or relative file .PATH sources respectively.
+#
+# All .JS.Inline artifacts shall only be provided with Hugo's virtual pathing.
+#
+# As for .JS.Include artifacts, Hestia's URL processing is available for
+# dynamic relative pathing constructions. As long as the URL is accessible,
+# storing location is not restricted to any single location.
+#
+# Example, for the artifact placed in:
+#          assets storage directory =    assets/
+#          artifact location        =    assets/js/my-site.min.js
+#          .Inline value            =    assets/js/my-site.min.js
+#          .Include value           =    NOT APPLICABLE
+#
+#          page storage directory   =    en/my-page-here/
+#          artifact location        =    en/my-page-here/my-page.min.js
+#          .Inline value            =    en/my-page-here/my-page.min.js
+#          .Include value           =    /en/my-page-here/my-page.min.js
+#
+#          static storage directory =    static/js/
+#          artifact location        =    static/js/my-page.min.js
+#          .Inline value            =    NOT APPLICABLE
+#          .Include value           =    /js/my-page.min.js
+#
+# The data structure pattern is as follows:
+#                  [[JS.Inline]]
+#                  Path = '{{ .Inline }}'
+#
+#                         OR
+#
+#                  [[JS.Include]]
+#                  URL = '{{ .Include }}'
+#                  Timing = '...'
+#
+# To add more entries into either list, simply append new data structure below.
+# The position of the entries dictates the rendering sequence of its statement.
+#
+# For the .Include List, the .Timing value can be any of the following:
+#     1. 'defer' - download the asset first and execute after DOM (default).
+#     2. 'async' - download the asset in parallel to DOM and execute immediately
+#                  regardless of DOM completion status.
+#     3. 'sync'  - block DOM and synchonously download and execute the asset.
+# When in doubt, stick to 'defer' as you would not want to block the page from
+# DOM rendering completion at all time.
+#
+# NOTE:
+# The '__content.hestiaJS', the page-specific JS control file will
+# automatically be appended into .JS.Inline as the last item (deemed the most
+# powerful among all when operating in .Include leading .Inline mode). You DO
+# NOT need to manually add it in.
+[[JS.Inline]]
+Path = ''
+
+
+[[JS.Include]]
+URL = ''
+Timing = 'defer'

--- a/sites/content/licenses/__components.toml
+++ b/sites/content/licenses/__components.toml
@@ -1,0 +1,103 @@
+# HESTIA PAGE-LEVEL WEB UI COMPONENTS LIST
+# ========================================
+# All Hestia internal web UI components for this page.
+#
+# The components' low-level codes are auto-generated from hestiaGO code
+# libraries for rendering consistency between non-WASM users and WASM users.
+#
+# If you're using WASM from Hestia code libraries and they are directly
+# controlling the page UI (either as single-page rendering or reactive
+# rendering), you **SHOULD NOT** include anything below as they're duplicates
+# and can cause confusing complications. Please stick to ONE(1) rendering
+# method.
+#
+# You SHOULD ONLY include components that are used in this page. To configure:
+#     [[List]]
+#     Name = "COMPONENT"
+#     Include = true
+#     Variables = [
+#            { "--variable-1" = "1rem" },
+#            { "--variable-2" = "2rem" },
+#     ]
+#
+#     List.{POSITION}.Name      = name of the component (string)
+#     List.{POSITION}.Include   = inclusion decision (bool true/false)
+#     List.{POSITION}.Variables = list of overriding variables to the component.
+#
+# NOTE:
+#     1) The position of the component listing influences the variables
+#        overriding sequence. Please construct your list properly.
+#     2) Check out Hestia's hestiaGUI catalog list for supported UI components
+#        at:
+#                 https://hestia.zoralab.com/en/specs/hestiaGUI/
+#
+#
+# EXAMPLE:
+#        [[List]]
+#        Name = "zoralabCORE"
+#        Include = true
+#        Variables = [
+#                  { "--test-variable-1" = "1rem" },
+#                  { "--test-variable-2" = "2rem" },
+#        ]
+#
+#        [[List]]
+#        Name = "zoralabFONT_NOTOSANS"
+#        Include = true
+#        Variables = []
+#
+#        ...
+[[List]]
+Name = "zoralabCORE"
+Include = true
+Variables = [
+	{ "--body-scroll-behavior" = "smooth" },
+]
+
+[[List]]
+Name = "zoralabFONT_NOTOSANS"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabDRAWER"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabDRAWER_LEFT"
+Include = true
+Variables = [
+	{ "--left-drawer-width-opened" = "80vw" },
+	{ "--left-drawer-trigger-position-top" = "0" },
+]
+
+[[List]]
+Name = "zoralabANCHOR"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabBUTTON"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabTILE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabTABLE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabCODE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabULIST"
+Include = true
+Variables = []

--- a/sites/content/licenses/__content.hestiaCSS
+++ b/sites/content/licenses/__content.hestiaCSS
@@ -1,0 +1,15 @@
+{{- /*
+Page's CSS Prime Control
+
+This page constructs the page-specific CSS codes that will be appeneded into
+.CSS.Inline as the last entry (most powerful). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+
+
+
+
+{{- /* render your page output */ -}}

--- a/sites/content/licenses/__content.hestiaHTML
+++ b/sites/content/licenses/__content.hestiaHTML
@@ -1,0 +1,16 @@
+{{- /*
+Page's HTML Output Prime Control
+
+This file is your HTML output file (index.html). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms are required.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $ret := false -}}
+{{- $i18n := .Data.Page.i18n -}}
+
+
+
+
+{{- /* render outputs */ -}}

--- a/sites/content/licenses/__content.hestiaJS
+++ b/sites/content/licenses/__content.hestiaJS
@@ -1,0 +1,15 @@
+{{- /*
+Page's Javascript Prime Control
+
+This page constructs the page-specific JS codes that will be appeneded into
+.JS.Inline as last entry (most powerful). Hugo's and Go's template processors
+are available at your disposal in case of mathematical or logical algorithms
+development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+
+
+
+
+{{- /* render your Javascript output */ -}}

--- a/sites/content/licenses/__content.hestiaJSON
+++ b/sites/content/licenses/__content.hestiaJSON
@@ -1,0 +1,9 @@
+{{- /*
+Page's JSON Output Prime Control
+
+This file is your JSON output file (index.json). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms development.
+*/ -}}
+{{- /* render output */ -}}
+{{- jsonify dict -}}

--- a/sites/content/licenses/__content.hestiaLDJSON
+++ b/sites/content/licenses/__content.hestiaLDJSON
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (partial "hestiaJSON/schemaorgLDJSON/WebPage" .) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/licenses/__contributors.toml
+++ b/sites/content/licenses/__contributors.toml
@@ -1,0 +1,78 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...
+[[Contributors]]
+Key = 'ZORALab'
+
+[Contributors.Contribution]
+Creation = true
+Contact = true
+Artwork = false
+Knowledge = false
+Editor = true
+Developer = false
+Maintainer = false
+Producer = true
+Provider = true
+Publisher = true
+Funder = false
+Sponsor = true
+
+
+
+
+[[Contributors]]
+Key = 'HollowayKeanHo'
+
+[Contributors.Contribution]
+Creation = true
+Contact = false
+Artwork = false
+Knowledge = true
+Editor = true
+Developer = false
+Maintainer = false
+Producer = false
+Provider = false
+Publisher = false
+Funder = false
+Sponsor = false

--- a/sites/content/licenses/__i18n.toml
+++ b/sites/content/licenses/__i18n.toml
@@ -1,0 +1,214 @@
+[i18n]
+Title = 'Title'
+Description = 'Description'
+
+
+
+
+[i18n.Introduction]
+ID = 'zoralab-hestia-licenses'
+Title = "ZORALab's Hestia Authorized Licenses"
+
+
+
+
+[i18n.Documentations]
+ID = 'documentations'
+Title = 'Documentations'
+Description = '''
+All required legal documents for the entire ZORALab's Hestia Project in the
+following table. Please read through ALL OF THEM thoroughly before use.
+'''
+
+
+[i18n.Documentations.Labels]
+Type = 'TYPE'
+PDF = 'PDF'
+Signature = 'GPG SIGNATURE'
+Key = 'GPG KEY'
+Coverage = 'COVERAGE'
+Examples = 'EXAMPLES'
+Sources = "SOURCES"
+
+
+
+[i18n.Guidelines]
+ID = 'guidelines'
+Title = 'Guidelines'
+Description = '''
+While ZORALab's Hestia Project permits you to have quite a large freedom to
+perform your creation freely, its legal documentations are still very hostile to
+some. We had prepared this simple guidelines just in case:
+'''
+
+[i18n.Guidelines.Labels]
+Do = 'Please DO'
+Dont = 'Please DO NOT'
+
+
+[[i18n.Guidelines.DO]]
+Value = '''
+Only use the source codes from the ZORALab's Hestia Project. Anything that are
+not codes (e.g. image, video, binary, audio, etc) are prohibited. If you need
+them, contact the original artists or creators at our attribution list in the
+landing page.
+'''
+
+[[i18n.Guidelines.DO]]
+Value = '''
+Attribute (or add credits) back to ZORALab's Hestia Project when you use the
+library. A simple "Thanks to ZORALab's Hestia Project" with an URL backlink is
+suffice.
+'''
+
+[[i18n.Guidelines.DO]]
+Value = '''
+Can use ZORALab's Hestia Project in your commerical use (e.g. building a
+chargable app, whether directly or requesting donation) as long as you do the
+attributions.
+'''
+
+[[i18n.Guidelines.DO]]
+Value = '''
+When referring a Copyleft effect source (e.g. GPL-2), ONLY: (1) try to read;
+understand the algorithm; (2) produce an algorithm document; (3) remove the code
+sources; (4) then based on the algorithm document and write a fresh new set of
+codes. NEVER copy and paste directly.
+'''
+
+[[i18n.Guidelines.DO]]
+Value = '''
+When contributing back to upstream: please make sure your contributions are
+compliant to the outbound licenses shown above. We are not allowed to accept
+incompatible licenses like GPL-2, GPL-3, unknown, or worse: proprietary.
+'''
+
+[[i18n.Guidelines.DO]]
+Value = '''
+When contributing back to upstream: please make sure you reference all your
+sources in the files' copyright headers (trace all the way back to its birth).
+We do file-level licensing notice, not just LICENSE.md file for added defenses.
+'''
+
+[[i18n.Guidelines.DO]]
+Value = '''
+When contributing back to upstream: please make sure you references' info are
+publicly obtainable (e.g. published portfolio website). Generally, the minimum
+is only full name and contactable email address are required.
+'''
+
+[[i18n.Guidelines.DO]]
+Value = '''
+If your upstream contributions involve graphical work, only code-only SVG
+vector graphics with no embedded or remote URL calls file type is accepted.
+'''
+
+[[i18n.Guidelines.DO]]
+Value = '''
+If your upstream contributions involving graphical work for documentations,
+please ONLY source from free (as in price and use rights) like Pexels or Pixabay
+and attribute the artists eventhough their licenses are permissive.
+'''
+
+[[i18n.Guidelines.DO]]
+Value = '''
+When contributing back to upstream involving graphical work for documentations:
+please make sure you references' first contact MUST be a public website
+and indicating the origin of your source (every artist's first actionable link
+represents the source of info and his/her artworks).
+'''
+
+[[i18n.Guidelines.DO]]
+Value = '''
+When contributing back to upstream involving graphical work for documentations:
+please make sure the graphics you use DO NOT contain any identifiable model
+entity (requires a separate model release form legal document for each one).
+Model includes identifiable owned non-human entites like pet animals or iconic
+cases like the night shot of Effiel Tower.
+'''
+
+[[i18n.Guidelines.DO]]
+Value = '''
+Avoid AI generated artwork whenever possible. Please support the artists even
+as little as attributions in the landing page.
+'''
+
+[[i18n.Guidelines.DO]]
+Value = '''
+Please respect your references' work, efforts, inbound licenses' terms and
+conditions, and thier priacy.
+'''
+
+[[i18n.Guidelines.DONT]]
+Value = '''
+DO NOT USE the ZORALab's Hestia Project's source codes THEN CLAIM your entire
+build is YOUR NOVEL DEVELOPMENT. Site-note: don't force us or anyone to publicly
+snipe you; you bloodly dumb and idiotic pirate!
+'''
+
+[[i18n.Guidelines.DONT]]
+Value = '''
+DO NOT COPY PASTE your codes from anywhere without investigating its source of
+origin or its references.
+'''
+
+[[i18n.Guidelines.DONT]]
+Value = '''
+DO NOT USE our pictures, audio, media files and artifacts from the sites/ and
+the artworks/ directories. Go source them directly from the artists listed in
+the landing page.
+'''
+
+[[i18n.Guidelines.DONT]]
+Value = '''
+DO NOT REFERENCE any closed-source documentations or engineering specification
+(where general public cannot obtain without purchase or etc). We do not intend
+to propogate unnecessary difficulties downstream.
+'''
+
+[[i18n.Guidelines.DONT]]
+Value = '''
+DO NOT USE graphical work involving model entities like human or identifiable
+owned entities like pet animals for documentations WITHOUT all signed and
+ratified Model Release Form legal documents made available publicly.
+'''
+
+[[i18n.Guidelines.DONT]]
+Value = '''
+DO NOT USE graphical work, regardless being legally or illegally from a paid
+stocked photos that are non-distributable by default.
+'''
+
+[[i18n.Guidelines.DONT]]
+Value = '''
+DO NOT DISRESPECT your references' inbound licenses' terms and conditions and
+their privacy.
+'''
+
+
+
+
+[i18n.COC]
+ID = 'code-of-conduct'
+Title = 'Code of Conduct'
+Description = '''
+This is a software library repository for software developers; not a baby
+daycare, not a kindergarden, not a school, not a forum, not a political body,
+and not your enforcement entity. Please BEHAVE & RESPECT. DO NOT FORCE US to
+write a long restrictive human psychological mind-control manual here ⇒
+PLEASE BRING YOUR OPINIONS AND POLITICS ELSEWHERE.
+'''
+
+
+
+
+[i18n.Epilogue]
+ID = 'epilogue'
+Title = 'Epilogue'
+Description = '''
+That's all for ZORALab's Hestia Project's licenses and all related legal
+documents. When you're ready, we got you covered! Please feel free to start your
+journey here:
+'''
+URL = '/en/getting-started'
+CTA = 'Getting Started'

--- a/sites/content/licenses/__languages.toml
+++ b/sites/content/licenses/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = '/en/licenses/'
+
+[zh-Hans]
+URL = '/zh-hans/licenses/'

--- a/sites/content/licenses/__page.toml
+++ b/sites/content/licenses/__page.toml
@@ -1,0 +1,109 @@
+# PAGE METADATA
+# =============
+# Date fields.
+#
+# NOTE:
+#   1. You can generate date easily on linux using '$ date' command.
+#   2. If date field is left blank, the current time shall be used instead.
+#   3. Date should ONLY comply to this pattern when manually constructed:
+#                    Thu 21 Jul 2022 14:27:39 PM +08
+[Date]
+Created   = 'Mon 19 Dec 2022 12:31:12 PM +08'
+Published = 'Mon 19 Dec 2022 12:31:12 PM +08'
+
+
+
+
+# Content fields.
+# NOTE:
+#   1. For .Title, Hestia's string processing using page variables are allowed
+#      and only limited to .Titles sub-fields.
+#   2. For .Keywords, Hestia's string processing using page variables are
+#      allowed but strongly discouraged.
+[Content]
+Title = "ZORALab's Hestia Licenses"
+Keywords = [
+	'Licenses',
+	'Software Libraries',
+	'ZORALab',
+	"ZORALab's Hestia",
+]
+
+
+
+
+# Description fields.
+# NOTE:
+#   1. Hestia's string processing using page variables are allowed.
+#   2. The .Description.Pitch is at maximum 160 characters.
+#   3. The .Description.Summary is at maximum of 250 characters.
+#   4. All fields shall have their whitespace cleansed during the processing.
+[Description]
+Pitch = '''
+Redirecting you to your language.
+'''
+Summary = '''
+Redirecting one to your own language.
+'''
+
+
+
+
+# Redirect fields.
+# NOTE:
+#   1. Hestia's URL processing is allowed for .URL field.
+#   2. .Delay timing sets the delay time before redirect. Setting to '0' means
+#      an immediate redirect is requested.
+#   3. Redirect is only available if .Enabled is set to 'true'.
+#   4. Redirect.Language is to redirect the current page to its
+#      language-specific page when Javascript is made available on client side
+#      or fallback to default language.
+[Redirect]
+Delay = 0 # second
+URL = ''
+Enabled = false
+
+[Redirect.Language]
+Enabled = true
+
+
+
+
+# Content Files' Sourcing Location
+# NOTE:
+#   1. To denote where are the content sources.
+#   2. If you're sourcing from assets directory, prefix 'assets/'.
+#   3. If you're sourcing from layouts directory, prefix 'layouts/'.
+#   2. If you're sourcing from static directory, prefix 'static/'.
+#   3. If you're sourcing from partial directory, prefix 'layouts/partials/'.
+[Sources]
+HTML = '__content.hestiaHTML'
+JSON = '__content.hestiaJSON'
+LDJSON = '__content.hestiaLDJSON'
+Contributors = '__contributors.toml'
+Thumbnails = '__thumbnails.toml'
+Languages = '__languages.toml'
+
+
+
+
+# Data fields.
+# NOTE:
+#   1. List only the page-level data files. It can be in any of the following
+#      formats: '.json', '.toml', or '.yaml'.
+#   2. Hestia string processing is available and shall be processed prior to
+#      dataset transformation.
+#   3. Sequences of the .Data array dictates sequences of loading and overriding
+#      (the latter shall overwrite the former for the same data fields).
+#   4. The final processed dataset shall be served as main data content in
+#      supported output format (e.g. index.json).
+#   5. Missing data file shall be ignored.
+#   6. To add more data files, simply duplicate and add more .Data array entry.
+#      Example:
+#                             [[data]]
+#                             Filename = 'file1.json'
+#
+#                             [[data]]
+#                             Filename = 'file2.toml'
+[[Data]]
+Filename = '__i18n.toml'

--- a/sites/content/licenses/__robots.toml
+++ b/sites/content/licenses/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/licenses/__thumbnails.toml
+++ b/sites/content/licenses/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/thumbnails-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/thumbnails-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/thumbnails-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/licenses/__twitter.toml
+++ b/sites/content/licenses/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/licenses/__wasm.toml
+++ b/sites/content/licenses/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/licenses/_index.html
+++ b/sites/content/licenses/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++


### PR DESCRIPTION
Since originally the licenses page has a generic URL link, we have to restore it. Hence, let's do this.

This patch adds /licenses/ generic URL link into sites/ directory.