### PR TITLE
hestiaHUGO: fixed hugo compilation bug for PWA manifest and worker sc…

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaCOMPILERS/hestiaHUGO/Start
+++ b/hestiaHUGO/layouts/partials/hestiaCOMPILERS/hestiaHUGO/Start
@@ -120,7 +120,7 @@ specific language governing permissions and limitations under the License.
 	{{- $data = string $data -}}
 	{{- if not $Page.IsServerMode -}}
 		{{- $data = dict "Type" "application/json" "Data" $data -}}
-		{{- $data = merge $Page (dict "Input" (dict "Data" $data)) -}}
+		{{- $data = merge $Page (dict "Input" $data) -}}
 		{{- $data = partial "hestiaSTRING/Minify" $data -}}
 		{{- $data = $data.Output -}}
 	{{- end -}}
@@ -135,7 +135,7 @@ specific language governing permissions and limitations under the License.
 	{{- $data = string $data -}}
 	{{- if not $Page.IsServerMode -}}
 		{{- $data = dict "Type" "application/javascript" "Data" $data -}}
-		{{- $data = merge $Page (dict "Input" (dict "Data" $data)) -}}
+		{{- $data = merge $Page (dict "Input" $data) -}}
 		{{- $data = partial "hestiaSTRING/Minify" $data -}}
 		{{- $data = $data.Output -}}
 	{{- end -}}


### PR DESCRIPTION
…ripts

Appearently, there were some bad codes appearing for PWA manifest and PWA worker discovered by Jemma. This is caused by the improper Minify input data structure (double "Data" depths) when operating as a non-server mode. It's a critical bug so we have to fix it.

This patch fixes hugo compilation bug for PWA manifest and worker scripts in hestiaHUGO/ directory.