### PR TITLE
hestiaHUGO: fixed hestiaMEDIA HTML rendering bug

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaMEDIA/Sanitize
+++ b/hestiaHUGO/layouts/partials/hestiaMEDIA/Sanitize
@@ -238,7 +238,7 @@ specific language governing permissions and limitations under the License.
 				{{- continue -}}
 			{{- end -}}
 		{{- end -}}
-		{{- $data = merge $data (dict "Media" (default "1x" $ret.Output)) -}}
+		{{- $data = merge $data (dict "Descriptor" (default "1x" $ret.Output)) -}}
 
 		{{- /* merge to datalist */ -}}
 		{{- $dataList = merge $dataList (dict "Sources" (dict (string $i) $data)) -}}

--- a/hestiaHUGO/layouts/partials/hestiaMEDIA/ToHTML
+++ b/hestiaHUGO/layouts/partials/hestiaMEDIA/ToHTML
@@ -99,13 +99,12 @@ specific language governing permissions and limitations under the License.
 	{{- if lt $last 0 -}}{{- $last = 0 -}}{{- end -}}
 	{{- $last = printf "%d" $last -}}
 	{{- range $i, $v := $media.Sources }}
-	<source srcset='{{- $v.URL -}} {{- if $v.Descriptor }} {{ $v.Descriptior -}}{{- end -}}'
+	<source srcset='{{- $v.URL -}} {{- if $v.Descriptor }} {{ $v.Descriptor -}}{{- end -}}'
 		type='{{- $v.Type -}}'
 		width='{{- $media.Width -}}'
 		height='{{- $media.Height -}}'
 		{{ if $media.Loading -}} loading='{{- $media.Loading -}}'
-		{{ else -}} loading='lazy'
-		{{- end }}
+		{{ else -}} loading='lazy'{{- end }}
 		media='{{- $v.Media -}}'
 	/>
 		{{- if eq $i $last }}


### PR DESCRIPTION
There are some bugs releated to hestiaMEDIA's HTML rendering and data sanitization. This is mainly because the Source.Descriptor was wrongly saved as Source.Media upon sanitization. When a wrong value is provided to the wrong field, the generated HTML code will not work. Hence, we need to fix it.

This patch fixes hestiaMEDIA HTML rendering bug in hestiaHUGO/ directory.