### PR TITLE
sites: fixed __content.hestiaJS rendering bug

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaCOMPILERS/hestiaHUGO/localizePageData
+++ b/hestiaHUGO/layouts/partials/hestiaCOMPILERS/hestiaHUGO/localizePageData
@@ -163,9 +163,9 @@ specific language governing permissions and limitations under the License.
 {{- $Page = merge $Page (dict "JS" (dict "Include" $dataList)) -}}
 
 {{- /* source page-level main JS file */ -}}
-{{- $ret = printf "%s/%s" .Filesystem.Directory "__content.hestiaJS" -}}
-{{- if not (partial "hestiaIO/hestiaFS/IsFileExists" (path.Clean $ret)) -}}
-	{{- $ret = "" -}}
+{{- $dataList = printf "%s/%s" .Filesystem.Directory "__content.hestiaJS" -}}
+{{- if not (partial "hestiaIO/hestiaFS/IsFileExists" (path.Clean $dataList)) -}}
+	{{- $dataList = "" -}}
 {{- end -}}
 {{- $Page = merge $Page (dict "JS" (dict "Main" $dataList)) -}}
 


### PR DESCRIPTION
Appearently, the __content.hestiaJS was not rendered due to an internal bug (wrong use of variable). Hence, we need to fix it.

This patch fixes __content.hestiaJS rendering bug in sites/ directory.