### PR TITLE
sites: added release statuses rendering

### DIFF
--- a/sites/content/en/releases/__i18n.toml
+++ b/sites/content/en/releases/__i18n.toml
@@ -9,6 +9,8 @@ Description = 'Description'
 ID = 'ID'
 ReleaseNote = 'ReleaseNote'
 List = 'List'
+Development = 'Development'
+Latest = 'Latest'
 
 
 

--- a/sites/content/en/releases/v1p0p0/__components.toml
+++ b/sites/content/en/releases/v1p0p0/__components.toml
@@ -111,3 +111,18 @@ Variables = []
 Name = "zoralabOLIST"
 Include = true
 Variables = []
+
+[[List]]
+Name = "zoralabNOTE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabNOTE_WARNING"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabNOTE_ERROR"
+Include = true
+Variables = []

--- a/sites/content/en/releases/v1p0p0/__i18n.toml
+++ b/sites/content/en/releases/v1p0p0/__i18n.toml
@@ -11,6 +11,11 @@ Assets = 'Assets'
 Statement = 'Statement'
 References = 'References'
 Notes = 'Notes'
+Status = 'Status'
+BackwardCompatible = 'Backward Compatible'
+Development = 'Development'
+Retired = 'Retired'
+Latest = 'Latest'
 
 
 
@@ -21,6 +26,30 @@ Title = 'v1.0.0 Release Note'
 Description = '''
 The technical summary about ZORALab's Hestia version v1.0.0 release covering
 its related technologies.
+'''
+
+
+
+
+[i18n.Notices.NonBackwardCompatible]
+Title = 'WARNING: NOT BACKWARD COMPATIBLE'
+Text = '''
+This release contains non-backward compatible implementations. Use with extreme
+care.
+'''
+
+
+[i18n.Notices.Development]
+Title = 'IMPORTANT: UNDER DEVELOPMENT'
+Text = '''
+This release is still under development and is subjected to change.
+'''
+
+
+[i18n.Notices.Retired]
+Title = 'WARNING: Retired Package'
+Text = '''
+This release is retired and will no longer be supported. Please use the latest.
 '''
 
 

--- a/sites/content/en/releases/v1p1p0/__components.toml
+++ b/sites/content/en/releases/v1p1p0/__components.toml
@@ -111,3 +111,18 @@ Variables = []
 Name = "zoralabOLIST"
 Include = true
 Variables = []
+
+[[List]]
+Name = "zoralabNOTE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabNOTE_WARNING"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabNOTE_ERROR"
+Include = true
+Variables = []

--- a/sites/content/en/releases/v1p1p0/__i18n.toml
+++ b/sites/content/en/releases/v1p1p0/__i18n.toml
@@ -11,12 +11,41 @@ Assets = 'Assets'
 Statement = 'Statement'
 References = 'References'
 Notes = 'Notes'
+Status = 'Status'
+BackwardCompatible = 'Backward Compatible'
+Development = 'Development'
+Retired = 'Retired'
+Latest = 'Latest'
 
 
 
 
 [i18n.Introduction]
 ID = 'introduction'
+
+
+
+
+[i18n.Notices.NonBackwardCompatible]
+Title = 'WARNING: NOT BACKWARD COMPATIBLE'
+Text = '''
+This release contains non-backward compatible implementations. Use with extreme
+care.
+'''
+
+
+[i18n.Notices.Development]
+Title = 'IMPORTANT: UNDER DEVELOPMENT'
+Text = '''
+This release is still under development and is subjected to change.
+'''
+
+
+[i18n.Notices.Retired]
+Title = 'WARNING: Retired Package'
+Text = '''
+This release is retired and will no longer be supported. Please use the latest.
+'''
 
 
 

--- a/sites/content/en/releases/v1p2p0/__components.toml
+++ b/sites/content/en/releases/v1p2p0/__components.toml
@@ -111,3 +111,18 @@ Variables = []
 Name = "zoralabOLIST"
 Include = true
 Variables = []
+
+[[List]]
+Name = "zoralabNOTE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabNOTE_WARNING"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabNOTE_ERROR"
+Include = true
+Variables = []

--- a/sites/content/en/releases/v1p2p0/__i18n.toml
+++ b/sites/content/en/releases/v1p2p0/__i18n.toml
@@ -11,12 +11,41 @@ Assets = 'Assets'
 Statement = 'Statement'
 References = 'References'
 Notes = 'Notes'
+Status = 'Status'
+BackwardCompatible = 'Backward Compatible'
+Development = 'Development'
+Retired = 'Retired'
+Latest = 'Latest'
 
 
 
 
 [i18n.Introduction]
 ID = 'introduction'
