### PR TITLE
sites: ported /en/getting-started/ page

### DIFF
--- a/sites/content/en/getting-started/__assets.toml
+++ b/sites/content/en/getting-started/__assets.toml
@@ -1,0 +1,122 @@
+# PAGE SPECIFIC ASSETS
+# ====================
+# You can include or inline CSS assets into this specific page only by listing
+# out their .URL or relative file .PATH sources respectively.
+#
+# All .CSS.Inline artifacts shall only be provided with Hugo's virtual pathing
+# only.
+#
+# As For .CSS.Include artifacts, Hestia's URL processing is available for
+# dynamic relative pathing constructions. As long as the URL is accessible,
+# storing location is not restricted to any single location.
+#
+# Example, for the artifact placed in:
+#          assets storage directory =    assets/
+#          artifact location        =    assets/css/my-site.min.css
+#          .Inline value            =    assets/css/my-site.min.css
+#          .Include value           =    NOT APPLICABLE
+#
+#          page storage directory   =    en/my-page-here/
+#          artifact location        =    en/my-page-here/my-page.min.css
+#          .Inline value            =    en/my-page-here/my-page.min.css
+#          .Include value           =    /en/my-page-here/my-page.min.css
+#
+#          static storage directory =    static/css/
+#          artifact location        =    static/css/my-page.min.css
+#          .Inline value            =    NOT APPLICABLE
+#          .Include value           =    /css/my-page.min.css
+#
+# The data structure pattern is as follows:
+#                  [[CSS.Inline]]
+#                  Path = '{{ .Inline }}'
+#
+#                         OR
+#
+#                  [[CSS.Include]]
+#                  URL = '{{ .Include }}'
+#                  Media = '{{ .Include.Media }}'
+#                  OnLoad = '{{ .Include.OnLoad }}'
+#
+# To add more entries into either list, simply append new data structure below.
+# The position of the entries dictates the rendering sequence of its statement.
+#
+# For .Include list, should .Media or .Onload is used for asynchonous loading,
+# there is no guarentee for the actual CSS loading sequences (see:
+# https://web.dev/critical-rendering-path-render-blocking-css/). When in doubt,
+# leaving them blank.
+#
+# NOTE:
+# The '__content.hestiaCSS', the page-specific CSS control file will be
+# automatically appended into .CSS.Inline as the last item (demmed the most
+# powerful among all when operating in .Include leading the .Inline mode). You
+# DO NOT need to manually add it in.
+[[CSS.Inline]]
+Path = ''
+
+
+[[CSS.Include]]
+URL = ''
+Media = ''
+OnLoad = ''
+
+
+
+
+# You can include or inline JS assets into this specific page only by listing
+# out their .URL or relative file .PATH sources respectively.
+#
+# All .JS.Inline artifacts shall only be provided with Hugo's virtual pathing.
+#
+# As for .JS.Include artifacts, Hestia's URL processing is available for
+# dynamic relative pathing constructions. As long as the URL is accessible,
+# storing location is not restricted to any single location.
+#
+# Example, for the artifact placed in:
+#          assets storage directory =    assets/
+#          artifact location        =    assets/js/my-site.min.js
+#          .Inline value            =    assets/js/my-site.min.js
+#          .Include value           =    NOT APPLICABLE
+#
+#          page storage directory   =    en/my-page-here/
+#          artifact location        =    en/my-page-here/my-page.min.js
+#          .Inline value            =    en/my-page-here/my-page.min.js
+#          .Include value           =    /en/my-page-here/my-page.min.js
+#
+#          static storage directory =    static/js/
+#          artifact location        =    static/js/my-page.min.js
+#          .Inline value            =    NOT APPLICABLE
+#          .Include value           =    /js/my-page.min.js
+#
+# The data structure pattern is as follows:
+#                  [[JS.Inline]]
+#                  Path = '{{ .Inline }}'
+#
+#                         OR
+#
+#                  [[JS.Include]]
+#                  URL = '{{ .Include }}'
+#                  Timing = '...'
+#
+# To add more entries into either list, simply append new data structure below.
+# The position of the entries dictates the rendering sequence of its statement.
+#
+# For the .Include List, the .Timing value can be any of the following:
+#     1. 'defer' - download the asset first and execute after DOM (default).
+#     2. 'async' - download the asset in parallel to DOM and execute immediately
+#                  regardless of DOM completion status.
+#     3. 'sync'  - block DOM and synchonously download and execute the asset.
+# When in doubt, stick to 'defer' as you would not want to block the page from
+# DOM rendering completion at all time.
+#
+# NOTE:
+# The '__content.hestiaJS', the page-specific JS control file will
+# automatically be appended into .JS.Inline as the last item (deemed the most
+# powerful among all when operating in .Include leading .Inline mode). You DO
+# NOT need to manually add it in.
+[[JS.Inline]]
+Path = ''
+
+
+[[JS.Include]]
+URL = ''
+Timing = 'defer'

