### PR TITLE
sites: translated /zh-hans/getting-started/setup-hugo/ page

### DIFF
--- a/sites/content/en/getting-started/setup-hugo/__i18n.toml
+++ b/sites/content/en/getting-started/setup-hugo/__i18n.toml
@@ -46,10 +46,6 @@ Value = 'How to start a hugo server for development'
 
 
 [[i18n.Objectives.Outcomes]]
-Value = 'How to compose your hugo contents'
-
-
-[[i18n.Objectives.Outcomes]]
 Value = 'How to use git along the way'
 
 

--- a/sites/content/zh-hans/getting-started/__data-hugo.toml
+++ b/sites/content/zh-hans/getting-started/__data-hugo.toml
@@ -35,8 +35,8 @@ Descriptor = '1x'
 
 
 [[Hugo]]
-ID = '建设简单和占位符性的网页'
-Title = '建设简单和占位符性的网页'
+ID = '建设简单和占位符性的Hugo网页'
+Title = '建设简单和占位符性的Hugo网页'
 Description = '''
 第一步是要通过建设简单和占位符性的网页来了解hestiaHUGO的操作程序。
 '''

--- a/sites/content/zh-hans/getting-started/setup-hugo/__assets.toml
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__assets.toml
@@ -1,0 +1,122 @@
+# PAGE SPECIFIC ASSETS
+# ====================
+# You can include or inline CSS assets into this specific page only by listing
+# out their .URL or relative file .PATH sources respectively.
+#
+# All .CSS.Inline artifacts shall only be provided with Hugo's virtual pathing
+# only.
+#
+# As For .CSS.Include artifacts, Hestia's URL processing is available for
+# dynamic relative pathing constructions. As long as the URL is accessible,
+# storing location is not restricted to any single location.
+#
+# Example, for the artifact placed in:
+#          assets storage directory =    assets/
+#          artifact location        =    assets/css/my-site.min.css
+#          .Inline value            =    assets/css/my-site.min.css
+#          .Include value           =    NOT APPLICABLE
+#
+#          page storage directory   =    en/my-page-here/
+#          artifact location        =    en/my-page-here/my-page.min.css
+#          .Inline value            =    en/my-page-here/my-page.min.css
+#          .Include value           =    /en/my-page-here/my-page.min.css
+#
+#          static storage directory =    static/css/
+#          artifact location        =    static/css/my-page.min.css
+#          .Inline value            =    NOT APPLICABLE
+#          .Include value           =    /css/my-page.min.css
+#
+# The data structure pattern is as follows:
+#                  [[CSS.Inline]]
+#                  Path = '{{ .Inline }}'
+#
+#                         OR
+#
+#                  [[CSS.Include]]
+#                  URL = '{{ .Include }}'
+#                  Media = '{{ .Include.Media }}'
+#                  OnLoad = '{{ .Include.OnLoad }}'
+#
+# To add more entries into either list, simply append new data structure below.
+# The position of the entries dictates the rendering sequence of its statement.
+#
+# For .Include list, should .Media or .Onload is used for asynchonous loading,
+# there is no guarentee for the actual CSS loading sequences (see:
+# https://web.dev/critical-rendering-path-render-blocking-css/). When in doubt,
+# leaving them blank.
+#
+# NOTE:
+# The '__content.hestiaCSS', the page-specific CSS control file will be
+# automatically appended into .CSS.Inline as the last item (demmed the most
+# powerful among all when operating in .Include leading the .Inline mode). You
+# DO NOT need to manually add it in.
+[[CSS.Inline]]
+Path = ''
+
+
+[[CSS.Include]]
+URL = ''
+Media = ''
+OnLoad = ''
+
+
+
+
+# You can include or inline JS assets into this specific page only by listing
+# out their .URL or relative file .PATH sources respectively.
+#
+# All .JS.Inline artifacts shall only be provided with Hugo's virtual pathing.
+#
+# As for .JS.Include artifacts, Hestia's URL processing is available for
+# dynamic relative pathing constructions. As long as the URL is accessible,
+# storing location is not restricted to any single location.
+#
+# Example, for the artifact placed in:
+#          assets storage directory =    assets/
+#          artifact location        =    assets/js/my-site.min.js
+#          .Inline value            =    assets/js/my-site.min.js
+#          .Include value           =    NOT APPLICABLE
+#
+#          page storage directory   =    en/my-page-here/
+#          artifact location        =    en/my-page-here/my-page.min.js
+#          .Inline value            =    en/my-page-here/my-page.min.js
+#          .Include value           =    /en/my-page-here/my-page.min.js
+#
+#          static storage directory =    static/js/
+#          artifact location        =    static/js/my-page.min.js
+#          .Inline value            =    NOT APPLICABLE
+#          .Include value           =    /js/my-page.min.js
+#
+# The data structure pattern is as follows:
+#                  [[JS.Inline]]
+#                  Path = '{{ .Inline }}'
+#
+#                         OR
+#
+#                  [[JS.Include]]
+#                  URL = '{{ .Include }}'
+#                  Timing = '...'
+#
+# To add more entries into either list, simply append new data structure below.
+# The position of the entries dictates the rendering sequence of its statement.
+#
+# For the .Include List, the .Timing value can be any of the following:
+#     1. 'defer' - download the asset first and execute after DOM (default).
+#     2. 'async' - download the asset in parallel to DOM and execute immediately
+#                  regardless of DOM completion status.
+#     3. 'sync'  - block DOM and synchonously download and execute the asset.
+# When in doubt, stick to 'defer' as you would not want to block the page from
+# DOM rendering completion at all time.
+#
+# NOTE:
+# The '__content.hestiaJS', the page-specific JS control file will
+# automatically be appended into .JS.Inline as the last item (deemed the most
+# powerful among all when operating in .Include leading .Inline mode). You DO
+# NOT need to manually add it in.
+[[JS.Inline]]
+Path = ''
+
+
+[[JS.Include]]
+URL = ''
+Timing = 'defer'

