### PR TITLE
sites: ported /en/specs/ page from the old system

### DIFF
--- a/sites/content/en/specs/__assets.toml
+++ b/sites/content/en/specs/__assets.toml
@@ -1,0 +1,122 @@
+# PAGE SPECIFIC ASSETS
+# ====================
+# You can include or inline CSS assets into this specific page only by listing
+# out their .URL or relative file .PATH sources respectively.
+#
+# All .CSS.Inline artifacts shall only be provided with Hugo's virtual pathing
+# only.
+#
+# As For .CSS.Include artifacts, Hestia's URL processing is available for
+# dynamic relative pathing constructions. As long as the URL is accessible,
+# storing location is not restricted to any single location.
+#
+# Example, for the artifact placed in:
+#          assets storage directory =    assets/
+#          artifact location        =    assets/css/my-site.min.css
+#          .Inline value            =    assets/css/my-site.min.css
+#          .Include value           =    NOT APPLICABLE
+#
+#          page storage directory   =    en/my-page-here/
+#          artifact location        =    en/my-page-here/my-page.min.css
+#          .Inline value            =    en/my-page-here/my-page.min.css
+#          .Include value           =    /en/my-page-here/my-page.min.css
+#
+#          static storage directory =    static/css/
+#          artifact location        =    static/css/my-page.min.css
+#          .Inline value            =    NOT APPLICABLE
+#          .Include value           =    /css/my-page.min.css
+#
+# The data structure pattern is as follows:
+#                  [[CSS.Inline]]
+#                  Path = '{{ .Inline }}'
+#
+#                         OR
+#
+#                  [[CSS.Include]]
+#                  URL = '{{ .Include }}'
+#                  Media = '{{ .Include.Media }}'
+#                  OnLoad = '{{ .Include.OnLoad }}'
+#
+# To add more entries into either list, simply append new data structure below.
+# The position of the entries dictates the rendering sequence of its statement.
+#
+# For .Include list, should .Media or .Onload is used for asynchonous loading,
+# there is no guarentee for the actual CSS loading sequences (see:
+# https://web.dev/critical-rendering-path-render-blocking-css/). When in doubt,
+# leaving them blank.
+#
+# NOTE:
+# The '__content.hestiaCSS', the page-specific CSS control file will be
+# automatically appended into .CSS.Inline as the last item (demmed the most
+# powerful among all when operating in .Include leading the .Inline mode). You
+# DO NOT need to manually add it in.
+[[CSS.Inline]]
+Path = ''
+
+
+[[CSS.Include]]
+URL = ''
+Media = ''
+OnLoad = ''
+
+
+
+
+# You can include or inline JS assets into this specific page only by listing
+# out their .URL or relative file .PATH sources respectively.
+#
+# All .JS.Inline artifacts shall only be provided with Hugo's virtual pathing.
+#
+# As for .JS.Include artifacts, Hestia's URL processing is available for
+# dynamic relative pathing constructions. As long as the URL is accessible,
+# storing location is not restricted to any single location.
+#
+# Example, for the artifact placed in:
+#          assets storage directory =    assets/
+#          artifact location        =    assets/js/my-site.min.js
+#          .Inline value            =    assets/js/my-site.min.js
+#          .Include value           =    NOT APPLICABLE
+#
+#          page storage directory   =    en/my-page-here/
+#          artifact location        =    en/my-page-here/my-page.min.js
+#          .Inline value            =    en/my-page-here/my-page.min.js
+#          .Include value           =    /en/my-page-here/my-page.min.js
+#
+#          static storage directory =    static/js/
+#          artifact location        =    static/js/my-page.min.js
+#          .Inline value            =    NOT APPLICABLE
+#          .Include value           =    /js/my-page.min.js
+#
+# The data structure pattern is as follows:
+#                  [[JS.Inline]]
+#                  Path = '{{ .Inline }}'
+#
+#                         OR
+#
+#                  [[JS.Include]]
+#                  URL = '{{ .Include }}'
+#                  Timing = '...'
+#
+# To add more entries into either list, simply append new data structure below.
+# The position of the entries dictates the rendering sequence of its statement.
+#
+# For the .Include List, the .Timing value can be any of the following:
+#     1. 'defer' - download the asset first and execute after DOM (default).
+#     2. 'async' - download the asset in parallel to DOM and execute immediately
+#                  regardless of DOM completion status.
+#     3. 'sync'  - block DOM and synchonously download and execute the asset.
+# When in doubt, stick to 'defer' as you would not want to block the page from
+# DOM rendering completion at all time.
+#
+# NOTE:
+# The '__content.hestiaJS', the page-specific JS control file will
+# automatically be appended into .JS.Inline as the last item (deemed the most
+# powerful among all when operating in .Include leading .Inline mode). You DO
+# NOT need to manually add it in.
+[[JS.Inline]]
+Path = ''
+
+
+[[JS.Include]]
+URL = ''
+Timing = 'defer'