--- a/sites/content/en/getting-started/__components.toml
+++ b/sites/content/en/getting-started/__components.toml
@@ -1,0 +1,108 @@
+# HESTIA PAGE-LEVEL WEB UI COMPONENTS LIST
+# ========================================
+# All Hestia internal web UI components for this page.
+#
+# The components' low-level codes are auto-generated from hestiaGO code
+# libraries for rendering consistency between non-WASM users and WASM users.
+#
+# If you're using WASM from Hestia code libraries and they are directly
+# controlling the page UI (either as single-page rendering or reactive
+# rendering), you **SHOULD NOT** include anything below as they're duplicates
+# and can cause confusing complications. Please stick to ONE(1) rendering
+# method.
+#
+# You SHOULD ONLY include components that are used in this page. To configure:
+#     [[List]]
+#     Name = "COMPONENT"
+#     Include = true
+#     Variables = [
+#            { "--variable-1" = "1rem" },
+#            { "--variable-2" = "2rem" },
+#     ]
+#
+#     List.{POSITION}.Name      = name of the component (string)
+#     List.{POSITION}.Include   = inclusion decision (bool true/false)
+#     List.{POSITION}.Variables = list of overriding variables to the component.
+#
+# NOTE:
+#     1) The position of the component listing influences the variables
+#        overriding sequence. Please construct your list properly.
+#     2) Check out Hestia's hestiaGUI catalog list for supported UI components
+#        at:
+#                 https://hestia.zoralab.com/en/specs/hestiaGUI/
+#
+#
+# EXAMPLE:
+#        [[List]]
+#        Name = "zoralabCORE"
+#        Include = true
+#        Variables = [
+#                  { "--test-variable-1" = "1rem" },
+#                  { "--test-variable-2" = "2rem" },
+#        ]
+#
+#        [[List]]
+#        Name = "zoralabFONT_NOTOSANS"
+#        Include = true
+#        Variables = []
+#
+#        ...
+[[List]]
+Name = "zoralabCORE"
+Include = true
+Variables = [
+	{ "--body-scroll-behavior" = "smooth" },
+]
+
+[[List]]
+Name = "zoralabFONT_NOTOSANS"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabDRAWER"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabDRAWER_LEFT"
+Include = true
+Variables = [
+	{ "--left-drawer-width-opened" = "80vw" },
+	{ "--left-drawer-trigger-position-top" = "0" },
+]
+
+[[List]]
+Name = "zoralabANCHOR"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabBUTTON"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabTILE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabCARD"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabPICTURE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabNOTE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabNOTE_WARNING"
+Include = true
+Variables = []

--- a/sites/content/en/getting-started/__content.hestiaCSS
+++ b/sites/content/en/getting-started/__content.hestiaCSS
@@ -1,0 +1,15 @@
+{{- /*
+Page's CSS Prime Control
+
+This page constructs the page-specific CSS codes that will be appeneded into
+.CSS.Inline as the last entry (most powerful). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+
+
+
+
+{{- /* render your page output */ -}}

--- a/sites/content/en/getting-started/__content.hestiaHTML
+++ b/sites/content/en/getting-started/__content.hestiaHTML
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML Output Prime Control
+
+This file is your HTML output file (index.html). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms are required.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $ret := false -}}
+{{- $i18n := .Data.Page.i18n -}}
+
+
+
+
+{{- /* render outputs */ -}}
+<main>
+	<section id='{{- $i18n.Introduction.ID -}}'>
+		<h1>{{- .Titles.Page -}}</h1>
+		<p>{{- .Descriptions.Page.Pitch }} {{ .Descriptions.Page.Summary -}}</p>
+	</section>
+</main>

