### PR TITLE
sites: fixed getting-started/setup-hugo page CTA broken URL bug

### DIFF
--- a/sites/content/en/getting-started/setup-hugo/__i18n.toml
+++ b/sites/content/en/getting-started/setup-hugo/__i18n.toml
@@ -439,5 +439,5 @@ fully functional hestiaHUGO equipped Hugo repository for your frontend website
 or web application construction. Please feel free to take notes before
 proceeding to the next tutorial:
 '''
-URL = 'create-basic-and-placeholder-hugo-pages'
+URL = '/en/getting-started/create-basic-and-placeholder-hugo-pages'
 CTA = 'Create Basic and Placeholder Hugo Pages'

--- a/sites/content/zh-hans/getting-started/setup-hugo/__i18n.toml
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__i18n.toml
@@ -418,5 +418,5 @@ Description = '''
 恭喜！我们也到了这个指南的终结了。在这点，您已经有一份拥有hestiaHUGO的Hugo代码库
 了。请随时点记。当您准备好时，我们就进入下一个指南吧：
 '''
-URL = 'create-basic-and-placeholder-hugo-pages'
+URL = '/zh-hans/getting-started/create-basic-and-placeholder-hugo-pages'
 CTA = '建设简单和占位符性的Hugo网页'


### PR DESCRIPTION
Appearently, the URL in the setup-hugo page is broken and outdated. Hence, we need to fix it.

This patch fixes getting-started/setup-hugo pages' broken CTA URL bug in sites/ directory.