--- a/sites/content/en/specs/__components.toml
+++ b/sites/content/en/specs/__components.toml
@@ -1,0 +1,98 @@
+# HESTIA PAGE-LEVEL WEB UI COMPONENTS LIST
+# ========================================
+# All Hestia internal web UI components for this page.
+#
+# The components' low-level codes are auto-generated from hestiaGO code
+# libraries for rendering consistency between non-WASM users and WASM users.
+#
+# If you're using WASM from Hestia code libraries and they are directly
+# controlling the page UI (either as single-page rendering or reactive
+# rendering), you **SHOULD NOT** include anything below as they're duplicates
+# and can cause confusing complications. Please stick to ONE(1) rendering
+# method.
+#
+# You SHOULD ONLY include components that are used in this page. To configure:
+#     [[List]]
+#     Name = "COMPONENT"
+#     Include = true
+#     Variables = [
+#            { "--variable-1" = "1rem" },
+#            { "--variable-2" = "2rem" },
+#     ]
+#
+#     List.{POSITION}.Name      = name of the component (string)
+#     List.{POSITION}.Include   = inclusion decision (bool true/false)
+#     List.{POSITION}.Variables = list of overriding variables to the component.
+#
+# NOTE:
+#     1) The position of the component listing influences the variables
+#        overriding sequence. Please construct your list properly.
+#     2) Check out Hestia's hestiaGUI catalog list for supported UI components
+#        at:
+#                 https://hestia.zoralab.com/en/specs/hestiaGUI/
+#
+#
+# EXAMPLE:
+#        [[List]]
+#        Name = "zoralabCORE"
+#        Include = true
+#        Variables = [
+#                  { "--test-variable-1" = "1rem" },
+#                  { "--test-variable-2" = "2rem" },
+#        ]
+#
+#        [[List]]
+#        Name = "zoralabFONT_NOTOSANS"
+#        Include = true
+#        Variables = []
+#
+#        ...
+[[List]]
+Name = "zoralabCORE"
+Include = true
+Variables = [
+	{ "--body-scroll-behavior" = "smooth" },
+]
+
+[[List]]
+Name = "zoralabFONT_NOTOSANS"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabDRAWER"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabDRAWER_LEFT"
+Include = true
+Variables = [
+	{ "--left-drawer-width-opened" = "80vw" },
+	{ "--left-drawer-trigger-position-top" = "0" },
+]
+
+[[List]]
+Name = "zoralabANCHOR"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabBUTTON"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabTILE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabPRE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabCATALOG"
+Include = true
+Variables = []

--- a/sites/content/en/specs/__content.hestiaCSS
+++ b/sites/content/en/specs/__content.hestiaCSS
@@ -1,0 +1,15 @@
+{{- /*
+Page's CSS Prime Control
+
+This page constructs the page-specific CSS codes that will be appeneded into
+.CSS.Inline as the last entry (most powerful). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+
+
+
+
+{{- /* render your page output */ -}}

--- a/sites/content/en/specs/__content.hestiaHTML
+++ b/sites/content/en/specs/__content.hestiaHTML
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML Output Prime Control
+
+This file is your HTML output file (index.html). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms are required.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $ret := false -}}
+{{- $i18n := .Data.Page.i18n -}}
+
+
+
+
+{{- /* render outputs */ -}}
+<main>
+	<section id='{{- $i18n.Introduction.ID -}}'>
+		<h1>{{- .Titles.Page -}}</h1>
+		<p>{{- .Descriptions.Page.Pitch }} {{ .Descriptions.Page.Summary -}}</p>
+	</section>
+</main>

