### PR TITLE
sites: translated /zh-hans/specs/ page

### DIFF
--- a/sites/content/en/specs/__i18n.toml
+++ b/sites/content/en/specs/__i18n.toml
@@ -243,10 +243,16 @@ Reserve
 Sanitize
 Scan
 Search
+Sort(VARIANT)
 Split(VARIANT)
 String
 To[OBJECT]
 Zero
+
+
+「·LEGENDS·」
+()     = Optional
+[]     = Compulsory Variable Values
 '''
 
 

--- a/sites/content/zh-hans/specs/__assets.toml
+++ b/sites/content/zh-hans/specs/__assets.toml
@@ -1,0 +1,122 @@
+# PAGE SPECIFIC ASSETS
+# ====================
+# You can include or inline CSS assets into this specific page only by listing
+# out their .URL or relative file .PATH sources respectively.
+#
+# All .CSS.Inline artifacts shall only be provided with Hugo's virtual pathing
+# only.
+#
+# As For .CSS.Include artifacts, Hestia's URL processing is available for
+# dynamic relative pathing constructions. As long as the URL is accessible,
+# storing location is not restricted to any single location.
+#
+# Example, for the artifact placed in:
+#          assets storage directory =    assets/
+#          artifact location        =    assets/css/my-site.min.css
+#          .Inline value            =    assets/css/my-site.min.css
+#          .Include value           =    NOT APPLICABLE
+#
+#          page storage directory   =    en/my-page-here/
+#          artifact location        =    en/my-page-here/my-page.min.css
+#          .Inline value            =    en/my-page-here/my-page.min.css
+#          .Include value           =    /en/my-page-here/my-page.min.css
+#
+#          static storage directory =    static/css/
+#          artifact location        =    static/css/my-page.min.css
+#          .Inline value            =    NOT APPLICABLE
+#          .Include value           =    /css/my-page.min.css
+#
+# The data structure pattern is as follows:
+#                  [[CSS.Inline]]
+#                  Path = '{{ .Inline }}'
+#
+#                         OR
+#
+#                  [[CSS.Include]]
+#                  URL = '{{ .Include }}'
+#                  Media = '{{ .Include.Media }}'
+#                  OnLoad = '{{ .Include.OnLoad }}'
+#
+# To add more entries into either list, simply append new data structure below.
+# The position of the entries dictates the rendering sequence of its statement.
+#
+# For .Include list, should .Media or .Onload is used for asynchonous loading,
+# there is no guarentee for the actual CSS loading sequences (see:
+# https://web.dev/critical-rendering-path-render-blocking-css/). When in doubt,
+# leaving them blank.
+#
+# NOTE:
+# The '__content.hestiaCSS', the page-specific CSS control file will be
+# automatically appended into .CSS.Inline as the last item (demmed the most
+# powerful among all when operating in .Include leading the .Inline mode). You
+# DO NOT need to manually add it in.
+[[CSS.Inline]]
+Path = ''
+
+
+[[CSS.Include]]
+URL = ''
+Media = ''
+OnLoad = ''
+
+
+
+
+# You can include or inline JS assets into this specific page only by listing
+# out their .URL or relative file .PATH sources respectively.
+#
+# All .JS.Inline artifacts shall only be provided with Hugo's virtual pathing.
+#
+# As for .JS.Include artifacts, Hestia's URL processing is available for
+# dynamic relative pathing constructions. As long as the URL is accessible,
+# storing location is not restricted to any single location.
+#
+# Example, for the artifact placed in:
+#          assets storage directory =    assets/
+#          artifact location        =    assets/js/my-site.min.js
+#          .Inline value            =    assets/js/my-site.min.js
+#          .Include value           =    NOT APPLICABLE
+#
+#          page storage directory   =    en/my-page-here/
+#          artifact location        =    en/my-page-here/my-page.min.js
+#          .Inline value            =    en/my-page-here/my-page.min.js
+#          .Include value           =    /en/my-page-here/my-page.min.js
+#
+#          static storage directory =    static/js/
+#          artifact location        =    static/js/my-page.min.js
+#          .Inline value            =    NOT APPLICABLE
+#          .Include value           =    /js/my-page.min.js
+#
+# The data structure pattern is as follows:
+#                  [[JS.Inline]]
+#                  Path = '{{ .Inline }}'
+#
+#                         OR
+#
+#                  [[JS.Include]]
+#                  URL = '{{ .Include }}'
+#                  Timing = '...'
+#
+# To add more entries into either list, simply append new data structure below.
+# The position of the entries dictates the rendering sequence of its statement.
+#
+# For the .Include List, the .Timing value can be any of the following:
+#     1. 'defer' - download the asset first and execute after DOM (default).
+#     2. 'async' - download the asset in parallel to DOM and execute immediately
+#                  regardless of DOM completion status.
+#     3. 'sync'  - block DOM and synchonously download and execute the asset.
+# When in doubt, stick to 'defer' as you would not want to block the page from
+# DOM rendering completion at all time.
+#
+# NOTE:
+# The '__content.hestiaJS', the page-specific JS control file will
+# automatically be appended into .JS.Inline as the last item (deemed the most
+# powerful among all when operating in .Include leading .Inline mode). You DO
+# NOT need to manually add it in.
+[[JS.Inline]]
+Path = ''
+
+
+[[JS.Include]]
+URL = ''
+Timing = 'defer'

--- a/sites/content/zh-hans/specs/__components.toml
+++ b/sites/content/zh-hans/specs/__components.toml
@@ -1,0 +1,98 @@
+# HESTIA PAGE-LEVEL WEB UI COMPONENTS LIST
+# ========================================
+# All Hestia internal web UI components for this page.
+#
+# The components' low-level codes are auto-generated from hestiaGO code
+# libraries for rendering consistency between non-WASM users and WASM users.
+#
+# If you're using WASM from Hestia code libraries and they are directly
+# controlling the page UI (either as single-page rendering or reactive
+# rendering), you **SHOULD NOT** include anything below as they're duplicates
+# and can cause confusing complications. Please stick to ONE(1) rendering
+# method.
+#
+# You SHOULD ONLY include components that are used in this page. To configure:
+#     [[List]]
+#     Name = "COMPONENT"
+#     Include = true
+#     Variables = [
+#            { "--variable-1" = "1rem" },
+#            { "--variable-2" = "2rem" },
+#     ]
+#
+#     List.{POSITION}.Name      = name of the component (string)
+#     List.{POSITION}.Include   = inclusion decision (bool true/false)
+#     List.{POSITION}.Variables = list of overriding variables to the component.
+#
+# NOTE:
+#     1) The position of the component listing influences the variables
+#        overriding sequence. Please construct your list properly.
+#     2) Check out Hestia's hestiaGUI catalog list for supported UI components
+#        at:
+#                 https://hestia.zoralab.com/en/specs/hestiaGUI/
+#
+#
+# EXAMPLE:
+#        [[List]]
+#        Name = "zoralabCORE"
+#        Include = true
+#        Variables = [
+#                  { "--test-variable-1" = "1rem" },
+#                  { "--test-variable-2" = "2rem" },
+#        ]
+#
+#        [[List]]
+#        Name = "zoralabFONT_NOTOSANS"
+#        Include = true
+#        Variables = []
+#
+#        ...
+[[List]]
+Name = "zoralabCORE"
+Include = true
+Variables = [
+	{ "--body-scroll-behavior" = "smooth" },
+]
+
+[[List]]
+Name = "zoralabFONT_NOTOSANS"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabDRAWER"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabDRAWER_LEFT"
+Include = true
+Variables = [
+	{ "--left-drawer-width-opened" = "80vw" },
+	{ "--left-drawer-trigger-position-top" = "0" },
+]
+
+[[List]]
+Name = "zoralabANCHOR"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabBUTTON"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabTILE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabPRE"
+Include = true
+Variables = []
+
+[[List]]
+Name = "zoralabCATALOG"
+Include = true
+Variables = []

--- a/sites/content/zh-hans/specs/__content.hestiaCSS
+++ b/sites/content/zh-hans/specs/__content.hestiaCSS
@@ -1,0 +1,15 @@
+{{- /*
+Page's CSS Prime Control
+
+This page constructs the page-specific CSS codes that will be appeneded into
+.CSS.Inline as the last entry (most powerful). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+
+
+
+
+{{- /* render your page output */ -}}

--- a/sites/content/zh-hans/specs/__content.hestiaHTML
+++ b/sites/content/zh-hans/specs/__content.hestiaHTML
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML Output Prime Control
+
+This file is your HTML output file (index.html). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms are required.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $ret := false -}}
+{{- $i18n := .Data.Page.i18n -}}
+
+
+
+
+{{- /* render outputs */ -}}
+<main>
+	<section id='{{- $i18n.Introduction.ID -}}'>
+		<h1>{{- .Titles.Page -}}</h1>
+		<p>{{- .Descriptions.Page.Pitch }} {{ .Descriptions.Page.Summary -}}</p>
+	</section>
+</main>

--- a/sites/content/zh-hans/specs/__content.hestiaJS
+++ b/sites/content/zh-hans/specs/__content.hestiaJS
@@ -1,0 +1,15 @@
+{{- /*
+Page's Javascript Prime Control
+
+This page constructs the page-specific JS codes that will be appeneded into
+.JS.Inline as last entry (most powerful). Hugo's and Go's template processors
+are available at your disposal in case of mathematical or logical algorithms
+development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+
+
+
+
+{{- /* render your Javascript output */ -}}

--- a/sites/content/zh-hans/specs/__content.hestiaJSON
+++ b/sites/content/zh-hans/specs/__content.hestiaJSON
@@ -1,0 +1,26 @@
+{{- /*
+Page's JSON Output Prime Control
+
+This file is your JSON output file (index.json). Hugo's and Go's template
+processors are available at your disposal in case of mathematical or logical
+algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+{{- $i18n := .Data.Page.i18n -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (dict
+	$i18n.Title .Titles.Page
+	$i18n.Description (printf "%s %s" .Descriptions.Page.Pitch .Descriptions.Page.Summary)
+) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/zh-hans/specs/__content.hestiaLDJSON
+++ b/sites/content/zh-hans/specs/__content.hestiaLDJSON
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (partial "hestiaJSON/schemaorgLDJSON/WebPage" .) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/zh-hans/specs/__contributors.toml
+++ b/sites/content/zh-hans/specs/__contributors.toml
@@ -1,0 +1,78 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...
+[[Contributors]]
+Key = 'ZORALab'
+
+[Contributors.Contribution]
+Creation = true
+Contact = true
+Artwork = false
+Knowledge = false
+Editor = true
+Developer = false
+Maintainer = false
+Producer = true
+Provider = true
+Publisher = true
+Funder = false
+Sponsor = true
+
+
+
+
+[[Contributors]]
+Key = 'HollowayKeanHo'
+
+[Contributors.Contribution]
+Creation = true
+Contact = false
+Artwork = false
+Knowledge = true
+Editor = true
+Developer = false
+Maintainer = false
+Producer = false
+Provider = false
+Publisher = false
+Funder = false
+Sponsor = false

--- a/sites/content/zh-hans/specs/__i18n.toml
+++ b/sites/content/zh-hans/specs/__i18n.toml
@@ -1,0 +1,277 @@
+[i18n]
+Title = '标题'
+Description = '大纲'
+
+
+
+
+[i18n.Labels]
+Pattern = '模式'
+Examples = '例子'
+
+
+
+
+[i18n.Introduction]
+ID = '自介'
+
+
+
+
+[i18n.DecentralizedDistribution]
+ID = '无中心化分发'
+Label = '无中心化分发'
+Title = '无中心化分发'
+Description = '''
+根据ZORALab赫斯提亚设计，我们是为了防止地缘政治和事后的肮脏诡计带来的无畏无聊的
+麻烦而很小心地选出我们支持的代码语言。在选择中，我们是检验它们不单一靠自己的中心
+化型方式分发软件包。在最高的开源（我们），所以支持的科技都可以不管上线或离线地
+通过一个简单的.zip格式无中心化分发。
+'''
+
+
+
+
+[i18n.StreamVsMemory]
+ID = '流动-vs-记忆'
+Label = '流动式vs记忆式'
+Title = '流动式vs记忆式'
+Description = '''
+在ZORALab赫斯提亚设计算法，基本上有2种方式：（1）流动式[S]专注于运用非常少的记忆
+空间但可以用长一点的时间来完成任务。（2）记忆式[M]专注于运用多记忆空间来快速地把
+任务完成。通常大多数的开发者是建设记忆式的计算法（设计时是没有顾虑到运用多少记忆
+空间）。在微型控制器和嵌入式的世界里，由于记忆空间通常是实在太小了，多数人都会使
+用流动式。如此，ZORALab赫斯提亚所写的功能和运作方法··一定··要双双供应记忆式和流
+动式的方式以先到者为准。
+'''
+
+
+
+
+[i18n.MonomorphizeByCPUSize]
+ID = '通过中央处理器的位大小单态化'
+Label = '通过中央处理器的位大小单态化'
+Title = '通过中央处理器的位大小单态化'
+Description = '''
+有一个问题ZORALab赫斯提亚一定要解决的是能供应各种不同的中央处理器的位大小（如：
+8-Bits、16-Bits、24-Bits、32-Bits、64-Bits、...2048-Bits）功能。多数的代码库是为
+64-Bits的中央处理器而写出。这把功能移植工作给其他位大小中央处理器非常困难和复杂。
+为了对抗这稀缺性的问题，ZORALab赫斯提亚会手动地通过中央处理器的位大小把所有供应
+的功能单态化好让顾客有个选择总好过没有选择。
+'''
+
+
+
+
+[i18n.ImportDirection]
+ID = '导入方向'
+Label = '导入方向'
+Title = '导入方向'
+Description = '''
+在ZORALab赫斯提亚里，××永远让顾客导入最后端的代码包（统称‘叶子包’）××。开发者永
+远都要把叶子包给写得自给自足方式。至于前一层的代码包（统称‘树枝包’或‘父母包’），
+××它们的责任是为他们所有的叶子包供应共同数据和功能××。以下是导入方向的模式：
+'''
+Pattern = '''
+[叶子]
+->
+[超级共同]/[叶子]
+-------->
+[超级共同]/[共同]/[叶子]
+-------------->
+'''
+Example = '''
+根据以上的模式，以下是我们可以为了深入明白而写出的例子：
+'''
+Samples = '''
+hestiaSTRING
+   ⮱ hestiaSTRING.M64_Sanitize
+hestiaNET/hestiaHTTP
+   ⮱ hestiaHTTP.Server
+   ⮱ hestiaHTTP.Client
+hestiaNET/hestiaHTTP/hestiaPWA
+   ⮱ hestiaPWA.ToAppJS
+   ⮱ hestiaPWA.ToAppManifest
+'''
+
+
+
+
+[i18n.NamingConvention]
+ID = '命名模范'
+Label = '命名模范'
+Title = '命名模范'
+Description = '''
+为了促进以上的规则和为了供应良好的互操作性体验和避免与标准库冲突，
+ZORALab赫斯提亚为它所有支持的科技而雇用自己的命名模范。我们还是运用Go的标题案例
+为出口指示器和Nim在它的语言需要的尾段的星号。ZORALab赫斯提亚的命名模式如下：
+'''
+Pattern = '''
+「·模范·」
+软件包   = (x_)[origin][OUTPUT](_[VARIANT](_[SKU]))
+固定值   = (X/x_)(priv_)[PURPOSE]_[NAME](_[VARIANT](_[SKU]))
+功能     = (X/x_)[[S/s]/[M/m]][CPU_BITS/N]_[Verb](_[VARIANT](_[SKU]))
+格式     = (X/x_)[[S/s]/[M/m]][CPU_BITS/N]_[Verb](_[VARIANT](_[SKU]))
+
+
+「·图例指示器·」
+()     = 随和
+[]     = 必修的变化值
+/      = 或者
+lower  = 小型字母
+UPPER  = 大型字母
+X_, x_ = 实验类
+'''
+Example = '''
+根据以上的模式，以下是我们可以为了深入明白而写出的例子：
+'''
+Samples = '''
+「·软件包·」
+hestiaSTRING                   (hugo, go, nim)
+x_hestiaSTRING                 (hugo, go, nim)
+hestiaGUI/zoralabCORE          (hugo, go, nim)
+hestiaGUI/x_zoralabCORE        (hugo, go, nim)
+x_hestiaGUI/x_zoralabCORE      (hugo, go, nim)
+
+
+「·固定值·」
+hestiaNET.TLS_1_3              (go-pub, nim-pub*)
+hestiaNET.X_TLS_1_3            (go-pub, nim-pub*)
+hestiaSYS.SYSTEM_NAME          (go-pub, nim-pub*)
+hestiaNET.priv_TLS_1_3         (go-priv, nim-priv)
+hestiaNET.priv_TLS_1_3         (go-priv, nim-priv)
+hestiaSYS.priv_SYSTEM_NAME     (go-priv, nim-priv)
+
+
+「·功能·」
+hestiaSTRING/Sanitize          (hugo-pub)
+hestiaSTRING.M64_Sanitize      (go-pub, nim-pub*)
+hestiaSTRING.S8_Sanitize       (go-pub, nim-pub*)
+hestiaSTRING.m64_Sanitize_V2   (go-priv, nim-priv)
+hestiaSTRING.s8_Sanitize_V2    (go-priv, nim-priv)
+hestiaSTRING.X_S8_Sanitize_V3  (go-pub, nim-pub*)
+hestiaSTRING.x_S8_Sanitize_V3  (go-priv, nim-priv)
+hestiaTESTING.SN_Format        (go-pub, nim-pub*)
+hestiaTESTING.MN_Format        (go-pub, nim-pub*)
+
+
+「·格式·」
+obj.M64_Sanitize               (go-pub, nim-pub*)
+obj.S8_Sanitize                (go-pub, nim-pub*)
+obj.m64_Sanitize_V2            (go-priv, nim-priv)
+obj.s8_Sanitize_V2             (go-priv, nim-priv)
+obj.X_S8_Sanitize_V3           (go-pub, nim-pub*)
+obj.x_S8_Sanitize_V3           (go-priv, nim-priv)
+'''
+
+
+
+
+[i18n.ErrorCodeNoPanic]
+ID = '错误代码和不可恐慌'
+Label = '错误代码和不可恐慌'
+Title = '错误代码和不可恐慌'
+Description = '''
+通过窜字符串来表达错误在记忆空间稀少的环境里是蛮昂贵的。如此以来，我们就只能运用
+传统的错误（hestiaERROR代码包-2个字节位）代码来表啦。还有：千万不可恐慌。所有的
+功能和格式都必须越有确定性越好。基本上，越少抽象化越好。
+'''
+
+
+
+
+[i18n.UseMacroAvoidGenerics]
+ID = '使用Macro和避免使用Generics'
+Label = '使用Macro和避免使用Generics'
+Title = '使用Macro和避免使用Generics'
+Description = '''
+Generics只能在1中元编程的用法条件下可使用。头痛的问题是在不同的中央处理器的位大小
+单位算法里，各有不同的运行方式。Generics是不可能做到的。这种情况下，唯有Macro才能
+有这个能力。所以呢，如果支持的语言有Macro功能，那就运用吧。千万不可使用Generics。
+'''
+
+
+
+
+[i18n.FunctionVsMethod]
+ID = '功能-vs-格式'
+Label = '功能vs格式'
+Title = '功能vs格式'
+Description = '''
+既然代码包是用输出出产类型而被立名，那我们是先以功能方式为先，格式为有需要鸭子打
+字需求和相关处理需求而定。重点是要不管任何方式要把它们全部给好好记录啦。所有目前
+运用的动词如下:
+'''
+Pattern = '''
+Add
+Append
+Begin
+Copy
+Delete
+Divide
+End
+Index(类型)
+Insert(类型)
+Join
+Length
+Minus
+Modulus
+Multiply
+Next
+Parse[对象]
+Pop
+Prepend
+Previous
+Replace(类型)
+Reserve
+Sanitize
+Scan
+Search
+Sort(类型)
+Split(类型)
+String
+To[对象]
+Zero
+
+
+「·图例指示器·」
+()     = 随和
+[]     = 必修的变化值
+'''
+
+
+
+
+[i18n.WASMCapable]
+ID = 'wasm能力'
+Label = 'WASM能力'
+Title = 'WASM能力'
+Description = '''
+所有的代码包必须支持WASM和无条件之下可以运用。我们绝对不可让顾客在用JavaScript去
+做任何事包括界面渲染工作（这就是代码包的首先责任啊）。
+'''
+
+
+
+
+[i18n.Catalog]
+ID = '菜单'
+Label = '菜单'
+Title = '菜单'
+Description = '''
+以下是我们所有的代码包规范让您去询问。它们是从跟根级开始。
+'''
+CTA = '了解更多'
+
+
+
+
+[i18n.Epilogue]
+ID = '终结'
+Title = '终结'
+Description = '''
+我们已经抵达这个ZORALab赫斯提亚的规范终结段了。如有询问，您是可以通过以下管道来
+联系我们吧：
+'''
+URL = 'https://github.com/ZORALab/Hestia/discussions'
+CTA = 'GitHub讨论论坛'

--- a/sites/content/zh-hans/specs/__languages.toml
+++ b/sites/content/zh-hans/specs/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = '/en/specs/'
+
+[zh-Hans]
+URL = '/zh-hans/specs/'

--- a/sites/content/zh-hans/specs/__page.toml
+++ b/sites/content/zh-hans/specs/__page.toml
@@ -21,21 +21,21 @@ Published = 'Thu 08 Dec 2022 05:55:06 PM +08'
 #   2. For .Keywords, Hestia's string processing using page variables are
 #      allowed but strongly discouraged.
 [Content]
-Title = "ZORALab's Hestia Technical Specifications"
+Title = "ZORALab赫斯提亚科技规范"
 Keywords = [
-	'Technical Specifications',
-	'Specifications',
-	'Web',
-	'Tech',
+	'科技规范',
+	'规范',
+	'网站',
+	'科技',
 	'PWA',
 	'WASM',
-	'Software Libraries',
+	'代码库',
 	'Hugo',
 	'Go',
 	'TinyGo',
 	'Nim',
 	'ZORALab',
-	"ZORALab's Hestia",
+	'ZORALab赫斯提亚',
 ]
 
 
@@ -49,10 +49,10 @@ Keywords = [
 #   4. All fields shall have their whitespace cleansed during the processing.
 [Description]
 Pitch = '''
-The technical specifications to refer when using ZORALab's Hestia.
+那为了运用ZORALab赫斯提亚的科技规范文件。
 '''
 Summary = '''
-Easy-going, offline supported (via web PWA installation), and detailed oriented.
+随和、支持离线（通过PWA安装）和非常注重细节的。
 '''
 
 

--- a/sites/content/zh-hans/specs/__robots.toml
+++ b/sites/content/zh-hans/specs/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/zh-hans/specs/__thumbnails.toml
+++ b/sites/content/zh-hans/specs/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/thumbnails-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/thumbnails-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/thumbnails-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/zh-hans/specs/__twitter.toml
+++ b/sites/content/zh-hans/specs/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/zh-hans/specs/__wasm.toml
+++ b/sites/content/zh-hans/specs/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/zh-hans/specs/_index.html
+++ b/sites/content/zh-hans/specs/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++


### PR DESCRIPTION
Since the /en/specs/ page is ready, we can proceed to translate /zh-hans/specs/ page. Hence, let's do this.

This patch translates /zh-hans/specs/ page in sites/ directory.