### PR TITLE
hestiaHUGO: fixed left and right drawers' UI height bug

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_LEFT/CSSVariables
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_LEFT/CSSVariables
@@ -4,7 +4,7 @@
 
 "--left-drawer-width" = "0"
 "--left-drawer-width-opened" = "90vw"
-"--left-drawer-height" = "100vh"
+"--left-drawer-height" = "100%"
 "--left-drawer-height-opened" = "var(--left-drawer-height)"
 "--left-drawer-overflow" = "hidden auto"
 "--left-drawer-border" = "var(--drawer-border)"

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_RIGHT/CSSVariables
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_RIGHT/CSSVariables
@@ -4,7 +4,7 @@
 
 "--right-drawer-width" = "0"
 "--right-drawer-width-opened" = "90vw"
-"--right-drawer-height" = "100vh"
+"--right-drawer-height" = "100%"
 "--right-drawer-height-opened" = "var(--right-drawer-height)"
 "--right-drawer-overflow" = "hidden auto"
 "--right-drawer-border" = "var(--drawer-border)"


### PR DESCRIPTION
Appearently, the left and right drawers' are not complying to its container's height (100vh) due to bad CSS variable value (not 100%). Hence, we need to fix it.

This patch fixes left and right drawers' UI height bug in hestiaHUGO/ directory.