--- a/sites/content/en/specs/__content.hestiaJS
+++ b/sites/content/en/specs/__content.hestiaJS
@@ -1,0 +1,15 @@
+{{- /*
+Page's Javascript Prime Control
+
+This page constructs the page-specific JS codes that will be appeneded into
+.JS.Inline as last entry (most powerful). Hugo's and Go's template processors
+are available at your disposal in case of mathematical or logical algorithms
+development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+
+
+
+
+{{- /* render your Javascript output */ -}}

--- a/sites/content/en/specs/__content.hestiaJSON
+++ b/sites/content/en/specs/__content.hestiaJSON
@@ -1,0 +1,26 @@
+{{- /*
+Page's JSON Output Prime Control
+
+This file is your JSON output file (index.json). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+{{- $i18n := .Data.Page.i18n -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (dict
+	$i18n.Title .Titles.Page
+	$i18n.Description (printf "%s %s" .Descriptions.Page.Pitch .Descriptions.Page.Summary)
+) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/en/specs/__content.hestiaLDJSON
+++ b/sites/content/en/specs/__content.hestiaLDJSON
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (partial "hestiaJSON/schemaorgLDJSON/WebPage" .) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/en/specs/__contributors.toml
+++ b/sites/content/en/specs/__contributors.toml
@@ -1,0 +1,78 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...
+[[Contributors]]
+Key = 'ZORALab'
+
+[Contributors.Contribution]
+Creation = true
+Contact = true
+Artwork = false
+Knowledge = false
+Editor = true
+Developer = false
+Maintainer = false
+Producer = true
+Provider = true
+Publisher = true
+Funder = false
+Sponsor = true
+
+
+
+
+[[Contributors]]
+Key = 'HollowayKeanHo'
+
+[Contributors.Contribution]
+Creation = true
+Contact = false
+Artwork = false
+Knowledge = true
+Editor = true
+Developer = false
+Maintainer = false
+Producer = false
+Provider = false
+Publisher = false
+Funder = false
+Sponsor = false

--- a/sites/content/en/specs/__i18n.toml
+++ b/sites/content/en/specs/__i18n.toml
@@ -1,0 +1,289 @@
+[i18n]
+Title = 'Title'
+Description = 'Description'
+
+
+
+
+[i18n.Labels]
+Pattern = 'Pattern'
+Examples = 'Examples'
+
+
+
+
+[i18n.Introduction]
+ID = 'introduction'
+
+
+
+
+[i18n.DecentralizedDistribution]
+ID = 'decentralized-distribution'
+Label = 'DecentralizedDistribution'
+Title = 'Decentralized Distribution'
+Description = '''
+By design, ZORALab's Hestia carefully pick programming languages that do not
+soley depending on its specialized distribution system alone for countering
+geo-political and after-the-fact business changes nuisance threats (e.g.
+implement restrictive geo-fencing or sudden steep price hike overnight without
+any notices). At the most upstream source (us), all supported technologies MUST
+be distributable and re-distributable securely, online and offline with just a
+simple .zip archive format.
+'''
+
+
+
+
+[i18n.StreamVsMemory]
+ID = 'stream-vs-memory'
+Label = 'StreamVsMemory'
+Title = 'Stream Vs. Memory'
+Description = '''
+For ZORALab's Hestia, there are 2 orientations when it comes to designing
+algorithm: (1) stream-oriented [S] focuses on extremely low memory footprint
+but takes more time for processing; (2) memory-oriented [M] focuses on maximum
+memory usage for faster speed. The default everyone practice is usually
+memory-oriented where most people would care less about how much the memory is
+used in a 64-bit operating system. Microcontrollers and embedded folks however,
+tend to prefer stream-oriented due to the memory size limitations. Hence, all
+functions and methods **MUST** cater both stream-oriented and memory-oriented
+executions, whichever comes first.
+'''
+
+
+
+
+[i18n.MonomorphizeByCPUSize]
+ID = 'monomorphize-by-cpu-size'
+Label = 'MonomorphizeByCPUSize'
+Title = 'Monomorphize By CPU Size'
+Description = '''
+One problem ZORALab's Hestia set to solve is to facilitate all functions and
+methods by CPU Size (8-Bits, 16-bits, 24-bits, 32-bits, 64-bits, ...2048-bits).
+Most standard libraries are heavily geared towards 64-bits CPU, making it very
+difficult to port into other CPU types like 8-bits and 16-bits. Therefore, to
+combat scarcity, ZORALab's Hestia manually monomorphize all processing functions
+and methods giving the end users a choice rather than no-choice.
+'''
+
+
+
+
+[i18n.ImportDirection]
+ID = 'import-direction'
+Label = 'ImportDirection'
+Title = 'Import Direction'
+Description = '''
+For ZORALab's Hestia, ALWAYS LET USER TO ONLY IMPORT LEAF PACKAGES WHENEVER
+AVAILABLE. Build the leaf package to the point of self-sufficient manner. As for
+the parent packages, **they are there to facilitate common utilities among the
+children packages**. Below is the import pattern:
+'''
+Pattern = '''
+[Leaf]
+->
+[SuperCommon]/[Leaf]
+------------->
+[SuperCommon]/[Common]/[Leaf]
+---------------------->
+'''
+Example = '''
+From the pattern above, we can showcase some examples for comprehensions:
+'''
+Samples = '''
+hestiaSTRING
+   ⮱ hestiaSTRING.M64_Sanitize
+hestiaNET/hestiaHTTP
+   ⮱ hestiaHTTP.Server
+   ⮱ hestiaHTTP.Client
+hestiaNET/hestiaHTTP/hestiaPWA
+   ⮱ hestiaPWA.ToAppJS
+   ⮱ hestiaPWA.ToAppManifest
+'''
+
+
+
+
+[i18n.NamingConvention]
+ID = 'naming-convention'
+Label = 'NamingConvention'
+Title = 'Naming Convention'
+Description = '''
+To comply with the import direction above and to avoid conflicting with the
+standard libraries for facilitating a good experience of inter-operability,
+ZORALab's Hestia employs its own naming convention across all supported
+technologies. We are still using Go's Titlecase as export indicator
+while Nim will just append its required astrisk at the end. ZORALab's Hestia
+naming convention follow this pattern:
+'''
+Pattern = '''
+「·PATTERN·」
+PACKAGE   = (x_)[origin][OUTPUT](_[VARIANT](_[SKU]))
+CONSTANT  = (X/x_)(priv_)[PURPOSE]_[NAME](_[VARIANT](_[SKU]))
+FUNCTION  = (X/x_)[[S/s]/[M/m]][CPU_BITS/N]_[Verb](_[VARIANT](_[SKU]))
+METHOD    = (X/x_)[[S/s]/[M/m]][CPU_BITS/N]_[Verb](_[VARIANT](_[SKU]))
+
+
+「·LEGENDS·」
+()     = Optional
+[]     = Compulsory Variable Values
+/      = OR
+lower  = lowercase
+UPPER  = UPPERCASE
+X_, x_ = experimental
+'''
+Example = '''
+From the pattern above, we can showcase some examples for comprehensions:
+'''
+Samples = '''
+「·PACKAGE·」
+hestiaSTRING                   (hugo, go, nim)
+x_hestiaSTRING                 (hugo, go, nim)
+hestiaGUI/zoralabCORE          (hugo, go, nim)
+hestiaGUI/x_zoralabCORE        (hugo, go, nim)
+x_hestiaGUI/x_zoralabCORE      (hugo, go, nim)
+
+
+「·CONSTANT·」
+hestiaNET.TLS_1_3              (go-pub, nim-pub*)
+hestiaNET.X_TLS_1_3            (go-pub, nim-pub*)
+hestiaSYS.SYSTEM_NAME          (go-pub, nim-pub*)
+hestiaNET.priv_TLS_1_3         (go-priv, nim-priv)
+hestiaNET.priv_TLS_1_3         (go-priv, nim-priv)
+hestiaSYS.priv_SYSTEM_NAME     (go-priv, nim-priv)
+
+
+「·FUNCTION·」
+hestiaSTRING/Sanitize          (hugo-pub)
+hestiaSTRING.M64_Sanitize      (go-pub, nim-pub*)
+hestiaSTRING.S8_Sanitize       (go-pub, nim-pub*)
+hestiaSTRING.m64_Sanitize_V2   (go-priv, nim-priv)
+hestiaSTRING.s8_Sanitize_V2    (go-priv, nim-priv)
+hestiaSTRING.X_S8_Sanitize_V3  (go-pub, nim-pub*)
+hestiaSTRING.x_S8_Sanitize_V3  (go-priv, nim-priv)
+hestiaTESTING.SN_Format        (go-pub, nim-pub*)
+hestiaTESTING.MN_Format        (go-pub, nim-pub*)
+
+
+「·METHOD·」
+obj.M64_Sanitize               (go-pub, nim-pub*)
+obj.S8_Sanitize                (go-pub, nim-pub*)
+obj.m64_Sanitize_V2            (go-priv, nim-priv)
+obj.s8_Sanitize_V2             (go-priv, nim-priv)
+obj.X_S8_Sanitize_V3           (go-pub, nim-pub*)
+obj.x_S8_Sanitize_V3           (go-priv, nim-priv)
+'''
+
+
+
+
+[i18n.ErrorCodeNoPanic]
+ID = 'error-code-no-panic'
+Label = 'ErrorCodeNoPanic'
+Title = 'Error Code and No Panic'
+Description = '''
+Error string returning as practiced in Go is actually quite expensive when
+deployed in low memory footprint environment. Hence, we only use back the
+conventional  internal 'hestiaERROR' error codes (2 bytes) instead. Also,
+DO NOT PANIC. All functions and methods must be as deterministic as possible.
+The lesser the abstraction, the better.
+'''
+
+
+
+
+[i18n.UseMacroAvoidGenerics]
+ID = 'use-macro-and-avoid-generic'
+Label = 'UseMacroAvoidGenerics'
+Title = 'Use Macro and Avoid Generics'
+Description = '''
+Generics is only serving 1 specific type of meta-programming and
+monomorphization. The problem is that at each cpu size, the monomorphic
+algorithm can be very different and in most cases generics can't cater such
+capability. THEREFORE, DO NOT USE IT. If the language provides macro system,
+use that instead.
+'''
+
+
+
+
+[i18n.FunctionVsMethod]
+ID = 'function-vs-method'
+Label = 'FunctionVsMethod'
+Title = 'Function vs. Method'
+Description = '''
+Since the package is output oriented: package function by default and method
+whenever makes sense for duck-typing and associated processing
+(e.g. interfaces). The most important job is getting them documented. Among
+known common names (or verbs) are:
+'''
+Pattern = '''
+Add
+Append
+Begin
+Copy
+Delete
+Divide
+End
+Index(VARIANT)
+Insert(VARIANT)
+Join
+Length
+Minus
+Modulus
+Multiply
+Next
+Parse[OBJECT]
+Pop
+Prepend
+Previous
+Replace(VARIANT)
+Reserve
+Sanitize
+Scan
+Search
+Split(VARIANT)
+String
+To[OBJECT]
+Zero
+'''
+
+
+
+
+[i18n.WASMCapable]
+ID = 'wasm-capable'
+Label = 'WASMCapable'
+Title = 'WASM Capable'
+Description = '''
+All packages shall be usable in WASM. Do not let user to mess with Javascript
+when used including UI rendering (that's what the library for).
+'''
+
+
+
+
+[i18n.Catalog]
+ID = 'catalog'
+Label = 'Catalog'
+Title = 'Catalog'
+Description = '''
+Here's all of our libraries' specifications for you to browse through. They're
+starting from the root level.
+'''
+CTA = 'Read More'
+
+
+
+
+[i18n.Epilogue]
+ID = 'epilogue'
+Title = 'Epilogue'
+Description = '''
+We have reach the end of the specification overview for ZORALab's Hestia
+Project. If you have any query, please feel free to contact us at our following
+portal:
+'''
+URL = 'https://github.com/ZORALab/Hestia/discussions'
+CTA = 'GitHub Discussion Portal'

--- a/sites/content/en/specs/__languages.toml
+++ b/sites/content/en/specs/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = '/en/specs/'
+
+[zh-Hans]
+URL = '/zh-hans/specs/'

--- a/sites/content/en/specs/__page.toml
+++ b/sites/content/en/specs/__page.toml
@@ -1,0 +1,118 @@
+# PAGE METADATA
+# =============
+# Date fields.
+#
+# NOTE:
+#   1. You can generate date easily on linux using '$ date' command.
+#   2. If date field is left blank, the current time shall be used instead.
+#   3. Date should ONLY comply to this pattern when manually constructed:
+#                    Thu 21 Jul 2022 14:27:39 PM +08
+[Date]
+Created   = 'Thu 08 Dec 2022 05:55:06 PM +08'
+Published = 'Thu 08 Dec 2022 05:55:06 PM +08'
+
+
+
+
+# Content fields.
+# NOTE:
+#   1. For .Title, Hestia's string processing using page variables are allowed
+#      and only limited to .Titles sub-fields.
+#   2. For .Keywords, Hestia's string processing using page variables are
+#      allowed but strongly discouraged.
+[Content]
+Title = "ZORALab's Hestia Technical Specifications"
+Keywords = [
+	'Technical Specifications',
+	'Specifications',
+	'Web',
+	'Tech',
+	'PWA',
+	'WASM',
+	'Software Libraries',
+	'Hugo',
+	'Go',
+	'TinyGo',
+	'Nim',
+	'ZORALab',
+	"ZORALab's Hestia",
+]
+
+
+
+
+# Description fields.
+# NOTE:
+#   1. Hestia's string processing using page variables are allowed.
+#   2. The .Description.Pitch is at maximum 160 characters.
+#   3. The .Description.Summary is at maximum of 250 characters.
+#   4. All fields shall have their whitespace cleansed during the processing.
+[Description]
+Pitch = '''
+The technical specifications to refer when using ZORALab's Hestia.
+'''
+Summary = '''
+Detailed, offline supported (via web PWA installation), and detailed oriented.
+'''
+
+
+
+
+# Redirect fields.
+# NOTE:
+#   1. Hestia's URL processing is allowed for .URL field.
+#   2. .Delay timing sets the delay time before redirect. Setting to '0' means
+#      an immediate redirect is requested.
+#   3. Redirect is only available if .Enabled is set to 'true'.
+#   4. Redirect.Language is to redirect the current page to its
+#      language-specific page when Javascript is made available on client side
+#      or fallback to default language.
+[Redirect]
+Delay = 0 # second
+URL = ''
+Enabled = false
+
+[Redirect.Language]
+Enabled = false
+
+
+
+
+# Content Files' Sourcing Location
+# NOTE:
+#   1. To denote where are the content sources.
+#   2. If you're sourcing from assets directory, prefix 'assets/'.
+#   3. If you're sourcing from layouts directory, prefix 'layouts/'.
+#   2. If you're sourcing from static directory, prefix 'static/'.
+#   3. If you're sourcing from partial directory, prefix 'layouts/partials/'.
+[Sources]
+HTML = 'layouts/content/specs/index.html'
+JSON = 'layouts/content/specs/index.json'
+LDJSON = '__content.hestiaLDJSON'
+Contributors = '__contributors.toml'
+Thumbnails = '__thumbnails.toml'
+Languages = '__languages.toml'
+
+
+
+
+# Data fields.
+# NOTE:
+#   1. List only the page-level data files. It can be in any of the following
+#      formats: '.json', '.toml', or '.yaml'.
+#   2. Hestia string processing is available and shall be processed prior to
+#      dataset transformation.
+#   3. Sequences of the .Data array dictates sequences of loading and overriding
+#      (the latter shall overwrite the former for the same data fields).
+#   4. The final processed dataset shall be served as main data content in
+#      supported output format (e.g. index.json).
+#   5. Missing data file shall be ignored.
+#   6. To add more data files, simply duplicate and add more .Data array entry.
+#      Example:
+#                             [[data]]
+#                             Filename = 'file1.json'
+#
+#                             [[data]]
+#                             Filename = 'file2.toml'
+[[Data]]
+Filename = '__i18n.toml'

--- a/sites/content/en/specs/__robots.toml
+++ b/sites/content/en/specs/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/en/specs/__thumbnails.toml
+++ b/sites/content/en/specs/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/thumbnails-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/thumbnails-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/thumbnails-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/en/specs/__twitter.toml
+++ b/sites/content/en/specs/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/en/specs/__wasm.toml
+++ b/sites/content/en/specs/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/en/specs/_index.html
+++ b/sites/content/en/specs/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++

--- a/sites/data/Nav.toml
+++ b/sites/data/Nav.toml
@@ -94,6 +94,18 @@ Title = "Code of Conduct"
 URL = '/en/licenses/#code-of-conduct'
 
 
+[[Languages.EN]]
+Title = 'Specifications'
+
+[[Languages.EN.Items]]
+Title = "Visit"
+URL = '/en/specs'
+
+[[Languages.EN.Items]]
+Title = "Technical Properties"
+URL = '/en/specs'
+
+
 
 
 [[Languages.ZH-HANS]]
@@ -190,3 +202,15 @@ URL = '/zh-hans/licenses/#指引'
 [[Languages.ZH-HANS.Items]]
 Title = "行为准则"
 URL = '/zh-hans/licenses/#行为准则'
+
+
+[[Languages.ZH-HANS]]
+Title = '规范'
+
+[[Languages.ZH-HANS.Items]]
+Title = "询问"
+URL = '/zh-hans/specs'
+
+[[Languages.ZH-HANS.Items]]
+Title = "所有科技术性"
+URL = '/zh-hans/specs'

--- a/sites/layouts/content/specs/index.html
+++ b/sites/layouts/content/specs/index.html
@@ -1,0 +1,125 @@
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $i18n := .Data.Page.i18n -}}
+{{- $lang := false -}}
+{{- $ret := false -}}
+
+
+
+
+{{- /* render output */ -}}
+<main style='padding-bottom: 0;'>
+	<section id='{{- $i18n.Introduction.ID -}}'>
+		<h1>{{- .Titles.Page -}}</h1>
+		<p>{{- .Descriptions.Page.Pitch }} {{ .Descriptions.Page.Summary -}}</p>
+	</section>
+
+
+	<section id='{{- $i18n.DecentralizedDistribution.ID -}}'>
+		<h2>{{- $i18n.DecentralizedDistribution.Title -}}</h2>
+		<p>{{- $i18n.DecentralizedDistribution.Description -}}</p>
+	</section>
+
+
+	<section id='{{- $i18n.StreamVsMemory.ID -}}'>
+		<h2>{{- $i18n.StreamVsMemory.Title -}}</h2>
+		<p>{{- $i18n.StreamVsMemory.Description -}}</p>
+	</section>
+
+
+	<section id='{{- $i18n.MonomorphizeByCPUSize.ID -}}'>
+		<h2>{{- $i18n.MonomorphizeByCPUSize.Title -}}</h2>
+		<p>{{- $i18n.MonomorphizeByCPUSize.Description -}}</p>
+	</section>
+
+
+	<section id='{{- $i18n.ImportDirection.ID -}}'>
+		<h2>{{- $i18n.ImportDirection.Title -}}</h2>
+		<p>{{- $i18n.ImportDirection.Description -}}</p>
+		<pre>{{- $i18n.ImportDirection.Pattern -}}</pre>
+		<p>{{- $i18n.ImportDirection.Example -}}</p>
+		<pre>{{- $i18n.ImportDirection.Samples -}}</pre>
+	</section>
+
+
+	<section id='{{- $i18n.NamingConvention.ID -}}'>
+		<h2>{{- $i18n.NamingConvention.Title -}}</h2>
+		<p>{{- $i18n.NamingConvention.Description -}}</p>
+		<pre>{{- $i18n.NamingConvention.Pattern -}}</pre>
+		<p>{{- $i18n.NamingConvention.Example -}}</p>
+		<pre>{{- $i18n.NamingConvention.Samples -}}</pre>
+	</section>
+
+
+	<section id='{{- $i18n.ErrorCodeNoPanic.ID -}}'>
+		<h2>{{- $i18n.ErrorCodeNoPanic.Title -}}</h2>
+		<p>{{- $i18n.ErrorCodeNoPanic.Description -}}</p>
+	</section>
+
+
+	<section id='{{- $i18n.UseMacroAvoidGenerics.ID -}}'>
+		<h2>{{- $i18n.UseMacroAvoidGenerics.Title -}}</h2>
+		<p>{{- $i18n.UseMacroAvoidGenerics.Description -}}</p>
+	</section>
+
+
+	<section id='{{- $i18n.FunctionVsMethod.ID -}}'>
+		<h2>{{- $i18n.FunctionVsMethod.Title -}}</h2>
+		<p>{{- $i18n.FunctionVsMethod.Description -}}</p>
+		<pre>{{- $i18n.FunctionVsMethod.Pattern -}}</pre>
+	</section>
+
+
+	<section id='{{- $i18n.WASMCapable.ID -}}'>
+		<h2>{{- $i18n.WASMCapable.Title -}}</h2>
+		<p>{{- $i18n.WASMCapable.Description -}}</p>
+	</section>
+
+
+	<section id='{{- $i18n.Catalog.ID -}}'>
+		<h2>{{- $i18n.Catalog.Title -}}</h2>
+		<p>{{- $i18n.Catalog.Description -}}</p>
+		<div class='row'>{{- range $i, $v := .Nav.Children }}
+			<div class='column'><div class='card'>
+				<div class='content'>
+					<h3>{{- $v.Titles.Page -}}</h3>
+					<p>{{- $v.Descriptions.Pitch -}}</p>
+				</div>
+				<div class='actions'>
+					<a href='{{- $v.URL.Current.Absolute -}}'
+						class='button'>
+						{{- $i18n.Catalog.CTA -}}
+					</a>
+				</div>
+			</div></div>
+		{{- end }}</div>
+	</section>
+
+
+	{{- $ret = merge $Page (dict "Input" (dict "Data"
+		"/img/backgrounds/matrix-cube-lorenzo-verzini.svg"
+	)) -}}
+	{{- $ret = partial "hestiaURL/Sanitize" $ret -}}
+	{{- $ret = string $ret.Output -}}
+	<section id='{{- $i18n.Epilogue.ID -}}' class='inverted' style='
+		margin-top: 10rem;
+		background: url({{- $ret -}}),linear-gradient(to top,#010329,#000005)
+				no-repeat
+				fixed;
+		background-position: center center;
+		background-size: cover;
+		padding-bottom: var(--main-padding-top);
+	'>
+		<h2>{{- $i18n.Epilogue.Title -}}</h2>
+		<p>{{- $i18n.Epilogue.Description -}}</p>
+		<br/>
+		{{- $ret = merge $Page (dict "Input" (dict "Data" $i18n.Epilogue.URL)) -}}
+		{{- $ret = partial "hestiaURL/Sanitize" $ret -}}
+		{{- $ret = string $ret.Output -}}
+		<a href='{{- $ret -}}' class='button' style='
+			--button-color: green;
+		'>{{- $i18n.Epilogue.CTA -}}</a>
+	</section>
+</main>
+{{ partial "common/footer.html" $Page }}
+{{ partial "common/nav-prime.html" $Page }}

--- a/sites/layouts/content/specs/index.json
+++ b/sites/layouts/content/specs/index.json
@@ -1,0 +1,47 @@
+{{- /*
+Page's JSON Output Prime Control
+
+This file is your JSON output file (index.html). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+{{- $i18n := .Data.Page.i18n -}}
+{{- $lang := dict -}}
+{{- $list := slice -}}
+{{- $ret := false -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (dict
+	$i18n.Title .Titles.Page
+	$i18n.Description (printf "%s %s" .Descriptions.Page.Pitch .Descriptions.Page.Summary)
+	$i18n.DecentralizedDistribution.Label $i18n.DecentralizedDistribution.Description
+	$i18n.StreamVsMemory.Label $i18n.StreamVsMemory.Description
+	$i18n.MonomorphizeByCPUSize.Label $i18n.MonomorphizeByCPUSize.Description
+	$i18n.ImportDirection.Label (dict
+		$i18n.Labels.Pattern $i18n.ImportDirection.Pattern
+		$i18n.Labels.Examples $i18n.ImportDirection.Examples
+	)
+	$i18n.NamingConvention.Label (dict
+		$i18n.Labels.Pattern $i18n.NamingConvention.Pattern
+		$i18n.Labels.Examples $i18n.NamingConvention.Samples
+	)
+	$i18n.ErrorCodeNoPanic.Label $i18n.ErrorCodeNoPanic.Description
+	$i18n.UseMacroAvoidGenerics.Label $i18n.UseMacroAvoidGenerics.Description
+	$i18n.FunctionVsMethod.Label (dict
+		$i18n.Description $i18n.FunctionVsMethod.Description
+		$i18n.Labels.Pattern $i18n.FunctionVsMethod.Pattern
+	)
+	$i18n.WASMCapable.Label $i18n.WASMCapable.Description
+) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}


### PR DESCRIPTION
Since the /en/ page is ready, we can proceed to port /en/specs/ page from the old system. Hence, let's do this.

This patch ports /en/specs/ page from the old system into sites/ directory.