--- a/sites/content/zh-hans/getting-started/setup-hugo/__components.toml
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__components.toml
@@ -1,0 +1,103 @@
+# HESTIA PAGE-LEVEL WEB UI COMPONENTS LIST
+# ========================================
+# All Hestia internal web UI components for this page.
+#
+# The components' low-level codes are auto-generated from hestiaGO code
+# libraries for rendering consistency between non-WASM users and WASM users.
+#
+# If you're using WASM from Hestia code libraries and they are directly
+# controlling the page UI (either as single-page rendering or reactive
+# rendering), you **SHOULD NOT** include anything below as they're duplicates
+# and can cause confusing complications. Please stick to ONE(1) rendering
+# method.
+#
+# You SHOULD ONLY include components that are used in this page. To configure:
+#     [[List]]
+#     Name = "COMPONENT"
+#     Include = true
+#     Variables = [
+#            { "--variable-1" = "1rem" },
+#            { "--variable-2" = "2rem" },
+#     ]
+#
+#     List.{POSITION}.Name      = name of the component (string)
+#     List.{POSITION}.Include   = inclusion decision (bool true/false)
+#     List.{POSITION}.Variables = list of overriding variables to the component.
+#
+# NOTE:
+#     1) The position of the component listing influences the variables
+#        overriding sequence. Please construct your list properly.
+#     2) Check out Hestia's hestiaGUI catalog list for supported UI components
+#        at:
+#                 https://hestia.zoralab.com/en/specs/hestiaGUI/
+#
+#
+# EXAMPLE:
+#        [[List]]
+#        Name = "zoralabCORE"
+#        Include = true
+#        Variables = [
+#                  { "--test-variable-1" = "1rem" },
+#                  { "--test-variable-2" = "2rem" },
+#        ]
+#
+#        [[List]]
+#        Name = "zoralabFONT_NOTOSANS"
+#        Include = true
+#        Variables = []
+#
+#        ...
+[[List]]
+Name = "zoralabCORE"
+Include = true
+Variables = [
+	{ "--body-scroll-behavior" = "smooth" },
+]
+
+[[List]]
+Name = "zoralabFONT_NOTOSANS"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabDRAWER"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabDRAWER_LEFT"
+Include = true
+Variables = [
+	{ "--left-drawer-width-opened" = "80vw" },
+	{ "--left-drawer-trigger-position-top" = "0" },
+]
+
+[[List]]
+Name = "zoralabANCHOR"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabBUTTON"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabTILE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabPICTURE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabOLIST"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabPRE"
+Include = true
+Variables = []