--- a/sites/content/en/getting-started/__content.hestiaJS
+++ b/sites/content/en/getting-started/__content.hestiaJS
@@ -1,0 +1,15 @@
+{{- /*
+Page's Javascript Prime Control
+
+This page constructs the page-specific JS codes that will be appeneded into
+.JS.Inline as last entry (most powerful). Hugo's and Go's template processors
+are available at your disposal in case of mathematical or logical algorithms
+development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+
+
+
+
+{{- /* render your Javascript output */ -}}

--- a/sites/content/en/getting-started/__content.hestiaJSON
+++ b/sites/content/en/getting-started/__content.hestiaJSON
@@ -1,0 +1,26 @@
+{{- /*
+Page's JSON Output Prime Control
+
+This file is your JSON output file (index.json). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+{{- $i18n := .Data.Page.i18n -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (dict
+	$i18n.Title .Titles.Page
+	$i18n.Description (printf "%s %s" .Descriptions.Page.Pitch .Descriptions.Page.Summary)
+) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/en/getting-started/__content.hestiaLDJSON
+++ b/sites/content/en/getting-started/__content.hestiaLDJSON
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (partial "hestiaJSON/schemaorgLDJSON/WebPage" .) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/en/getting-started/__contributors.toml
+++ b/sites/content/en/getting-started/__contributors.toml
@@ -1,0 +1,42 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...

--- a/sites/content/en/getting-started/__data-go.toml
+++ b/sites/content/en/getting-started/__data-go.toml
@@ -1,0 +1,70 @@
+[[Go]]
+ID = 'setup-go'
+Title = 'Setup Go'
+Description = '''
+The very beginning of the journey where you setup and configure the Go Git
+repository with hestiaGO, ZORALab's Hestia Go module from scratch.
+'''
+URL = 'setup-go'
+Label = 'Begin'
+Include = false
+
+
+[Go.Image]
+Name = ""
+Decorative = true
+Loading = 'lazy'
+Width = "600"
+Height = "600"
+CORS = "anonymous"
+Relationship = ""
+Design = ""
+Preload = ""
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Go.Image.Sources]]
+URL = "/img/logos/google-go-gopher-t2-200x200.svg"
+Type = "image/svg+xml"
+Media = "all"
+Descriptor = '1x'
+
+
+
+
+[[Go]]
+ID = 'understanding-zoralab-hestia-mission-with-go'
+Title = "Understanding ZORALab's Hestia Mission with Go"
+Description = '''
+Before we start using hestiaGO straight away, there are some facts you need to
+understand to avoid confusion and collosal pitfalls like its design mission.
+'''
+URL = 'understanding-zoralab-hestia-mission-with-go'
+Label = 'Begin'
+Include = false
+
+
+[Go.Image]
+Name = ""
+Decorative = true
+Loading = 'lazy'
+Width = "600"
+Height = "600"
+CORS = "anonymous"
+Relationship = ""
+Design = ""
+Preload = ""
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Go.Image.Sources]]
+URL = "/img/logos/google-go-gopher-t2-200x200.svg"
+Type = "image/svg+xml"
+Media = "all"
+Descriptor = '1x'

--- a/sites/content/en/getting-started/__data-hugo.toml
+++ b/sites/content/en/getting-started/__data-hugo.toml
@@ -1,0 +1,68 @@
+[[Hugo]]
+ID = 'setup-hugo'
+Title = 'Setup Hugo'
+Description = '''
+The very beginning of the journey where you setup and configure the Hugo Git
+repository with hestiaHUGO, ZORALab's Hestia Hugo module from scratch.
+'''
+URL = 'setup-hugo'
+Label = 'Begin'
+Include = true
+
+[Hugo.Image]
+Name = ""
+Decorative = true
+Loading = 'lazy'
+Width = "600"
+Height = "600"
+CORS = "anonymous"
+Relationship = ""
+Design = ""
+Preload = ""
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Hugo.Image.Sources]]
+URL = "/img/logos/gohugo-gohper-200x200.svg"
+Type = "image/svg+xml"
+Media = "all"
+Descriptor = '1x'
+
+
+
+
+[[Hugo]]
+ID = 'create-basic-and-placeholder-hugo-pages'
+Title = 'Create Basic and Placeholder Hugo Pages'
+Description = '''
+The first step where you will understand how hestiaHUGO operates and create 1
+set placeholder page and 1 set of basic 404 pages.
+'''
+URL = 'create-basic-and-placeholder-hugo-pages'
+Label = 'Begin'
+Include = true
+
+[Hugo.Image]
+Name = ""
+Decorative = true
+Loading = 'lazy'
+Width = "600"
+Height = "600"
+CORS = "anonymous"
+Relationship = ""
+Design = ""
+Preload = ""
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Hugo.Image.Sources]]
+URL = "/img/logos/gohugo-gohper-200x200.svg"
+Type = "image/svg+xml"
+Media = "all"
+Descriptor = '1x'

--- a/sites/content/en/getting-started/__data-nim.toml
+++ b/sites/content/en/getting-started/__data-nim.toml
@@ -1,0 +1,70 @@
+[[Nim]]
+ID = 'setup-nim'
+Title = 'Setup Nim'
+Description = '''
+The very beginning of the journey where you setup and configure the Nim Git
+repository with hestiaNIM, ZORALab's Hestia Nim package from scratch.
+'''
+URL = 'setup-nim'
+Label = 'Begin'
+Include = false
+
+
+[Nim.Image]
+Name = ""
+Decorative = true
+Loading = 'lazy'
+Width = "600"
+Height = "600"
+CORS = "anonymous"
+Relationship = ""
+Design = ""
+Preload = ""
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Nim.Image.Sources]]
+URL = "/img/logos/nim-200x200.svg"
+Type = "image/svg+xml"
+Media = "all"
+Descriptor = '1x'
+
+
+
+
+[[Nim]]
+ID = 'understanding-zoralab-hestia-mission-with-nim'
+Title = "Understanding ZORALab's Hestia Mission with Nim"
+Description = '''
+Before we start using hestiaNIM straight away, there are some facts you need to
+understand to avoid confusion and collosal pitfalls like its design mission.
+'''
+URL = 'understanding-zoralab-hestia-mission-with-nim'
+Label = 'Begin'
+Include = false
+
+
+[Nim.Image]
+Name = ""
+Decorative = true
+Loading = 'lazy'
+Width = "600"
+Height = "600"
+CORS = "anonymous"
+Relationship = ""
+Design = ""
+Preload = ""
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Nim.Image.Sources]]
+URL = "/img/logos/nim-200x200.svg"
+Type = "image/svg+xml"
+Media = "all"
+Descriptor = '1x'

--- a/sites/content/en/getting-started/__data.toml
+++ b/sites/content/en/getting-started/__data.toml
@@ -1,0 +1,2 @@
+# [Table]
+# Key = 'Value'

--- a/sites/content/en/getting-started/__i18n.toml
+++ b/sites/content/en/getting-started/__i18n.toml
@@ -1,0 +1,79 @@
+[i18n]
+Title = 'Title'
+Description = 'Description'
+URL = 'URL'
+
+
+
+
+[i18n.UnderConstruction]
+Title = 'Heads Up'
+Description = '''
+This supporting feature is currently under development.
+'''
+
+
+
+
+[i18n.Introduction]
+ID = 'getting-started-catalog'
+Title = 'Getting Started Catalog'
+Description = '''
+The content here are written in a non-technical tone and presentations making
+them friendly for new comer attempting technologies for their first time. For
+technical specification, please refer to documentation section.
+'''
+
+
+
+
+[i18n.Hugo]
+ID = 'hugo'
+Title = 'Hugo'
+Description = '''
+Using it to build static content and data publications including hosting WASM
+artifacts or as an UI component design and test tool. The catalog is arranged
+in a very chronological manner prioritizing knowledge absorption starting from
+scratch, how to explore, and how to grow.
+'''
+
+
+
+
+[i18n.Go]
+ID = 'Go'
+Title = 'Go'
+Description = '''
+Using it to quickly build a WASM client-side application, a backend program
+with rich features, and even microcontroller's image via TinyGo. The catalog is
+arranged in a very chronological manner prioritizing knowledge absorption
+starting from scratch, how to explore, and how to grow.
+'''
+
+
+
+
+[i18n.Nim]
+ID = 'Nim'
+Title = 'Nim'
+Description = '''
+Using it to quickly build a non-GC (without garbage collection) requirement's
+WASM client-side application, a backend program with rich features, and
+microcontroller's image via C transpilation. The catalog is
+arranged in a very chronological manner prioritizing knowledge absorption
+starting from scratch, how to explore, and how to grow.
+'''
+
+
+
+
+[i18n.Epilogue]
+ID = 'epilogue'
+Title = 'Epilogue'
+Description = '''
+We have reach the end of the catalog for getting started with using
+ZORALab's Hestia Project. If you have any query, please feel free to contact us
+at our following portal:
+'''
+URL = 'https://github.com/ZORALab/Hestia/discussions'
+CTA = 'GitHub Discussion Portal'

--- a/sites/content/en/getting-started/__languages.toml
+++ b/sites/content/en/getting-started/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = ''
+
+[zh-Hans]
+URL = ''

--- a/sites/content/en/getting-started/__page.toml
+++ b/sites/content/en/getting-started/__page.toml
@@ -1,0 +1,127 @@
+# PAGE METADATA
+# =============
+# Date fields.
+#
+# NOTE:
+#   1. You can generate date easily on linux using '$ date' command.
+#   2. If date field is left blank, the current time shall be used instead.
+#   3. Date should ONLY comply to this pattern when manually constructed:
+#                    Thu 21 Jul 2022 14:27:39 PM +08
+[Date]
+Created   = 'Sat 24 Dec 2022 01:43:36 PM +08'
+Published = 'Sat 24 Dec 2022 01:43:36 PM +08'
+
+
+
+
+# Content fields.
+# NOTE:
+#   1. For .Title, Hestia's string processing using page variables are allowed
+#      and only limited to .Titles sub-fields.
+#   2. For .Keywords, Hestia's string processing using page variables are
+#      allowed but strongly discouraged.
+[Content]
+Title = 'Getting Started Catalog'
+Keywords = [
+	'Getting Started Catalog',
+	'Web',
+	'Tech',
+	'PWA',
+	'WASM',
+	'Software Libraries',
+	'Hugo',
+	'Go',
+	'TinyGo',
+	'Nim',
+	'ZORALab',
+	"ZORALab's Hestia",
+]
+
+
+
+
+# Description fields.
+# NOTE:
+#   1. Hestia's string processing using page variables are allowed.
+#   2. The .Description.Pitch is at maximum 160 characters.
+#   3. The .Description.Summary is at maximum of 250 characters.
+#   4. All fields shall have their whitespace cleansed during the processing.
+[Description]
+Pitch = '''
+Hustle in for getting started with ZORALab's Hestia to your advantage!
+'''
+Summary = '''
+A purpose-oriented hands-on guides for using ZORALab's Hestia Project from
+multiple perpectives.
+'''
+
+
+
+
+# Redirect fields.
+# NOTE:
+#   1. Hestia's URL processing is allowed for .URL field.
+#   2. .Delay timing sets the delay time before redirect. Setting to '0' means
+#      an immediate redirect is requested.
+#   3. Redirect is only available if .Enabled is set to 'true'.
+#   4. Redirect.Language is to redirect the current page to its
+#      language-specific page when Javascript is made available on client side
+#      or fallback to default language.
+[Redirect]
+Delay = 0 # second
+URL = ''
+Enabled = false
+
+[Redirect.Language]
+Enabled = false
+
+
+
+
+# Content Files' Sourcing Location
+# NOTE:
+#   1. To denote where are the content sources.
+#   2. If you're sourcing from assets directory, prefix 'assets/'.
+#   3. If you're sourcing from layouts directory, prefix 'layouts/'.
+#   2. If you're sourcing from static directory, prefix 'static/'.
+#   3. If you're sourcing from partial directory, prefix 'layouts/partials/'.
+[Sources]
+HTML = 'layouts/content/getting-started/index.html'
+JSON = 'layouts/content/getting-started/index.json'
+LDJSON = '__content.hestiaLDJSON'
+Contributors = '__contributors.toml'
+Thumbnails = '__thumbnails.toml'
+Languages = '__languages.toml'
+
+
+
+
+# Data fields.
+# NOTE:
+#   1. List only the page-level data files. It can be in any of the following
+#      formats: '.json', '.toml', or '.yaml'.
+#   2. Hestia string processing is available and shall be processed prior to
+#      dataset transformation.
+#   3. Sequences of the .Data array dictates sequences of loading and overriding
+#      (the latter shall overwrite the former for the same data fields).
+#   4. The final processed dataset shall be served as main data content in
+#      supported output format (e.g. index.json).
+#   5. Missing data file shall be ignored.
+#   6. To add more data files, simply duplicate and add more .Data array entry.
+#      Example:
+#                             [[data]]
+#                             Filename = 'file1.json'
+#
+#                             [[data]]
+#                             Filename = 'file2.toml'
+[[Data]]
+Filename = '__data-hugo.toml'
+
+[[Data]]
+Filename = '__data-go.toml'
+
+[[Data]]
+Filename = '__data-nim.toml'
+
+[[Data]]
+Filename = '__i18n.toml'

--- a/sites/content/en/getting-started/__robots.toml
+++ b/sites/content/en/getting-started/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/en/getting-started/__thumbnails.toml
+++ b/sites/content/en/getting-started/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/thumbnails-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/thumbnails-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/thumbnails-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/en/getting-started/__twitter.toml
+++ b/sites/content/en/getting-started/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/en/getting-started/__wasm.toml
+++ b/sites/content/en/getting-started/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/en/getting-started/_index.html
+++ b/sites/content/en/getting-started/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++

--- a/sites/layouts/content/getting-started/index.html
+++ b/sites/layouts/content/getting-started/index.html
@@ -1,0 +1,204 @@
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $i18n := .Data.Page.i18n -}}
+{{- $lang := false -}}
+{{- $ret := false -}}
+
+
+
+
+{{- /* render output */ -}}
+<main style='padding-bottom: 0;'>
+	<section id='{{- $i18n.Introduction.ID -}}'>
+		<div>
+			<h1>{{- $i18n.Introduction.Title -}}</h1>
+			<p>{{- $i18n.Introduction.Description -}}</p>
+		</div>
+	</section>
+
+
+	<section id='{{- $i18n.Hugo.ID -}}'>
+		<h2>{{- $i18n.Hugo.Title -}}</h2>
+		<p>{{- $i18n.Hugo.Description -}}</p>
+
+		<div class='row'>
+		{{- range $i, $v := $Page.Data.Page.Hugo }}
+			{{- if not $v.Include -}}
+				{{- continue -}}
+			{{- end }}
+			<div class='column'><div class='card' style='
+				--h3-margin: 0;
+				--tile-border-radius: .5rem;
+			'>
+				<div class='thumbnail'>
+					{{- if $v.Image -}}
+						{{- $ret = merge $Page (dict "Input"
+							(dict "Data" $v.Image)
+						) -}}
+					{{- else -}}
+						{{- $ret = merge $Page (dict "Input"
+							(dict "Data" $Page.Data.Store.Programming.Hugo.Logo)
+						) -}}
+					{{- end }}
+					{{- $ret = partial "hestiaMEDIA/Sanitize" $ret -}}
+					{{- $ret = $ret.Output }}
+					{{ partial "hestiaMEDIA/ToHTML" $ret }}
+				</div>
+				<div class='content'>
+					<h3>{{- $v.Title -}}</h3>
+					<p>{{- $v.Description -}}</p>
+				</div>
+				<div class='actions'>
+					{{- $ret = merge $Page (dict "Input"
+						(dict "Data" $v.URL)
+					) -}}
+					{{- $ret = partial "hestiaURL/Sanitize" $ret }}
+					<a href='{{- string $ret.Output -}}' class='button'>
+						{{- $v.Label -}}
+					</a>
+				</div>
+			</div></div>
+		{{- end }}
+		</div>
+	</section>
+
+
+	<section id='{{- $i18n.Go.ID -}}'>
+		<h2>{{- $i18n.Go.Title -}}</h2>
+		<p>{{- $i18n.Go.Description -}}</p>
+
+		<div class='row'>
+		{{- range $i, $v := $Page.Data.Page.Go }}
+			{{- if not $v.Include -}}
+				{{- continue -}}
+			{{- end }}
+			<div class='column'><div class='card' style='
+				--h3-margin: 0;
+				--tile-border-radius: .5rem;
+			'>
+				<div class='thumbnail'>
+					{{- if $v.Image -}}
+						{{- $ret = merge $Page (dict "Input"
+							(dict "Data" $v.Image)
+						) -}}
+					{{- else -}}
+						{{- $ret = merge $Page (dict "Input"
+							(dict "Data" $Page.Data.Store.Programming.Go.Logo)
+						) -}}
+					{{- end }}
+					{{- $ret = partial "hestiaMEDIA/Sanitize" $ret -}}
+					{{- $ret = $ret.Output }}
+					{{ partial "hestiaMEDIA/ToHTML" $ret }}
+				</div>
+				<div class='content'>
+					<h3>{{- $v.Title -}}</h3>
+					<p>{{- $v.Description -}}</p>
+				</div>
+				<div class='actions'>
+					{{- $ret = merge $Page (dict "Input"
+						(dict "Data" $v.URL)
+					) -}}
+					{{- $ret = partial "hestiaURL/Sanitize" $ret }}
+					<a href='{{- string $ret.Output -}}' class='button'>
+						{{- $v.Label -}}
+					</a>
+				</div>
+			</div></div>
+		{{- end }}
+		</div>
+
+		<div class="note warning">
+			<input id="note-under-dev-go" type="checkbox" checked>
+			<label for="note-under-dev-go">
+				{{- $i18n.UnderConstruction.Title -}}
+			</label>
+			<p class="content">
+				{{- $i18n.UnderConstruction.Description -}}
+			</p>
+		</div>
+	</section>
+
+
+	<section id='{{- $i18n.Nim.ID -}}'>
+		<h2>{{- $i18n.Nim.Title -}}</h2>
+		<p>{{- $i18n.Nim.Description -}}</p>
+
+		<div class='row'>
+		{{- range $i, $v := $Page.Data.Page.Nim }}
+			{{- if not $v.Include -}}
+				{{- continue -}}
+			{{- end }}
+			<div class='column'><div class='card' style='
+				--h3-margin: 0;
+				--tile-border-radius: .5rem;
+			'>
+				<div class='thumbnail'>
+					{{- if $v.Image -}}
+						{{- $ret = merge $Page (dict "Input"
+							(dict "Data" $v.Image)
+						) -}}
+					{{- else -}}
+						{{- $ret = merge $Page (dict "Input"
+							(dict "Data" $Page.Data.Store.Programming.Nim.Logo)
+						) -}}
+					{{- end }}
+					{{- $ret = partial "hestiaMEDIA/Sanitize" $ret -}}
+					{{- $ret = $ret.Output }}
+					{{ partial "hestiaMEDIA/ToHTML" $ret }}
+				</div>
+				<div class='content'>
+					<h3>{{- $v.Title -}}</h3>
+					<p>{{- $v.Description -}}</p>
+				</div>
+				<div class='actions'>
+					{{- $ret = merge $Page (dict "Input"
+						(dict "Data" $v.URL)
+					) -}}
+					{{- $ret = partial "hestiaURL/Sanitize" $ret }}
+					<a href='{{- string $ret.Output -}}' class='button'>
+						{{- $v.Label -}}
+					</a>
+				</div>
+			</div></div>
+		{{- end }}
+		</div>
+
+		<div class="note warning">
+			<input id="note-under-dev-nim" type="checkbox" checked>
+			<label for="note-under-dev-nim">
+				{{- $i18n.UnderConstruction.Title -}}
+			</label>
+			<p class="content">
+				{{- $i18n.UnderConstruction.Description -}}
+			</p>
+		</div>
+	</section>
+
+
+	{{- $ret = merge $Page (dict "Input" (dict "Data"
+		"/img/backgrounds/matrix-cube-lorenzo-verzini.svg"
+	)) -}}
+	{{- $ret = partial "hestiaURL/Sanitize" $ret -}}
+	{{- $ret = string $ret.Output -}}
+	<section id='{{- $i18n.Epilogue.ID -}}' class='inverted' style='
+		margin-top: 10rem;
+		background: url({{- $ret -}}),linear-gradient(to top,#010329,#000005)
+				no-repeat
+				fixed;
+		background-position: center center;
+		background-size: cover;
+		padding-bottom: var(--main-padding-top);
+	'>
+		<h2>{{- $i18n.Epilogue.Title -}}</h2>
+		<p>{{- $i18n.Epilogue.Description -}}</p>
+		<br/>
+		{{- $ret = merge $Page (dict "Input" (dict "Data" $i18n.Epilogue.URL)) -}}
+		{{- $ret = partial "hestiaURL/Sanitize" $ret -}}
+		{{- $ret = string $ret.Output -}}
+		<a href='{{- $ret -}}' class='button' style='
+			--button-color: green;
+		'>{{- $i18n.Epilogue.CTA -}}</a>
+	</section>
+</main>
+{{ partial "common/footer.html" $Page }}
+{{ partial "common/nav-prime.html" $Page }}

--- a/sites/layouts/content/getting-started/index.json
+++ b/sites/layouts/content/getting-started/index.json
@@ -1,0 +1,98 @@
+{{- /*
+Page's JSON Output Prime Control
+
+This file is your JSON output file (index.html). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+{{- $i18n := .Data.Page.i18n -}}
+{{- $lang := dict -}}
+{{- $list := slice -}}
+{{- $ret := false -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (dict
+	$i18n.Title .Titles.Page
+	$i18n.Description (printf "%s %s" .Descriptions.Page.Pitch .Descriptions.Page.Summary)
+) -}}
+
+
+
+
+{{- $list = slice -}}
+{{- range $i, $v := $Page.Data.Page.Hugo -}}
+	{{- if not $v.Include -}}
+		{{- continue -}}
+	{{- end -}}
+
+
+	{{- $ret = merge $Page (dict "Input" (dict "Data" $v.URL)) -}}
+	{{- $ret = partial "hestiaURL/Sanitize" $ret -}}
+	{{- $ret = string $ret.Output -}}
+
+
+	{{- $list = append (dict
+		$i18n.Title $v.Title
+		$i18n.Description (replace $v.Description "\n" " ")
+		$i18n.URL $ret
+	) $list -}}
+{{- end -}}
+{{- $dataList = merge $dataList (dict $i18n.Hugo.Title $list) -}}
+
+
+
+
+{{- $list = slice -}}
+{{- range $i, $v := $Page.Data.Page.Go -}}
+	{{- if not $v.Include -}}
+		{{- continue -}}
+	{{- end -}}
+
+
+	{{- $ret = merge $Page (dict "Input" (dict "Data" $v.URL)) -}}
+	{{- $ret = partial "hestiaURL/Sanitize" $ret -}}
+	{{- $ret = string $ret.Output -}}
+
+
+	{{- $list = append (dict
+		$i18n.Title $v.Title
+		$i18n.Description (replace $v.Description "\n" " ")
+		$i18n.URL $ret
+	) $list -}}
+{{- end -}}
+{{- $dataList = merge $dataList (dict $i18n.Go.Title $list) -}}
+
+
+
+
+{{- $list = slice -}}
+{{- range $i, $v := $Page.Data.Page.Nim -}}
+	{{- if not $v.Include -}}
+		{{- continue -}}
+	{{- end -}}
+
+
+	{{- $ret = merge $Page (dict "Input" (dict "Data" $v.URL)) -}}
+	{{- $ret = partial "hestiaURL/Sanitize" $ret -}}
+	{{- $ret = string $ret.Output -}}
+
+
+	{{- $list = append (dict
+		$i18n.Title $v.Title
+		$i18n.Description (replace $v.Description "\n" " ")
+		$i18n.URL $ret
+	) $list -}}
+{{- end -}}
+{{- $dataList = merge $dataList (dict $i18n.Nim.Title $list) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}


### PR DESCRIPTION
Since the /en/getting-started/ page is ready, we can port it to the new system. Hence, let's do this.

This patch ports /en/getting-started/ page into sites/ directory.