### PR TITLE
sites: translated /zh-hans/releases/v1p1p0/ page

### DIFF
--- a/sites/content/zh-hans/releases/v1p1p0/__assets.toml
+++ b/sites/content/zh-hans/releases/v1p1p0/__assets.toml
@@ -1,0 +1,122 @@
+# PAGE SPECIFIC ASSETS
+# ====================
+# You can include or inline CSS assets into this specific page only by listing
+# out their .URL or relative file .PATH sources respectively.
+#
+# All .CSS.Inline artifacts shall only be provided with Hugo's virtual pathing
+# only.
+#
+# As For .CSS.Include artifacts, Hestia's URL processing is available for
+# dynamic relative pathing constructions. As long as the URL is accessible,
+# storing location is not restricted to any single location.
+#
+# Example, for the artifact placed in:
+#          assets storage directory =    assets/
+#          artifact location        =    assets/css/my-site.min.css
+#          .Inline value            =    assets/css/my-site.min.css
+#          .Include value           =    NOT APPLICABLE
+#
+#          page storage directory   =    en/my-page-here/
+#          artifact location        =    en/my-page-here/my-page.min.css
+#          .Inline value            =    en/my-page-here/my-page.min.css
+#          .Include value           =    /en/my-page-here/my-page.min.css
+#
+#          static storage directory =    static/css/
+#          artifact location        =    static/css/my-page.min.css
+#          .Inline value            =    NOT APPLICABLE
+#          .Include value           =    /css/my-page.min.css
+#
+# The data structure pattern is as follows:
+#                  [[CSS.Inline]]
+#                  Path = '{{ .Inline }}'
+#
+#                         OR
+#
+#                  [[CSS.Include]]
+#                  URL = '{{ .Include }}'
+#                  Media = '{{ .Include.Media }}'
+#                  OnLoad = '{{ .Include.OnLoad }}'
+#
+# To add more entries into either list, simply append new data structure below.
+# The position of the entries dictates the rendering sequence of its statement.
+#
+# For .Include list, should .Media or .Onload is used for asynchonous loading,
+# there is no guarentee for the actual CSS loading sequences (see:
+# https://web.dev/critical-rendering-path-render-blocking-css/). When in doubt,
+# leaving them blank.
+#
+# NOTE:
+# The '__content.hestiaCSS', the page-specific CSS control file will be
+# automatically appended into .CSS.Inline as the last item (demmed the most
+# powerful among all when operating in .Include leading the .Inline mode). You
+# DO NOT need to manually add it in.
+[[CSS.Inline]]
+Path = ''
+
+
+[[CSS.Include]]
+URL = ''
+Media = ''
+OnLoad = ''
+
+
+
+
+# You can include or inline JS assets into this specific page only by listing
+# out their .URL or relative file .PATH sources respectively.
+#
+# All .JS.Inline artifacts shall only be provided with Hugo's virtual pathing.
+#
+# As for .JS.Include artifacts, Hestia's URL processing is available for
+# dynamic relative pathing constructions. As long as the URL is accessible,
+# storing location is not restricted to any single location.
+#
+# Example, for the artifact placed in:
+#          assets storage directory =    assets/
+#          artifact location        =    assets/js/my-site.min.js
+#          .Inline value            =    assets/js/my-site.min.js
+#          .Include value           =    NOT APPLICABLE
+#
+#          page storage directory   =    en/my-page-here/
+#          artifact location        =    en/my-page-here/my-page.min.js
+#          .Inline value            =    en/my-page-here/my-page.min.js
+#          .Include value           =    /en/my-page-here/my-page.min.js
+#
+#          static storage directory =    static/js/
+#          artifact location        =    static/js/my-page.min.js
+#          .Inline value            =    NOT APPLICABLE
+#          .Include value           =    /js/my-page.min.js
+#
+# The data structure pattern is as follows:
+#                  [[JS.Inline]]
+#                  Path = '{{ .Inline }}'
+#
+#                         OR
+#
+#                  [[JS.Include]]
+#                  URL = '{{ .Include }}'
+#                  Timing = '...'
+#
+# To add more entries into either list, simply append new data structure below.
+# The position of the entries dictates the rendering sequence of its statement.
+#
+# For the .Include List, the .Timing value can be any of the following:
+#     1. 'defer' - download the asset first and execute after DOM (default).
+#     2. 'async' - download the asset in parallel to DOM and execute immediately
+#                  regardless of DOM completion status.
+#     3. 'sync'  - block DOM and synchonously download and execute the asset.
+# When in doubt, stick to 'defer' as you would not want to block the page from
+# DOM rendering completion at all time.
+#
+# NOTE:
+# The '__content.hestiaJS', the page-specific JS control file will
+# automatically be appended into .JS.Inline as the last item (deemed the most
+# powerful among all when operating in .Include leading .Inline mode). You DO
+# NOT need to manually add it in.
+[[JS.Inline]]
+Path = ''
+
+
+[[JS.Include]]
+URL = ''
+Timing = 'defer'