--- a/sites/content/zh-hans/getting-started/setup-hugo/__content.hestiaCSS
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__content.hestiaCSS
@@ -1,0 +1,15 @@
+{{- /*
+Page's CSS Prime Control
+
+This page constructs the page-specific CSS codes that will be appeneded into
+.CSS.Inline as the last entry (most powerful). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+
+
+
+
+{{- /* render your page output */ -}}

--- a/sites/content/zh-hans/getting-started/setup-hugo/__content.hestiaHTML
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__content.hestiaHTML
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML Output Prime Control
+
+This file is your HTML output file (index.html). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms are required.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $ret := false -}}
+{{- $i18n := .Data.Page.i18n -}}
+
+
+
+
+{{- /* render outputs */ -}}
+<main>
+	<section id='{{- $i18n.Introduction.ID -}}'>
+		<h1>{{- .Titles.Page -}}</h1>
+		<p>{{- .Descriptions.Page.Pitch }} {{ .Descriptions.Page.Summary -}}</p>
+	</section>
+</main>

--- a/sites/content/zh-hans/getting-started/setup-hugo/__content.hestiaJS
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__content.hestiaJS
@@ -1,0 +1,15 @@
+{{- /*
+Page's Javascript Prime Control
+
+This page constructs the page-specific JS codes that will be appeneded into
+.JS.Inline as last entry (most powerful). Hugo's and Go's template processors
+are available at your disposal in case of mathematical or logical algorithms
+development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+
+
+
+
+{{- /* render your Javascript output */ -}}

