### PR TITLE
sites: updated RealCalmStudio's contributor data for fixing image bug

### DIFF
--- a/sites/data/Hestia/Contributors/RealCalmStudio.toml
+++ b/sites/data/Hestia/Contributors/RealCalmStudio.toml
@@ -141,55 +141,55 @@ Inline = false
 [[Image.Sources]]
 URL = "/img/portraits/real-calm-studio-1200x1200.avif"
 Type = "image/avif"
-Media = "min-width: 600px"
+Media = "(min-width: 600px)"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/real-calm-studio-1200x1200.webp"
 Type = "image/webp"
-Media = "min-width: 600px"
+Media = "(min-width: 600px)"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/real-calm-studio-1200x1200.jpg"
 Type = "image/jpeg"
-Media = "min-width: 600px"
+Media = "(min-width: 600px)"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/real-calm-studio-480x480.avif"
 Type = "image/avif"
-Media = "min-width: 400px"
+Media = "(min-width: 400px)"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/real-calm-studio-480x480.webp"
 Type = "image/webp"
-Media = "min-width: 400px"
+Media = "(min-width: 400px)"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/real-calm-studio-480x480.jpg"
 Type = "image/jpeg"
-Media = "min-width: 400px"
+Media = "(min-width: 400px)"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/real-calm-studio-220x220.avif"
 Type = "image/avif"
-Media = "max-width: 250px"
+Media = "all"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/real-calm-studio-220x220.webp"
 Type = "image/webp"
-Media = "max-width: 250px"
+Media = "all"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/real-calm-studio-220x220.jpg"
 Type = "image/jpeg"
-Media = "max-width: 250px"
+Media = "all"
 Descriptor = '1x'
 
 [Image.Tracks.en]


### PR DESCRIPTION
There is a bug with the media field in the contributor's data. Hence, we need to fix it.

This patch fixes RealCalmStudio's contributor data in sites/ directory.