+
+
+
+
+[i18n.Notices.NonBackwardCompatible]
+Title = 'WARNING: NOT BACKWARD COMPATIBLE'
+Text = '''
+This release contains non-backward compatible implementations. Use with extreme
+care.
+'''
+
+
+[i18n.Notices.Development]
+Title = 'IMPORTANT: UNDER DEVELOPMENT'
+Text = '''
+This release is still under development and is subjected to change.
+'''
+
+
+[i18n.Notices.Retired]
+Title = 'WARNING: Retired Package'
+Text = '''
+This release is retired and will no longer be supported. Please use the latest.
+'''
 
 
 

--- a/sites/content/zh-hans/releases/__i18n.toml
+++ b/sites/content/zh-hans/releases/__i18n.toml
@@ -9,6 +9,8 @@ Description = '大纲'
 ID = 'ID'
 ReleaseNote = '发行说明'
 List = '菜单'
+Latest = '最新'
+Development = '开发着'
 
 
 

--- a/sites/content/zh-hans/releases/v1p0p0/__components.toml
+++ b/sites/content/zh-hans/releases/v1p0p0/__components.toml
@@ -111,3 +111,18 @@ Variables = []
 Name = "zoralabOLIST"
 Include = true
 Variables = []
+
+[[List]]
+Name = "zoralabNOTE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabNOTE_WARNING"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabNOTE_ERROR"
+Include = true
+Variables = []

--- a/sites/content/zh-hans/releases/v1p0p0/__i18n.toml
+++ b/sites/content/zh-hans/releases/v1p0p0/__i18n.toml
@@ -11,12 +11,40 @@ Assets = '资产'
 Statement = '陈述'
 References = '引用'
 Notes = '笔记'
+Status = '状况'
+BackwardCompatible = '向后兼容'
+Development = '开发'
+Retired = '退化'
+Latest = '最新'
 
 
 
 
 [i18n.Introduction]
 ID = '自介'
+
+
+
+
+[i18n.Notices.NonBackwardCompatible]
+Title = '提警: 不向后兼容'
+Text = '''
+这个发行有不向后兼容的实现开发。请小心运用。
+'''
+
+
+[i18n.Notices.Development]
+Title = '重要:还正在开发'
+Text = '''
+这个发行还正在开发着。一切内容还是会被更改的。
+'''
+
+
+[i18n.Notices.Retired]
+Title = '提警: 已经退化了'
+Text = '''
+这个发行已经退化了。我们是不再支持了。请用最新的版本吧。
+'''
 
 
 

--- a/sites/content/zh-hans/releases/v1p1p0/__components.toml
+++ b/sites/content/zh-hans/releases/v1p1p0/__components.toml
@@ -111,3 +111,18 @@ Variables = []
 Name = "zoralabOLIST"
 Include = true
 Variables = []
+
+[[List]]
+Name = "zoralabNOTE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabNOTE_WARNING"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabNOTE_ERROR"
+Include = true
+Variables = []

--- a/sites/content/zh-hans/releases/v1p1p0/__i18n.toml
+++ b/sites/content/zh-hans/releases/v1p1p0/__i18n.toml
@@ -11,12 +11,40 @@ Assets = '资产'
 Statement = '陈述'
 References = '引用'
 Notes = '笔记'
+Status = '状况'
+BackwardCompatible = '向后兼容'
+Development = '开发'
+Retired = '退化'
+Latest = '最新'
 
 
 
 
 [i18n.Introduction]
 ID = '自介'
+
+
+
+
+[i18n.Notices.NonBackwardCompatible]
+Title = '提警: 不向后兼容'
+Text = '''
+这个发行有不向后兼容的实现开发。请小心运用。
+'''
+
+
+[i18n.Notices.Development]
+Title = '重要:还正在开发'
+Text = '''
+这个发行还正在开发着。一切内容还是会被更改的。
+'''
+
+
+[i18n.Notices.Retired]
+Title = '提警: 已经退化了'
+Text = '''
+这个发行已经退化了。我们是不再支持了。请用最新的版本吧。
+'''
 
 
 

--- a/sites/content/zh-hans/releases/v1p2p0/__components.toml
+++ b/sites/content/zh-hans/releases/v1p2p0/__components.toml
@@ -111,3 +111,18 @@ Variables = []
 Name = "zoralabOLIST"
 Include = true
 Variables = []
+
+[[List]]
+Name = "zoralabNOTE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabNOTE_WARNING"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabNOTE_ERROR"
+Include = true
+Variables = []

--- a/sites/content/zh-hans/releases/v1p2p0/__i18n.toml
+++ b/sites/content/zh-hans/releases/v1p2p0/__i18n.toml
@@ -11,12 +11,40 @@ Assets = '资产'
 Statement = '陈述'
 References = '引用'
 Notes = '笔记'