--- a/sites/content/zh-hans/getting-started/setup-hugo/__content.hestiaJSON
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__content.hestiaJSON
@@ -1,0 +1,26 @@
+{{- /*
+Page's JSON Output Prime Control
+
+This file is your JSON output file (index.json). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+{{- $i18n := .Data.Page.i18n -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (dict
+	$i18n.Title .Titles.Page
+	$i18n.Description (printf "%s %s" .Descriptions.Page.Pitch .Descriptions.Page.Summary)
+) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/zh-hans/getting-started/setup-hugo/__content.hestiaLDJSON
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__content.hestiaLDJSON
@@ -1,0 +1,21 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/zh-hans/getting-started/setup-hugo/__contributors.toml
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__contributors.toml
@@ -1,0 +1,78 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...
+[[Contributors]]
+Key = 'ZORALab'
+
+[Contributors.Contribution]
+Creation = true
+Contact = true
+Artwork = false
+Knowledge = false
+Editor = true
+Developer = false
+Maintainer = false
+Producer = true
+Provider = true
+Publisher = true
+Funder = false
+Sponsor = true
+
+
+
+
+[[Contributors]]
+Key = 'HollowayKeanHo'
+
+[Contributors.Contribution]
+Creation = true
+Contact = false
+Artwork = false
+Knowledge = true
+Editor = true
+Developer = false
+Maintainer = false
+Producer = false
+Provider = false
+Publisher = false
+Funder = false
+Sponsor = false

--- a/sites/content/zh-hans/getting-started/setup-hugo/__data.toml
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__data.toml
@@ -1,0 +1,2 @@
+# [Table]
+# Key = 'Value'

--- a/sites/content/zh-hans/getting-started/setup-hugo/__i18n.toml
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__i18n.toml
@@ -1,0 +1,385 @@
+[i18n]
+Title = '标题'
+Description = '大纲'
+
+
+
+
+[i18n.Labels]
+Code = '代码'
+URL = 'URL'
+Image = '图面'
+Guides = '指南'
+
+
+
+
+[i18n.Introduction]
+ID = '设置hugo'
+Title = "设置拥有hestiaHUGO的Hugo"
+Description = '''
+一个一步一步编好的从新设置拥有ZORALab赫斯提亚的Hugo Git代码库指南。
+'''
+
+
+
+
+[i18n.Objectives]
+ID = '学习目标'
+Title = '学习目标'
+Description = '''
+在成功完毕这个指南领导后，您会学到:
+'''
+
+
+[[i18n.Objectives.Outcomes]]
+Value = '如何设置Hugo的Git代码库'
+
+
+[[i18n.Objectives.Outcomes]]
+Value = '如何下载和设置hestiaHUGO'
+
+
+[[i18n.Objectives.Outcomes]]
+Value = '如何开动Hugo的服务器来编制网页内容'
+
+
+[[i18n.Objectives.Outcomes]]
+Value = '如何在行程中运用Git'
+
+
+
+
+[[i18n.Steps]]
+ID = '下载最新的包装'
+Title = '下载最新的包装'
+Description = '''
+我们先在ZORALab赫斯提亚下载购物中心里下载最新的hesitaHUGO包装。切记：记得只需要
+寻找：
+'''
+Code = 'hestiaHUGO'
+URL = '/zh-hans/releases'
+Label = '下载购物中心'
+
+
+[[i18n.Steps]]
+ID = '检查包装完整性'
+Title = '检查包装完整性'
+Description = '''
+在还没有开始前，为了安全，我们建议您检查包装完整性。这里有2个方式：GPG或SHASUM。
+在这个指南里，我们在以下的片段运用SHASUM来检查包装。当完整执行SHASUM命令后您将会
+得到一份HASHED_VALUE的数据。您的唯一任务就是要确定这份HASHED_VALUE是和下载购物中
+心所展现SHASUM的数据是100%相同的。
+'''
+Code = '''
+# 在 UNIX 系统 (LINUX / MACOS)
+# ----------------------------
+$ sha512sum hestiaHUGO-vNNNN.zip
+...
+[HASHED_VALUE]
+
+
+
+
+# 在 WINDOWS 系统
+# ---------------
+$ certutil -hashfile hestiaHUGO-vNNNN.zip sha512
+...
+SHA512 hash of hestiaHUGO-vNNNN.zip:
+[HASHED_VALUE]
+'''
+URL = ''
+Label = ''
+
+[i18n.Steps.Image]
+Name = "SHASUM数据比较的屏幕截图"
+Decorative = false
+Loading = 'lazy'
+Width = "600"
+Height = "600"
+CORS = "anonymous"
+Relationship = ""
+Design = ""
+Preload = ""
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[i18n.Steps.Image.Sources]]
+URL = "/img/getting-started/setup-hugo/check-package-integrity-600x600.avif"
+Type = "image/avif"
+Media = "(min-width: 600px)"
+Descriptor = '1x'
+
+[[i18n.Steps.Image.Sources]]
+URL = "/img/getting-started/setup-hugo/check-package-integrity-600x600.webp"
+Type = "image/webp"
+Media = "(min-width: 600px)"
+Descriptor = '1x'
+
+[[i18n.Steps.Image.Sources]]
+URL = "/img/getting-started/setup-hugo/check-package-integrity-600x600.jpg"
+Type = "image/jpeg"
+Media = "(min-width: 600px)"
+Descriptor = '1x'
+
+[[i18n.Steps.Image.Sources]]
+URL = "/img/getting-started/setup-hugo/check-package-integrity-400x400.avif"
+Type = "image/avif"
+Media = "(min-width: 300px)"
+Descriptor = '1x'
+
+[[i18n.Steps.Image.Sources]]
+URL = "/img/getting-started/setup-hugo/check-package-integrity-400x400.webp"
+Type = "image/webp"
+Media = "(min-width: 300px)"
+Descriptor = '1x'
+
+[[i18n.Steps.Image.Sources]]
+URL = "/img/getting-started/setup-hugo/check-package-integrity-400x400.jpg"
+Type = "image/jpeg"
+Media = "(min-width: 300px)"
+Descriptor = '1x'
+
+[[i18n.Steps.Image.Sources]]
+URL = "/img/getting-started/setup-hugo/check-package-integrity-220x220.avif"
+Type = "image/avif"
+Media = "(max-width: 299px)"
+Descriptor = '1x'
+
+[[i18n.Steps.Image.Sources]]
+URL = "/img/getting-started/setup-hugo/check-package-integrity-220x220.webp"
+Type = "image/webp"
+Media = "(max-width: 299px)"
+Descriptor = '1x'
+
+[[i18n.Steps.Image.Sources]]
+URL = "/img/getting-started/setup-hugo/check-package-integrity-220x220.jpg"
+Type = "image/jpeg"
+Media = "(max-width: 299px)"
+Descriptor = '1x'
+
+
+[[i18n.Steps]]
+ID = '设置git代码库'
+Title = '设置Git代码库'
+Description = '''
+当您有了一份检查成功的包装在手时，现在就是时候设置Git代码库。第一步：制造和开始您
+的Git代码库的文件夹（在这整个指南里，我们称它为“DemoHestia”）。在这文件夹里，你再
+制造新的文件夹（我们推荐名为“sites”）。然后在这最里面的文件夹里制造新的文件夹叫
+“themes”。最后呢，您就在这个themes的文件夹里打开hestiaHUGO的包装。您的成功文件夹
+有如以下：
+'''
+Code = '''
+DemoHestia/
+└── sites/
+    └── themes/
+        └── hestiaHUGO/
+            ├── config/
+            ├── server.cmd
+            ├── ...
+            └── ... 其他内容 ...
+'''
+URL = ''
+Label = ''
+
+
+[[i18n.Steps]]
+ID = '设置hugo系统文件夹'
+Title = '设置hugo系统文件夹'
+Description = '''
+由于hestiaHUGO的引擎的复杂性，hestiaHUGO有运出在自己的文件夹里同时运出config/文
+件夹。您需要把它移出来放入sites/文件夹里。要凭包装的版本，如果有一份‘server.cmd’
+的文件，您也需要同时移出来。最后成果有如：
+'''
+Code = '''
+DemoHestia/
+└── sites/
+    ├── server.cmd  (注意: 如果有一起包装)
+    │
+    ├── config/
+    │   ├── _default/
+    │   │   ├── caches.toml
+    │   │   └── config.toml
+    │   ├── development/
+    │   │   └── config.toml
+    │   └── production/
+    │       └── config.toml
+    │
+    └── themes/
+        └── hestiaHUGO/
+            └── ... 所有内容文件 ...
+'''
+URL = ''
+Label = ''
+
+
+[[i18n.Steps]]
+ID = '配置hugo'
+Title = '配置Hugo'
+Description = '''
+如今所有重要的文件已经归处，现在是时候配置Hugo了。大致上，您只需要配置
+'__sites/config/_default/config.toml'文件的第一部分就行了。其他的部分就跟着附加
+的注意文字行使就行了。没错的话，您只需要配置'baseURL'为您想要的域名URL地址就够了
+。有空的话，您可以参考Hugo配置指南手册来了解每个数码值的意义。
+'''
+Code = '''
+DemoHestia/
+└── sites/
+    ├── ...
+    │
+    ├── config/
+    │   ├── _default/
+    │   │   ├── ...
+    │   │   └── config.toml
+    │   │
+    │   └── ...
+    │
+    └── ...
+
+           ⤋
+
+# CONFIGURE THESE DATA
+# ====================
+baseURL = "https://hestia.zoralab.com"
+theme = [
+        "hestiaHUGO",
+]
+timeout = '10m'
+
+archetypeDir = "archetypes"
+contentDir = "content"
+assetDir = "assets"
+dataDir = "data"
+staticDir = [
+        "static",
+]
+layoutDir = "layouts"
+themesDir = ".."
+publishDir = "public"
+i18nDir = "i18n"
+
+
+# ╔══════════╗
+# ║!!  STOP  !!║
+# ╚══════════╝
+!!! 那就够了。别改任何以下的数据。您可能会搞炸hestiaHUGO的。 !!!
+...
+'''
+URL = 'https://gohugo.io/getting-started/configuration/'
+Label = 'Hugo配置指南手册'
+
+
+
+
+[[i18n.Steps]]
+ID = '开动Hugo服务器'
+Title = '开动Hugo服务器'
+Description = '''
+如今一却已经设置和配置好了，我们可以开始开动服务器引擎来测试用户。我们建议运用以
+下的命令。切记：如果您还未设置Hugo的话，您可以参考一下的URL链接网站来设置。如果
+'server.cmd'这份文件有同一起准备的话，您可以直接跑动它就行了（它其实是个简单化
+我们的建议命令文件好让您容易开动引擎。当引擎启动时，您要为下一步注意那网站的URL
+链接地址。
+'''
+Code = '''
+$ hugo server \
+	--buildDrafts \
+	--noBuildLock \
+	--disableFastRender \
+	--bind "localhost" \
+	--baseURL "http://localhost" \
+	--port 8080 \
+	--cleanDestinationDir \
+	--gc
+
+
+Start building sites …
+...
+Web Server is available at http://localhost:8080/ (bind address 127.0.0.1)
+...
+'''
+URL = 'https://gohugo.io/installation/'
+Label = 'Hugo设置手册'
+
+
+[[i18n.Steps]]
+ID = '观光服务器的URL链接地址'
+Title = '观光服务器的URL链接地址'
+Description = '''
+当服务器安全无损的运行时，您可以观光展览出的URL链接地址。如今我们还未建设任何网
+页内容，您也只能看到一面白页或一直被送去语言性的404网页。在这阶段呢，您已经有一
+个含有hestiaHUGO可用的Hugo代码库了！
+'''
+Code = ''
+URL = ''
+Label = ''
+
+
+[[i18n.Steps]]
+ID = 'git-commit'
+Title = 'Git Commit'
+Description = '''
+在还没开始编制任何网页内容前，我们建议您Git Commit掉这个代码库以防未来需要的时间
+穿越会点。有一件事必须搞清楚：把hestiaHUGO一起Git Commit。如今的hestiaHUGO不只是
+供应UI用具了。它其实还是个数据引擎来稳重化您的Hugo。所以呢，把它分开是会不安全
+的。
+'''
+Code = '''
+$ git add .
+$ git commit -s
+
+----
+根点: 为网站设计需求设置和配置hugo。
+
+这里有网站设计需求的Hugo需求。如此，我们也必须开始它的设置和配置
+工作。那就开始吧。
+
+这个代码补丁是为网站设计需求设置和配置hugo。
+
+
+Signed-off-by: 周健豪 ❬hollowaykeanho@gmail.com❭
+----
+
+$ git push
+'''
+URL = ''
+Label = ''
+
+
+[[i18n.Steps]]
+ID = '有关更新hestiaHUGO'
+Title = '有关更新hestiaHUGO'
+Description = '''
+在以后如果有需要更新hestiaHUGO，您只需更换那'themes/hestiaHUGO'文件夹就可以了。
+Hugo的从新配置如果下载中心手册没有列出是不需要的。切记：更新引擎有时会不小心破坏
+您所建设的边缘案例内容设计的。所以呢，您还是预备好时间检查所有的内容完整性。在这
+儿，我们也尽量会后向兼容。
+'''
+Code = '''
+DemoHestia/
+└── sites/
+    │
+    ├── ...
+    │
+    └── themes/
+        └── hestiaHUGO/     🡨 只需更新这个文件夹就行了
+            └── ...
+'''
+URL = ''
+Label = ''
+
+
+
+
+[i18n.Epilogue]
+ID = '终结'
+Title = '终结'
+Description = '''
+恭喜！我们也到了这个指南的终结了。在这点，您已经有一份拥有hestiaHUGO的Hugo代码库
+了。请随时点记。当您准备好时，我们就进入下一个指南吧：
+'''
+URL = 'create-basic-and-placeholder-hugo-pages'
+CTA = '建设简单和占位符性的Hugo网页'

--- a/sites/content/zh-hans/getting-started/setup-hugo/__languages.toml
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = '/en/getting-started/setup-hugo/'
+
+[zh-Hans]
+URL = '/zh-hans/getting-started/setup-hugo/'

--- a/sites/content/zh-hans/getting-started/setup-hugo/__page.toml
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__page.toml
@@ -1,0 +1,120 @@
+# PAGE METADATA
+# =============
+# Date fields.
+#
+# NOTE:
+#   1. You can generate date easily on linux using '$ date' command.
+#   2. If date field is left blank, the current time shall be used instead.
+#   3. Date should ONLY comply to this pattern when manually constructed:
+#                    Thu 21 Jul 2022 14:27:39 PM +08
+[Date]
+Created   = 'Sat 04 Mar 2023 10:46:33 AM +08'
+Published = 'Sat 04 Mar 2023 10:46:33 AM +08'
+
+
+
+
+# Content fields.
+# NOTE:
+#   1. For .Title, Hestia's string processing using page variables are allowed
+#      and only limited to .Titles sub-fields.
+#   2. For .Keywords, Hestia's string processing using page variables are
+#      allowed but strongly discouraged.
+[Content]
+Title = "设置拥有hestiaHUGO的Hugo"
+Keywords = [
+	'设置拥有hestiaHUGO的Hugo',
+	'设置hestiaHUGO',
+	'设置Hugo',
+	'网站',
+	'科技',
+	'PWA',
+	'WASM',
+	'hestiaHUGO',
+	'代码库',
+	'Hugo',
+	'ZORALab',
+	'ZORALab赫斯提亚',
+]
+
+
+
+
+# Description fields.
+# NOTE:
+#   1. Hestia's string processing using page variables are allowed.
+#   2. The .Description.Pitch is at maximum 160 characters.
+#   3. The .Description.Summary is at maximum of 250 characters.
+#   4. All fields shall have their whitespace cleansed during the processing.
+[Description]
+Pitch = '''
+整个行程最早的步骤就是设置拥有hestiaHUGO的Hugo啦。
+'''
+Summary = '''
+一个一步一步编好的ZORALab赫斯提亚Hugo从新设置指南。
+'''
+
+
+
+
+# Redirect fields.
+# NOTE:
+#   1. Hestia's URL processing is allowed for .URL field.
+#   2. .Delay timing sets the delay time before redirect. Setting to '0' means
+#      an immediate redirect is requested.
+#   3. Redirect is only available if .Enabled is set to 'true'.
+#   4. Redirect.Language is to redirect the current page to its
+#      language-specific page when Javascript is made available on client side
+#      or fallback to default language.
+[Redirect]
+Delay = 0 # second
+URL = ''
+Enabled = false
+
+[Redirect.Language]
+Enabled = false
+
+
+
+
+# Content Files' Sourcing Location
+# NOTE:
+#   1. To denote where are the content sources.
+#   2. If you're sourcing from assets directory, prefix 'assets/'.
+#   3. If you're sourcing from layouts directory, prefix 'layouts/'.
+#   2. If you're sourcing from static directory, prefix 'static/'.
+#   3. If you're sourcing from partial directory, prefix 'layouts/partials/'.
+[Sources]
+HTML = 'layouts/content/getting-started/setup-hugo/index.html'
+JSON = 'layouts/content/getting-started/setup-hugo/index.json'
+LDJSON = '__content.hestiaLDJSON'
+Contributors = '__contributors.toml'
+Thumbnails = '__thumbnails.toml'
+Languages = '__languages.toml'
+
+
+
+
+# Data fields.
+# NOTE:
+#   1. List only the page-level data files. It can be in any of the following
+#      formats: '.json', '.toml', or '.yaml'.
+#   2. Hestia string processing is available and shall be processed prior to
+#      dataset transformation.
+#   3. Sequences of the .Data array dictates sequences of loading and overriding
+#      (the latter shall overwrite the former for the same data fields).
+#   4. The final processed dataset shall be served as main data content in
+#      supported output format (e.g. index.json).
+#   5. Missing data file shall be ignored.
+#   6. To add more data files, simply duplicate and add more .Data array entry.
+#      Example:
+#                             [[data]]
+#                             Filename = 'file1.json'
+#
+#                             [[data]]
+#                             Filename = 'file2.toml'
+[[Data]]
+Filename = '__data.toml'
+
+[[Data]]
+Filename = '__i18n.toml'

--- a/sites/content/zh-hans/getting-started/setup-hugo/__robots.toml
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/zh-hans/getting-started/setup-hugo/__thumbnails.toml
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/thumbnails-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/thumbnails-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/thumbnails-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/zh-hans/getting-started/setup-hugo/__twitter.toml
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/zh-hans/getting-started/setup-hugo/__wasm.toml
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/zh-hans/getting-started/setup-hugo/_index.html
+++ b/sites/content/zh-hans/getting-started/setup-hugo/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++

--- a/sites/layouts/content/getting-started/setup-hugo/index.html
+++ b/sites/layouts/content/getting-started/setup-hugo/index.html
@@ -31,14 +31,14 @@
 		<h2>{{- $v.Title -}}</h2>
 		<p>{{- $v.Description -}}</p>
 
-		{{- if $v.Code }}
-		<pre>{{- $v.Code -}}</pre>
-		{{- end }}
-
 		{{- if $v.URL }}
 			{{- $ret = merge $Page (dict "Input" (dict "Data" $v.URL)) -}}
 			{{- $ret = partial "hestiaURL/Sanitize" $ret }}
 		<a href='{{- string $ret.Output -}}' class='button'>{{- $v.Label -}}</a>
+		{{- end }}
+
+		{{- if $v.Code }}
+		<pre>{{- $v.Code -}}</pre>
 		{{- end }}
 
 		{{- if $v.Image }}


### PR DESCRIPTION
Since the /en/getting-started/setup-hugo/ page is ready, we can proceed to translate it. Hence, let's do this.

This patch translates /zh-hans/getting-started/setup-hugo/ page in sites/ directory.