### PR TITLE
sites: updated RODNAEProductions's contributor data for fixing image bug

### DIFF
--- a/sites/data/Hestia/Contributors/RODNAEProductions.toml
+++ b/sites/data/Hestia/Contributors/RODNAEProductions.toml
@@ -149,55 +149,55 @@ Inline = false
 [[Image.Sources]]
 URL = "/img/portraits/rodnae-productions-1200x1200.avif"
 Type = "image/avif"
-Media = "min-width: 600px"
+Media = "(min-width: 600px)"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/rodnae-productions-1200x1200.webp"
 Type = "image/webp"
-Media = "min-width: 600px"
+Media = "(min-width: 600px)"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/rodnae-productions-1200x1200.jpg"
 Type = "image/jpeg"
-Media = "min-width: 600px"
+Media = "(min-width: 600px)"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/rodnae-productions-480x480.avif"
 Type = "image/avif"
-Media = "min-width: 400px"
+Media = "(min-width: 400px)"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/rodnae-productions-480x480.webp"
 Type = "image/webp"
-Media = "min-width: 400px"
+Media = "(min-width: 400px)"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/rodnae-productions-480x480.jpg"
 Type = "image/jpeg"
-Media = "min-width: 400px"
+Media = "(min-width: 400px)"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/rodnae-productions-220x220.avif"
 Type = "image/avif"
-Media = "max-width: 250px"
+Media = "all"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/rodnae-productions-220x220.webp"
 Type = "image/webp"
-Media = "max-width: 250px"
+Media = "all"
 Descriptor = '1x'
 
 [[Image.Sources]]
 URL = "/img/portraits/rodnae-productions-220x220.jpg"
 Type = "image/jpeg"
-Media = "max-width: 250px"
+Media = "all"
 Descriptor = '1x'
 
 [Image.Tracks.en]


### PR DESCRIPTION
There is a bug with the media field in the contributor's data. Hence, we need to fix it.

This patch fixes RODNAEProductions's contributor data in sites/ directory.