### PR TITLE
hestiaHUGO: decontaminated debugger from page assets

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaCOMPILERS/hestiaHUGO/parsePageData
+++ b/hestiaHUGO/layouts/partials/hestiaCOMPILERS/hestiaHUGO/parsePageData
@@ -152,11 +152,6 @@ specific language governing permissions and limitations under the License.
 {{- /* parse .Components */ -}}
 {{- if and .Site.Data.Hestia.Debugger.Default.Type .Site.IsServer -}}
 	{{- $dataList = merge $dataList (dict
-		"Components" (dict "0" (dict
-			"Name" .Site.Data.Hestia.Debugger.Default.Type
-			"Include" true
-			"Variables" dict
-		))
 		"Debugger" (dict
 			"Name" .Site.Data.Hestia.Debugger.Default.Type
 		)

--- a/hestiaHUGO/layouts/partials/hestiaCOMPILERS/hestiaHUGO/sanitizePageData
+++ b/hestiaHUGO/layouts/partials/hestiaCOMPILERS/hestiaHUGO/sanitizePageData
@@ -750,14 +750,66 @@ specific language governing permissions and limitations under the License.
 {{- /* process .Debugger */ -}}
 {{- $ret = "" -}}
 {{- if .Debugger.Name -}}
-	{{- $ret = printf "layouts/partials/hestiaGUI/%s/HTML" .Debugger.Name -}}
-	{{- if partial "hestiaIO/hestiaFS/IsFileExists" $ret -}}
-		{{- $ret = printf "hestiaGUI/%s/HTML" .Debugger.Name -}}
+	{{- $ret = merge $Page (dict "Input" (dict "Data" .Debugger.Name)) -}}
+	{{- $ret = partial "hestiaSTRING/Sanitize" $ret -}}
+	{{- $ret = $ret.Output -}}
+	{{- $Page = merge $Page (dict "Debugger" (dict "Name" $ret)) -}}
+{{- end -}}
+
+
+{{- if $Page.Debugger.Name -}}
+	{{- /* check component's proper existence */ -}}
+	{{- $path = printf "layouts/partials/hestiaGUI/%s" $Page.Debugger.Name -}}
+	{{- $ret = (fileExists (printf "%s/CSS" $path))
+			| and (fileExists (printf "%s/CSSVariables" $path))
+			| and (fileExists (printf "%s/JS" $path))
+			| and (fileExists (printf "%s/HTML" $path))
+	-}}
+
+	{{- if not $ret -}}
+		{{- $error = printf
+			".Debugger: '%v' component does not exist!\n"
+			$Page.Debugger.Name
+		-}}
+		{{- $error = merge $Page (dict "Error" $error) -}}
+		{{- partial "hestiaIO/hestiaTERM/Errorf" $error -}}
 	{{- else -}}
-		{{- $ret = "" -}}
+		{{- $ret = printf "hestiaGUI/%s/HTML" $Page.Debugger.Name -}}
+		{{- $Page = merge $Page (dict "Debugger" (dict "HTML" $ret)) -}}
+
+		{{- $ret = printf "%s/CSS" $path -}}
+		{{- $ret = merge $Page (dict "Input" (dict "Path" $ret)) -}}
+		{{- $ret = partial "hestiaIO/hestiaFS/ParseFile" $ret -}}
+		{{- $ret = merge $Page (dict "Input" (dict "Data" $ret.Output)) -}}
+		{{- $ret = partial "hestiaSTRING/Sanitize" $ret -}}
+		{{- if $ret.Error -}}
+			{{- $error = printf
+				".Debugger.%v.CSS: %v"
+				$Page.Debugger.Name
+				$ret.Error
+			-}}
+			{{- $error = merge $Page (dict "Error" $error) -}}
+			{{- partial "hestiaIO/hestiaTERM/Errorf" $error -}}
+		{{- end -}}
+		{{- $Page = merge $Page (dict "Debugger" (dict "CSS" $ret.Output)) -}}
+
+		{{- $ret = printf "%s/JS" $path -}}
+		{{- $ret = merge $Page (dict "Input" (dict "Path" $ret)) -}}
+		{{- $ret = partial "hestiaIO/hestiaFS/ParseFile" $ret -}}
+		{{- $ret = merge $Page (dict "Input" (dict "Data" $ret.Output)) -}}
+		{{- $ret = partial "hestiaSTRING/Sanitize" $ret -}}
+		{{- if $ret.Error -}}
+			{{- $error = printf
+				".Debugger.%v.JS: %v"
+				$Page.Debugger.Name
+				$ret.Error
+			-}}
+			{{- $error = merge $Page (dict "Error" $error) -}}
+			{{- partial "hestiaIO/hestiaTERM/Errorf" $error -}}
+		{{- end -}}
+		{{- $Page = merge $Page (dict "Debugger" (dict "JS" $ret.Output)) -}}
 	{{- end -}}
 {{- end -}}
-{{- $Page = merge $Page (dict "Debugger" (dict "Name" $ret)) -}}
 
 
 

--- a/hestiaHUGO/layouts/partials/hestiaHTML/ToString
+++ b/hestiaHUGO/layouts/partials/hestiaHTML/ToString
@@ -542,11 +542,23 @@ specific language governing permissions and limitations under the License.
 		});
 	</script>
 {{- end }}
+
+
+{{- /* render .Debugger */}}
+{{- if .Debugger.Name }}
+	{{- if .Debugger.CSS }}
+	<style>{{- safeCSS .Debugger.CSS -}}</style>
+	{{- end }}
+
+	{{- if .Debugger.JS }}
+	<script defer type='module'>{{- safeJS .Debugger.JS -}}</script>
+	{{- end }}
+{{- end }}
 </head>
 <body>
 	{{ safeHTML (index .Content "HTML") }}
 	{{- if .Debugger.Name }}
-	{{ partial .Debugger.Name . -}}
+	{{ partial .Debugger.HTML . -}}
 	{{- end }}
 </body>
 </html>


### PR DESCRIPTION
We want to make sure that the CSS and JS processed assets output are indeed page data. Right now, the debugger's assets are contaminating them as 1st component which is not desirable since users will copy-paste off the debugger console. Hence, we need to decontaminate it and debugger has its own delivery pipeline. Let's do this.

This patch decontaminate debugger from page assets in hestiaHUGO/ directory.