### PR TITLE
hestiaHUGO: removed unused fields in archetypes

### DIFF
--- a/hestiaHUGO/archetypes/hestia/__i18n.toml
+++ b/hestiaHUGO/archetypes/hestia/__i18n.toml
@@ -7,4 +7,3 @@ Description = 'Description'
 
 [i18n.Introduction]
 ID = 'introduction'
-Title = 'Introduction'


### PR DESCRIPTION
The currrent archetypes is introducing an unused Title field in __i18n.toml data file. Hence, we need to remove it for avoiding misled. Let's do this.

This patch removes unused fields in archetypes in hestiaHUGO/ directory.