### PR TITLE
hestiaHUGO: first attempt to reduce "memory leak" symptom

### DIFF
--- a/hestiaHUGO/data/Hestia/PWA/Caches.toml
+++ b/hestiaHUGO/data/Hestia/PWA/Caches.toml
@@ -12,7 +12,7 @@
 #                          prefix are cached regardless of its actual use in
 #                          any of the display contents.
 [Automation]
-Enabled = false
+Enabled = true
 
 
 

--- a/hestiaHUGO/layouts/partials/hestiaCOMPILERS/hestiaHUGO/SaveOfflineURL
+++ b/hestiaHUGO/layouts/partials/hestiaCOMPILERS/hestiaHUGO/SaveOfflineURL
@@ -66,6 +66,7 @@ specific language governing permissions and limitations under the License.
 		{{- $dataList = merge $dataList (dict $k $v) -}}
 	{{- end -}}
 
+	{{- $Page.Memory.Delete $Page.Constants.Offline.MemKey -}}
 	{{- $Page.Memory.Set $Page.Constants.Offline.MemKey $dataList -}}
 {{- end -}}
 

--- a/hestiaHUGO/layouts/partials/hestiaCOMPILERS/hestiaHUGO/saveContributors
+++ b/hestiaHUGO/layouts/partials/hestiaCOMPILERS/hestiaHUGO/saveContributors
@@ -45,6 +45,7 @@ specific language governing permissions and limitations under the License.
 
 {{- /* save to persistent memory */ -}}
 {{- if $dataset -}}
+	{{- .Memory.Delete .Constants.Contributors.RolesMemKey -}}
 	{{- .Memory.Set .Constants.Contributors.RolesMemKey $dataset -}}
 {{- end -}}
 

--- a/hestiaHUGO/layouts/partials/hestiaSTRING/Sanitize
+++ b/hestiaHUGO/layouts/partials/hestiaSTRING/Sanitize
@@ -48,8 +48,7 @@ specific language governing permissions and limitations under the License.
 {{- if $error -}}
 	{{- /* PASSTHROUGH */ -}}
 {{- else if partial "hestiaSTRING/IsString" $dataList -}}
-	{{- $filename = printf "deletable-%v-%v-%v-%v"
-				(mod (add (mul 13 now.Unix) 97) 400000)
+	{{- $filename = printf "deletable-%v-%v-%v"
 				(sha256 (string $Page.URL.Current.Absolute))
 				(now.Format "200601021504050700")
 				(crypto.FNV32a $dataList)

--- a/hestiaHUGO/layouts/partials/hestiaURL/Sanitize
+++ b/hestiaHUGO/layouts/partials/hestiaURL/Sanitize
@@ -90,8 +90,9 @@ specific language governing permissions and limitations under the License.
 
 
 	{{- if $ret -}}
-		{{- $ret = dict $ret $Page.PWA.Caches.Default.Policy -}}
-		{{- $ret = merge $Page (dict "Input" (dict "Data" $ret)) -}}
+		{{- $ret = merge $Page (dict "Input" (dict "Data"
+			$ret $Page.PWA.Caches.Default.Policy
+		)) -}}
 		{{- $ret = partial "hestiaCOMPILERS/hestiaHUGO/SaveOfflineURL" $ret -}}
 		{{- if and $ret.Error (not $error) -}}
 			{{- $error = printf


### PR DESCRIPTION
After resolving the iterative performance for hestiaHUGO, it appears we have a "memory leak" alike symptom now. We suspect it was caused by the imporper use of .Store (where Holloway believes manual memory deletion is required). Hence, we will apply this change for now to observe any improvements. Let's do this.

This patch applies first attempt to reduce "memory leak" symptom in hestiaHUGO/ directory.