### PR TITLE
hestiaHUGO: disabled auto URL offline caching due to "memory leak"

### DIFF
--- a/hestiaHUGO/data/Hestia/PWA/Caches.toml
+++ b/hestiaHUGO/data/Hestia/PWA/Caches.toml
@@ -12,7 +12,7 @@
 #                          prefix are cached regardless of its actual use in
 #                          any of the display contents.
 [Automation]
-Enabled = true
+Enabled = false
 
 
 


### PR DESCRIPTION
It appears that Hugo has a problem with its memory management when using its resources pipe: it caches without any directive. Each string data sanitization now contributes to a piece of memory cache when it's not needed. This is bad as it is shown consuming large amount of occupied but not usable memory similar to "memory leak". Hence, we need to reduce it and fix it temporarily by not facilitating the automatic URL offline caching capability.

This patch disables auto URL offline caching due to "memory leak" in hestiaHUGO/ directory.