### PR TITLE
sites: fixed Hugo's broken images' media query

### DIFF
--- a/sites/data/Licenses/Apache2.toml
+++ b/sites/data/Licenses/Apache2.toml
@@ -87,55 +87,55 @@ Inline = false
 [[Thumbnail.Sources]]
 URL = "/img/thumbnails/freedom-1200x1200.avif"
 Type = "image/avif"
-Media = "min-width: 600px"
+Media = "(min-width: 600px)"
 Descriptor = '1x'
 
 [[Thumbnail.Sources]]
 URL = "/img/thumbnails/freedom-1200x1200.webp"
 Type = "image/webp"
-Media = "min-width: 600px"
+Media = "(min-width: 600px)"
 Descriptor = '1x'
 
 [[Thumbnail.Sources]]
 URL = "/img/thumbnails/freedom-1200x1200.jpg"
 Type = "image/jpeg"
-Media = "min-width: 600px"
+Media = "(min-width: 600px)"
 Descriptor = '1x'
 
 [[Thumbnail.Sources]]
 URL = "/img/thumbnails/freedom-480x480.avif"
 Type = "image/avif"
-Media = "min-width: 400px"
+Media = "(min-width: 400px)"
 Descriptor = '1x'
 
 [[Thumbnail.Sources]]
 URL = "/img/thumbnails/freedom-480x480.webp"
 Type = "image/webp"
-Media = "min-width: 400px"
+Media = "(min-width: 400px)"
 Descriptor = '1x'
 
 [[Thumbnail.Sources]]
 URL = "/img/thumbnails/freedom-480x480.jpg"
 Type = "image/jpeg"
-Media = "min-width: 400px"
+Media = "(min-width: 400px)"
 Descriptor = '1x'
 
 [[Thumbnail.Sources]]
 URL = "/img/thumbnails/freedom-220x220.avif"
 Type = "image/avif"
-Media = "max-width: 250px"
+Media = "all"
 Descriptor = '1x'
 
 [[Thumbnail.Sources]]
 URL = "/img/thumbnails/freedom-220x220.webp"
 Type = "image/webp"
-Media = "max-width: 250px"
+Media = "all"
 Descriptor = '1x'
 
 [[Thumbnail.Sources]]
 URL = "/img/thumbnails/freedom-220x220.jpg"
 Type = "image/jpeg"
-Media = "max-width: 250px"
+Media = "all"
 Descriptor = '1x'
 
 [Thumbnail.Tracks.en]


### PR DESCRIPTION
Appearently, the Apache2 license dataset contains some broken images' media query data. Hence, we need to fix it.

This patch fixes Apache2 license's broken images' media query in sites/ directory.