--- a/sites/content/zh-hans/releases/v1p1p0/__components.toml
+++ b/sites/content/zh-hans/releases/v1p1p0/__components.toml
@@ -1,0 +1,113 @@
+# HESTIA PAGE-LEVEL WEB UI COMPONENTS LIST
+# ========================================
+# All Hestia internal web UI components for this page.
+#
+# The components' low-level codes are auto-generated from hestiaGO code
+# libraries for rendering consistency between non-WASM users and WASM users.
+#
+# If you're using WASM from Hestia code libraries and they are directly
+# controlling the page UI (either as single-page rendering or reactive
+# rendering), you **SHOULD NOT** include anything below as they're duplicates
+# and can cause confusing complications. Please stick to ONE(1) rendering
+# method.
+#
+# You SHOULD ONLY include components that are used in this page. To configure:
+#     [[List]]
+#     Name = "COMPONENT"
+#     Include = true
+#     Variables = [
+#            { "--variable-1" = "1rem" },
+#            { "--variable-2" = "2rem" },
+#     ]
+#
+#     List.{POSITION}.Name      = name of the component (string)
+#     List.{POSITION}.Include   = inclusion decision (bool true/false)
+#     List.{POSITION}.Variables = list of overriding variables to the component.
+#
+# NOTE:
+#     1) The position of the component listing influences the variables
+#        overriding sequence. Please construct your list properly.
+#     2) Check out Hestia's hestiaGUI catalog list for supported UI components
+#        at:
+#                 https://hestia.zoralab.com/en/specs/hestiaGUI/
+#
+#
+# EXAMPLE:
+#        [[List]]
+#        Name = "zoralabCORE"
+#        Include = true
+#        Variables = [
+#                  { "--test-variable-1" = "1rem" },
+#                  { "--test-variable-2" = "2rem" },
+#        ]
+#
+#        [[List]]
+#        Name = "zoralabFONT_NOTOSANS"
+#        Include = true
+#        Variables = []
+#
+#        ...
+[[List]]
+Name = "zoralabCORE"
+Include = true
+Variables = [
+	{ "--body-scroll-behavior" = "smooth" },
+]
+
+[[List]]
+Name = "zoralabFONT_NOTOSANS"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabDRAWER"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabDRAWER_LEFT"
+Include = true
+Variables = [
+	{ "--left-drawer-width-opened" = "80vw" },
+	{ "--left-drawer-trigger-position-top" = "0" },
+]
+
+[[List]]
+Name = "zoralabANCHOR"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabBUTTON"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabTILE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabCARD"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabPICTURE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabTABLE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabCODE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabOLIST"
+Include = true
+Variables = []

--- a/sites/content/zh-hans/releases/v1p1p0/__content.hestiaCSS
+++ b/sites/content/zh-hans/releases/v1p1p0/__content.hestiaCSS
@@ -1,0 +1,15 @@
+{{- /*
+Page's CSS Prime Control
+
+This page constructs the page-specific CSS codes that will be appeneded into
+.CSS.Inline as the last entry (most powerful). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+
+
+
+
+{{- /* render your page output */ -}}

