### PR TITLE
hestiaHUGO: added IO guarding for hestiaIO/hestiaFS/IsFileExists API

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaIO/hestiaFS/IsFileExists
+++ b/hestiaHUGO/layouts/partials/hestiaIO/hestiaFS/IsFileExists
@@ -21,4 +21,8 @@ specific language governing permissions and limitations under the License.
 
 
 {{- /* render output */ -}}
-{{- return fileExists . -}}
+{{- $ret := false -}}
+{{- if . -}}
+	{{- $ret = fileExists . -}}
+{{- end -}}
+{{- return $ret -}}


### PR DESCRIPTION
Appearently, fileExists from Hugo's API is not able to process empty pathing (throws error). We don't have a choice but to add IO guarding for it. Hence, let's do this.

This patch adds IO guarding for hestiaIO/hestiaFS/IsFileExists API into hestiaHUGO/ directory.