### PR TITLE
sites: corrected spelling errors for releases page

### DIFF
--- a/sites/content/en/releases/__i18n.toml
+++ b/sites/content/en/releases/__i18n.toml
@@ -14,11 +14,7 @@ List = 'List'
 
 
 [i18n.Introduction]
-ID = 'releases'
-Title = 'Releases'
-Description = '''
-All out historical product releases by version, from latest to the earliest.
-'''
+ID = 'introduction'
 
 
 

--- a/sites/content/zh-hans/releases/__i18n.toml
+++ b/sites/content/zh-hans/releases/__i18n.toml
@@ -14,11 +14,7 @@ List = '菜单'
 
 
 [i18n.Introduction]
-ID = '发行'
-Title = '发行'
-Description = '''
-我们历史中根据版本从最新到古前所发布的产品。
-'''
+ID = '自介'
 
 
 

--- a/sites/content/zh-hans/releases/__page.toml
+++ b/sites/content/zh-hans/releases/__page.toml
@@ -21,8 +21,10 @@ Published = 'Sat 24 Dec 2022 02:14:30 PM +08'
 #   2. For .Keywords, Hestia's string processing using page variables are
 #      allowed but strongly discouraged.
 [Content]
-Title = 'ZORALab赫斯提亚发布的软件包'
+Title = 'ZORALab赫斯提亚发行软件包'
 Keywords = [
+	'软件包',
+	'发行',
 	'网站',
 	'科技',
 	'PWA',

--- a/sites/data/Nav.toml
+++ b/sites/data/Nav.toml
@@ -137,7 +137,7 @@ URL = '/zh-hans/getting-started/#nim'
 
 
 [[Languages.ZH-HANS]]
-Title = '发布软件包'
+Title = '发行软件包'
 
 [[Languages.ZH-HANS.Items]]
 Title = "询问"

--- a/sites/layouts/content/releases/index.html
+++ b/sites/layouts/content/releases/index.html
@@ -10,10 +10,8 @@
 {{- /* render output */ -}}
 <main style='padding-bottom: 0;'>
 	<section id='{{- $i18n.Introduction.ID -}}'>
-		<div>
-			<h1>{{- $i18n.Introduction.Title -}}</h1>
-			<p>{{- $i18n.Introduction.Description -}}</p>
-		</div>
+		<h1>{{- .Titles.Page -}}</h1>
+		<p>{{- .Descriptions.Page.Pitch }} {{ .Descriptions.Page.Summary -}}</p>
 	</section>
 
 


### PR DESCRIPTION
Appearently, the release catalog page contains some spelling errors. Hence, let's correct them.

This patch corrects spelling errors for releases page in sites/ directory.