### PR TITLE
sites: fixed Go's broken images' media query

### DIFF
--- a/sites/data/Programming/Go.toml
+++ b/sites/data/Programming/Go.toml
@@ -353,19 +353,19 @@ Inline = false
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
 URL = "/img/thumbnails/on-point-first-600x600.avif"
 Type = "image/avif"
-Media = "min-width: 300px"
+Media = "(min-width: 300px)"
 Descriptor = '1x'
 
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
 URL = "/img/thumbnails/on-point-first-600x600.webp"
 Type = "image/webp"
-Media = "min-width: 300px"
+Media = "(min-width: 300px)"
 Descriptor = '1x'
 
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
 URL = "/img/thumbnails/on-point-first-600x600.jpg"
 Type = "image/jpeg"
-Media = "min-width: 300px"
+Media = "(min-width: 300px)"
 Descriptor = '1x'
 
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
@@ -410,19 +410,19 @@ Inline = false
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
 URL = "/img/thumbnails/go-big-fearlessly-600x600.avif"
 Type = "image/avif"
-Media = "min-width: 300px"
+Media = "(min-width: 300px)"
 Descriptor = '1x'
 
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
 URL = "/img/thumbnails/go-big-fearlessly-600x600.webp"
 Type = "image/webp"
-Media = "min-width: 300px"
+Media = "(min-width: 300px)"
 Descriptor = '1x'
 
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
 URL = "/img/thumbnails/go-big-fearlessly-600x600.jpg"
 Type = "image/jpeg"
-Media = "min-width: 300px"
+Media = "(min-width: 300px)"
 Descriptor = '1x'
 
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
@@ -467,19 +467,19 @@ Inline = false
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
 URL = "/img/thumbnails/microcontroller-600x600.avif"
 Type = "image/avif"
-Media = "min-width: 300px"
+Media = "(min-width: 300px)"
 Descriptor = '1x'
 
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
 URL = "/img/thumbnails/microcontroller-600x600.webp"
 Type = "image/webp"
-Media = "min-width: 300px"
+Media = "(min-width: 300px)"
 Descriptor = '1x'
 
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
 URL = "/img/thumbnails/microcontroller-600x600.jpg"
 Type = "image/jpeg"
-Media = "min-width: 300px"
+Media = "(min-width: 300px)"
 Descriptor = '1x'
 
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
@@ -524,19 +524,19 @@ Inline = false
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
 URL = "/img/thumbnails/work-harmoniously-600x600.avif"
 Type = "image/avif"
-Media = "min-width: 300px"
+Media = "(min-width: 300px)"
 Descriptor = '1x'
 
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
 URL = "/img/thumbnails/work-harmoniously-600x600.webp"
 Type = "image/webp"
-Media = "min-width: 300px"
+Media = "(min-width: 300px)"
 Descriptor = '1x'
 
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]
 URL = "/img/thumbnails/work-harmoniously-600x600.jpg"
 Type = "image/jpeg"
-Media = "min-width: 300px"
+Media = "(min-width: 300px)"
 Descriptor = '1x'
 
 [[Metadata.Languages.ZH-HANS.Features.Image.Sources]]


### PR DESCRIPTION
Appearently, the Go's dataset contains some broken images' media query data. Hence, we need to fix it.

This patch fixes Go's broken images' media query in sites/ directory.