--- a/sites/content/zh-hans/releases/v1p1p0/__content.hestiaHTML
+++ b/sites/content/zh-hans/releases/v1p1p0/__content.hestiaHTML
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML Output Prime Control
+
+This file is your HTML output file (index.html). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms are required.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $ret := false -}}
+{{- $i18n := .Data.Page.i18n -}}
+
+
+
+
+{{- /* render outputs */ -}}
+<main>
+	<section id='{{- $i18n.Introduction.ID -}}'>
+		<h1>{{- .Titles.Page -}}</h1>
+		<p>{{- .Descriptions.Page.Pitch }} {{ .Descriptions.Page.Summary -}}</p>
+	</section>
+</main>

--- a/sites/content/zh-hans/releases/v1p1p0/__content.hestiaJS
+++ b/sites/content/zh-hans/releases/v1p1p0/__content.hestiaJS
@@ -1,0 +1,15 @@
+{{- /*
+Page's Javascript Prime Control
+
+This page constructs the page-specific JS codes that will be appeneded into
+.JS.Inline as last entry (most powerful). Hugo's and Go's template processors
+are available at your disposal in case of mathematical or logical algorithms
+development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+
+
+
+
+{{- /* render your Javascript output */ -}}

--- a/sites/content/zh-hans/releases/v1p1p0/__content.hestiaJSON
+++ b/sites/content/zh-hans/releases/v1p1p0/__content.hestiaJSON
@@ -1,0 +1,26 @@
+{{- /*
+Page's JSON Output Prime Control
+
+This file is your JSON output file (index.json). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+{{- $i18n := .Data.Page.i18n -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (dict
+	$i18n.Title .Titles.Page
+	$i18n.Description (printf "%s %s" .Descriptions.Page.Pitch .Descriptions.Page.Summary)
+) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/zh-hans/releases/v1p1p0/__content.hestiaLDJSON
+++ b/sites/content/zh-hans/releases/v1p1p0/__content.hestiaLDJSON
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (partial "hestiaJSON/schemaorgLDJSON/WebPage" .) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/zh-hans/releases/v1p1p0/__contributors.toml
+++ b/sites/content/zh-hans/releases/v1p1p0/__contributors.toml
@@ -1,0 +1,78 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...
+[[Contributors]]
+Key = 'ZORALab'
+
+[Contributors.Contribution]
+Creation = true
+Contact = true
+Artwork = false
+Knowledge = false
+Editor = true
+Developer = false
+Maintainer = false
+Producer = true
+Provider = true
+Publisher = true
+Funder = false
+Sponsor = true
+
+
+
+
+[[Contributors]]
+Key = 'HollowayKeanHo'
+
+[Contributors.Contribution]
+Creation = true
+Contact = false
+Artwork = false
+Knowledge = true
+Editor = true
+Developer = false
+Maintainer = false
+Producer = false
+Provider = false
+Publisher = false
+Funder = false
+Sponsor = false

--- a/sites/content/zh-hans/releases/v1p1p0/__i18n.toml
+++ b/sites/content/zh-hans/releases/v1p1p0/__i18n.toml
@@ -1,7 +1,7 @@
 [i18n]
 Title = '标题'
 Description = '大纲'
-Version = 'v1p0p0'
+Version = 'v1p1p0'
 
 
 

--- a/sites/content/zh-hans/releases/v1p1p0/__languages.toml
+++ b/sites/content/zh-hans/releases/v1p1p0/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = '/en/releases/v1p1p0/'
+
+[zh-Hans]
+URL = '/zh-hans/releases/v1p1p0/'

--- a/sites/content/zh-hans/releases/v1p1p0/__page.toml
+++ b/sites/content/zh-hans/releases/v1p1p0/__page.toml
@@ -1,0 +1,118 @@
+# PAGE METADATA
+# =============
+# Date fields.
+#
+# NOTE:
+#   1. You can generate date easily on linux using '$ date' command.
+#   2. If date field is left blank, the current time shall be used instead.
+#   3. Date should ONLY comply to this pattern when manually constructed:
+#                    Thu 21 Jul 2022 14:27:39 PM +08
+[Date]
+Created   = 'Fri 24 Feb 2023 11:55:22 AM +08'
+Published = 'Fri 24 Feb 2023 11:55:22 AM +08'
+
+
+
+
+# Content fields.
+# NOTE:
+#   1. For .Title, Hestia's string processing using page variables are allowed
+#      and only limited to .Titles sub-fields.
+#   2. For .Keywords, Hestia's string processing using page variables are
+#      allowed but strongly discouraged.
+[Content]
+Title = "ZORALab赫斯提亚v1.1.0版发行说明"
+Keywords = [
+	'v1.1.0',
+	'发行说明',
+	'网站',
+	'科技',
+	'PWA',
+	'WASM',
+	'代码库',
+	'Hugo',
+	'Go',
+	'TinyGo',
+	'Nim',
+	'ZORALab',
+	'ZORALab赫斯提亚',
+]
+
+
+
+
+# Description fields.
+# NOTE:
+#   1. Hestia's string processing using page variables are allowed.
+#   2. The .Description.Pitch is at maximum 160 characters.
+#   3. The .Description.Summary is at maximum of 250 characters.
+#   4. All fields shall have their whitespace cleansed during the processing.
+[Description]
+Pitch = '''
+ZORALab赫斯提亚v1.1.0版的发行说明。
+'''
+Summary = '''
+随时可以安全地下载。
+'''
+
+
+
+
+# Redirect fields.
+# NOTE:
+#   1. Hestia's URL processing is allowed for .URL field.
+#   2. .Delay timing sets the delay time before redirect. Setting to '0' means
+#      an immediate redirect is requested.
+#   3. Redirect is only available if .Enabled is set to 'true'.
+#   4. Redirect.Language is to redirect the current page to its
+#      language-specific page when Javascript is made available on client side
+#      or fallback to default language.
+[Redirect]
+Delay = 0 # second
+URL = ''
+Enabled = false
+
+[Redirect.Language]
+Enabled = false
+
+
+
+
+# Content Files' Sourcing Location
+# NOTE:
+#   1. To denote where are the content sources.
+#   2. If you're sourcing from assets directory, prefix 'assets/'.
+#   3. If you're sourcing from layouts directory, prefix 'layouts/'.
+#   2. If you're sourcing from static directory, prefix 'static/'.
+#   3. If you're sourcing from partial directory, prefix 'layouts/partials/'.
+[Sources]
+HTML = 'layouts/content/releases/common/index.html'
+JSON = 'layouts/content/releases/common/index.json'
+LDJSON = '__content.hestiaLDJSON'
+Contributors = '__contributors.toml'
+Thumbnails = '__thumbnails.toml'
+Languages = '__languages.toml'
+
+
+
+
+# Data fields.
+# NOTE:
+#   1. List only the page-level data files. It can be in any of the following
+#      formats: '.json', '.toml', or '.yaml'.
+#   2. Hestia string processing is available and shall be processed prior to
+#      dataset transformation.
+#   3. Sequences of the .Data array dictates sequences of loading and overriding
+#      (the latter shall overwrite the former for the same data fields).
+#   4. The final processed dataset shall be served as main data content in
+#      supported output format (e.g. index.json).
+#   5. Missing data file shall be ignored.
+#   6. To add more data files, simply duplicate and add more .Data array entry.
+#      Example:
+#                             [[data]]
+#                             Filename = 'file1.json'
+#
+#                             [[data]]
+#                             Filename = 'file2.toml'
+[[Data]]
+Filename = '__i18n.toml'

--- a/sites/content/zh-hans/releases/v1p1p0/__robots.toml
+++ b/sites/content/zh-hans/releases/v1p1p0/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/zh-hans/releases/v1p1p0/__thumbnails.toml
+++ b/sites/content/zh-hans/releases/v1p1p0/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/img/thumbnails/zoralab-hestia-releases-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/img/thumbnails/zoralab-hestia-releases-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/img/thumbnails/zoralab-hestia-releases-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/zh-hans/releases/v1p1p0/__twitter.toml
+++ b/sites/content/zh-hans/releases/v1p1p0/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/zh-hans/releases/v1p1p0/__wasm.toml
+++ b/sites/content/zh-hans/releases/v1p1p0/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/zh-hans/releases/v1p1p0/_index.html
+++ b/sites/content/zh-hans/releases/v1p1p0/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++


### PR DESCRIPTION
Since the /en/releases/v1p1p0/ page is ready, we can proceed to translate it. Hence, let's do this.

This patch translate /zh-hans/releases/v1p1p0/ page in sites/ directory.