+Status = '状况'
+BackwardCompatible = '向后兼容'
+Development = '开发'
+Retired = '退化'
+Latest = '最新'
 
 
 
 
 [i18n.Introduction]
 ID = '自介'
+
+
+
+
+[i18n.Notices.NonBackwardCompatible]
+Title = '提警: 不向后兼容'
+Text = '''
+这个发行有不向后兼容的实现开发。请小心运用。
+'''
+
+
+[i18n.Notices.Development]
+Title = '重要:还正在开发'
+Text = '''
+这个发行还正在开发着。一切内容还是会被更改的。
+'''
+
+
+[i18n.Notices.Retired]
+Title = '提警: 已经退化了'
+Text = '''
+这个发行已经退化了。我们是不再支持了。请用最新的版本吧。
+'''
 
 
 

--- a/sites/data/Releases/v1p2p0.toml
+++ b/sites/data/Releases/v1p2p0.toml
@@ -17,7 +17,7 @@ ID = 'v1.2.0'
 URL = 'v1p2p0'
 BackwardCompatible = false
 Development = true
-Latest = true
+Latest = false
 Retired = false
 
 
@@ -26,7 +26,7 @@ Retired = false
 [Metadata.Languages.EN]
 Title = 'Version 1.2.0'
 Summary = '''
-Minor patches against version 1.1.0. Its main focus are to perform several
+Major patches against version 1.1.0. Its main focus are to perform several
 citical bug fixes discovered from the development of its predecessor.
 '''
 

--- a/sites/layouts/content/releases/common/index.html
+++ b/sites/layouts/content/releases/common/index.html
@@ -14,6 +14,36 @@
 	<section id='{{- $i18n.Introduction.ID -}}'>
 		<h1>{{- $Page.Titles.Page -}}</h1>
 		<p>{{- .Descriptions.Page.Pitch }} {{ .Descriptions.Page.Summary -}}</p>
+
+
+		{{- if not $dataset.Metadata.BackwardCompatible }}
+		<div class="note error">
+			<input id="notice-nbc-1" type="checkbox" checked>
+			<label for="notice-nbc-1">
+				{{- $i18n.Notices.NonBackwardCompatible.Title -}}
+			</label>
+			<p class="content">{{- $i18n.Notices.NonBackwardCompatible.Text -}}</p>
+		</div>
+		{{- end }}
+
+
+		{{- if $dataset.Metadata.Development }}
+		<div class="note warning">
+			<input id="notice-dev-1" type="checkbox" checked>
+			<label for="notice-dev-1">
+				{{- $i18n.Notices.Development.Title -}}
+			</label>
+			<p class="content">{{- $i18n.Notices.Development.Text -}}</p>
+		</div>
+		{{- else if $dataset.Metadata.Retired }}
+		<div class="note warning">
+			<input id="notice-dev-1" type="checkbox" checked>
+			<label for="notice-dev-1">
+				{{- $i18n.Notices.Retired.Title -}}
+			</label>
+			<p class="content">{{- $i18n.Notices.Retired.Text -}}</p>
+		</div>
+		{{- end }}
 	</section>
 
 

--- a/sites/layouts/content/releases/common/index.json
+++ b/sites/layouts/content/releases/common/index.json
@@ -23,6 +23,12 @@ algorithms development.
 {{- $dataList = merge $dataList (dict
 	$i18n.Title .Titles.Page
 	$i18n.Description (printf "%s %s" .Descriptions.Page.Pitch .Descriptions.Page.Summary)
+	$i18n.Labels.Status (dict
+		$i18n.Labels.BackwardCompatible $dataset.Metadata.BackwardCompatible
+		$i18n.Labels.Development $dataset.Metadata.Development
+		$i18n.Labels.Retired $dataset.Metadata.Retired
+		$i18n.Labels.Latest $dataset.Metadata.Latest
+	)
 ) -}}
 
 

--- a/sites/layouts/content/releases/index.html
+++ b/sites/layouts/content/releases/index.html
@@ -37,6 +37,15 @@
 				</div>
 				<div class='content'>
 					<h3>{{- $lang.Title -}}</h3>
+					{{- if $v.Metadata.Latest }}
+					<p style='color: green; text-align: center;'>
+						<b>{{- upper $i18n.Labels.Latest -}}</b>
+					</p>
+					{{- else if $v.Metadata.Development }}
+					<p style='color: orange; text-align: center;'>
+						<b>{{- upper $i18n.Labels.Development -}}</b>
+					</p>
+					{{- end }}
 					<p>{{- $lang.Summary -}}</p>
 				</div>
 				<div class='actions'>


### PR DESCRIPTION
Since the releases data contain statuses now, we should render it out. Hence, let's do this.

This patch adds release statuses rendering into sites/ directory.