### PR TITLE
sites: ported /en/specs/hestiaGUI/zoralabULIST/ page

### DIFF
--- a/sites/content/en/specs/hestiaGUI/zoralabULIST/__content.hestiaLDJSON
+++ b/sites/content/en/specs/hestiaGUI/zoralabULIST/__content.hestiaLDJSON
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (partial "hestiaJSON/schemaorgLDJSON/WebPage" .) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/en/specs/hestiaGUI/zoralabULIST/__contributors.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabULIST/__contributors.toml
@@ -1,0 +1,78 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...
+[[Contributors]]
+Key = 'ZORALab'
+
+[Contributors.Contribution]
+Creation = true
+Contact = true
+Artwork = false
+Knowledge = false
+Editor = true
+Developer = false
+Maintainer = false
+Producer = true
+Provider = true
+Publisher = true
+Funder = false
+Sponsor = true
+
+
+
+
+[[Contributors]]
+Key = 'HollowayKeanHo'
+
+[Contributors.Contribution]
+Creation = true
+Contact = false
+Artwork = false
+Knowledge = true
+Editor = true
+Developer = false
+Maintainer = false
+Producer = false
+Provider = false
+Publisher = false
+Funder = false
+Sponsor = false

--- a/sites/content/en/specs/hestiaGUI/zoralabULIST/__data.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabULIST/__data.toml
@@ -1,0 +1,2 @@
+[Dataset]
+Path = 'hestiaGUI.zoralabULIST'

--- a/sites/content/en/specs/hestiaGUI/zoralabULIST/__languages.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabULIST/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = '/en/specs/hestiagui/zoralabblockquote'
+
+[zh-Hans]
+URL = '/zh-hans/specs/hestiagui/zoralabblockquote'

--- a/sites/content/en/specs/hestiaGUI/zoralabULIST/__page.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabULIST/__page.toml
@@ -1,0 +1,125 @@
+# PAGE METADATA
+# =============
+# Date fields.
+#
+# NOTE:
+#   1. You can generate date easily on linux using '$ date' command.
+#   2. If date field is left blank, the current time shall be used instead.
+#   3. Date should ONLY comply to this pattern when manually constructed:
+#                    Thu 21 Jul 2022 14:27:39 PM +08
+[Date]
+Created   = 'Sun 11 Dec 2022 05:18:15 AM +08'
+Published = 'Sun 11 Dec 2022 05:18:15 AM +08'
+
+
+
+
+# Content fields.
+# NOTE:
+#   1. For .Title, Hestia's string processing using page variables are allowed
+#      and only limited to .Titles sub-fields.
+#   2. For .Keywords, Hestia's string processing using page variables are
+#      allowed but strongly discouraged.
+[Content]
+Title = "zoralabULIST Technical Specification - ZORALab's Hestia"
+Keywords = [
+	'zoralabULIST',
+	'hestiaGUI',
+	'Technical Specifications',
+	'Specifications',
+	'Web',
+	'Tech',
+	'PWA',
+	'WASM',
+	'Software Libraries',
+	'Hugo',
+	'Go',
+	'TinyGo',
+	'Nim',
+	'ZORALab',
+	"ZORALab's Hestia",
+]
+
+
+
+
+# Description fields.
+# NOTE:
+#   1. Hestia's string processing using page variables are allowed.
+#   2. The .Description.Pitch is at maximum 160 characters.
+#   3. The .Description.Summary is at maximum of 250 characters.
+#   4. All fields shall have their whitespace cleansed during the processing.
+[Description]
+Pitch = '''
+The technical specifications to refer when using the package.
+'''
+Summary = '''
+Easy-going, offline supported (via web PWA installation), and detailed oriented.
+Courtesy from ZORALab's Hestia.
+'''
+
+
+
+
+# Redirect fields.
+# NOTE:
+#   1. Hestia's URL processing is allowed for .URL field.
+#   2. .Delay timing sets the delay time before redirect. Setting to '0' means
+#      an immediate redirect is requested.
+#   3. Redirect is only available if .Enabled is set to 'true'.
+#   4. Redirect.Language is to redirect the current page to its
+#      language-specific page when Javascript is made available on client side
+#      or fallback to default language.
+[Redirect]
+Delay = 0 # second
+URL = ''
+Enabled = false
+
+[Redirect.Language]
+Enabled = false
+
+
+
+
+# Content Files' Sourcing Location
+# NOTE:
+#   1. To denote where are the content sources.
+#   2. If you're sourcing from assets directory, prefix 'assets/'.
+#   3. If you're sourcing from layouts directory, prefix 'layouts/'.
+#   2. If you're sourcing from static directory, prefix 'static/'.
+#   3. If you're sourcing from partial directory, prefix 'layouts/partials/'.
+[Sources]
+HTML = 'layouts/content/specs/zoralab/index.html'
+JSON = 'layouts/content/specs/zoralab/index.json'
+CSS = 'layouts/content/specs/zoralab/index.css'
+JS = 'layouts/content/specs/zoralab/index.js'
+LDJSON = '__content.hestiaLDJSON'
+Contributors = '__contributors.toml'
+Thumbnails = '__thumbnails.toml'
+Languages = '__languages.toml'
+Assets = 'layouts/content/specs/zoralab/assets.toml'
+Components = 'layouts/content/specs/zoralab/components.toml'
+
+
+
+
+# Data fields.
+# NOTE:
+#   1. List only the page-level data files. It can be in any of the following
+#      formats: '.json', '.toml', or '.yaml'.
+#   2. Hestia string processing is available and shall be processed prior to
+#      dataset transformation.
+#   3. Sequences of the .Data array dictates sequences of loading and overriding
+#      (the latter shall overwrite the former for the same data fields).
+#   4. The final processed dataset shall be served as main data content in
+#      supported output format (e.g. index.json).
+#   5. Missing data file shall be ignored.
+#   6. To add more data files, simply duplicate and add more .Data array entry.
+#      Example:
+#                             [[data]]
+#                             Filename = 'file1.json'
+#
+#                             [[data]]
+#                             Filename = 'file2.toml'
+[[Data]]
+Filename = '__data.toml'

--- a/sites/content/en/specs/hestiaGUI/zoralabULIST/__robots.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabULIST/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/en/specs/hestiaGUI/zoralabULIST/__thumbnails.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabULIST/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/thumbnails-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/thumbnails-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/thumbnails-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/en/specs/hestiaGUI/zoralabULIST/__twitter.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabULIST/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/en/specs/hestiaGUI/zoralabULIST/__wasm.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabULIST/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/en/specs/hestiaGUI/zoralabULIST/_index.html
+++ b/sites/content/en/specs/hestiaGUI/zoralabULIST/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++

--- a/sites/data/Specs/hestiaGUI/zoralabBLOCKQUOTE/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabBLOCKQUOTE/Designs.toml
@@ -327,10 +327,10 @@ Label = ''
 [[ZH-HANS.List.SubList]]
 Title = 'Padding'
 HTML = '''
-影响元件的大小控制态度。
+影响元件的内向边距空间。
 '''
 Plain = '''
-影响元件的大小控制态度。
+影响元件的内向边距空间。
 '''
 Code = '''
 变化值     : --blockquote-padding
@@ -405,10 +405,10 @@ Label = ''
 [[ZH-HANS.List.SubList]]
 Title = 'Border Radius'
 HTML = '''
-影响元件的边界线的角落圆形度。
+影响元件边界线的角落圆形度。
 '''
 Plain = '''
-影响元件的边界线的角落圆形度。
+影响元件边界线的角落圆形度。
 '''
 Code = '''
 变化值     : --blockquote-border-radius

--- a/sites/data/Specs/hestiaGUI/zoralabCODE/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabCODE/Designs.toml
@@ -319,10 +319,10 @@ Label = ''
 [[ZH-HANS.List.SubList]]
 Title = 'Border Radius'
 HTML = '''
-影响元件的边界线的角落圆形度。
+影响元件边界线的角落圆形度。
 '''
 Plain = '''
-影响元件的边界线的角落圆形度。
+影响元件边界线的角落圆形度。
 '''
 Code = '''
 变化值     : --code-border-radius

--- a/sites/data/Specs/hestiaGUI/zoralabPRE/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabPRE/Designs.toml
@@ -471,10 +471,10 @@ Label = ''
 [[ZH-HANS.List.SubList]]
 Title = 'Border Radius'
 HTML = '''
-影响元件的边界线的角落圆形度。
+影响元件边界线的角落圆形度。
 '''
 Plain = '''
-影响元件的边界线的角落圆形度。
+影响元件边界线的角落圆形度。
 '''
 Code = '''
 变化值     : --pre-border-radius

--- a/sites/data/Specs/hestiaGUI/zoralabULIST/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabULIST/Designs.toml
@@ -1,0 +1,1135 @@
+[[EN.List]]
+Title = 'Designers'
+HTML = '''
+This component was designed by the following creators:
+'''
+Plain = '''
+This component was designed by the following creators:
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = 'https://www.hollowaykeanho.com/en/'
+Label = '(Holloway) Chew, Kean Ho'
+
+
+[[ZH-HANS.List]]
+Title = '设计师'
+HTML = '''
+这个元件的设计是由以下的创造者所建设的：
+'''
+Plain = '''
+这个元件的设计是由以下的创造者所建设的：
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = 'https://www.hollowaykeanho.com/zh-hans/'
+Label = '(Holloway) 周健豪'
+
+
+
+
+[[EN.List]]
+Title = 'Dependencies'
+HTML = '''
+This component has the following dependencies (arranged in the order from
+left-top to right-bottom):
+'''
+Plain = '''
+This component has the following dependencies (arranged in the order from
+left-top to right-bottom):
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = '/en/specs/hestiagui/zoralabcore/'
+Label = 'zoralabCORE'
+
+
+[[ZH-HANS.List]]
+Title = '依赖其他元件'
+HTML = '''
+这个元件是需要以下的其他元件才能好好的运行 (排序从‘左上到右下’）：
+'''
+Plain = '''
+这个元件是需要以下的其他元件才能好好的运行 (排序从‘左上到右下’）：
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = '/zh-hans/specs/hestiagui/zoralabcore/'
+Label = 'zoralabCORE'
+
+
+
+
+[[EN.List]]
+Title = 'HTML'
+HTML = '''
+For HTML, ZORALab's Hestia employs the W3C native syntax for simplicity and
+maximum compatibility sakes. ZORALab's Hestia recommends the following HTML code
+structure for this component.
+'''
+Plain = '''
+For HTML, ZORALab's Hestia employs the W3C native syntax for simplicity and
+maximum compatibility sakes. ZORALab's Hestia recommends the following HTML code
+structure for this component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'HTML'
+HTML = '''
+至于HTML，为了简单化和最大的兼容性整个用法，ZORALab赫斯提亚运用W3C的语法。我们
+推荐您用以下的HTML代码来运用这个界面元件。
+'''
+Plain = '''
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Minimum HTML'
+HTML = '''
+The minimum required HTML codes are shown below:
+'''
+Plain = '''
+The minimum required HTML codes are shown below:
+'''
+Code = '''
+<ul>
+	<li>...</li>
+	<li>...</li>
+	<li>...</li>
+</ul>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '最小的HTML'
+HTML = '''
+在最小的HTML代码运用方法如下：
+'''
+Plain = '''
+在最小的HTML代码运用方法如下：
+'''
+Code = '''
+<ul>
+	<li>...</li>
+	<li>...</li>
+	<li>...</li>
+</ul>
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Compound List HTML'
+HTML = '''
+The compound list HTML codes are shown below:
+'''
+Plain = '''
+The compound list HTML codes are shown below:
+'''
+Code = '''
+<ul>
+	<li>
+		...
+	</li>
+	<li>
+		...
+		<ul style="--ulist-li-before-background:red;">
+			<li>...</li>
+			<li>...</li>
+		</ul>
+	</li>
+	<li>
+		...
+	</li>
+</ul>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '综合列表的HTML'
+HTML = '''
+在最小的HTML代码运用方法如下：
+'''
+Plain = '''
+在最小的HTML代码运用方法如下：
+'''
+Code = '''
+<ul>
+	<li>
+		...
+	</li>
+	<li>
+		...
+		<ul style="--ulist-li-before-background:red;">
+			<li>...</li>
+			<li>...</li>
+		</ul>
+	</li>
+	<li>
+		...
+	</li>
+</ul>
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'CSS'
+HTML = '''
+ZORALab's Hestia heavily rely on CSS to style this component and offering its
+css variables for customizations. Below are the list of available CSS variables
+at your disposal.
+'''
+Plain = '''
+ZORALab's Hestia heavily rely on CSS to style this component and offering its
+css variables for customizations. Below are the list of available CSS variables
+at your disposal.
+'''
+Code = '''
+'''
+
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+[[ZH-HANS.List]]
+Title = 'GUI界面一定要自选性'
+HTML = '''
+GUI界面元件主要是给那些没有科技文学的顾客可以方便使用某个科技。如此以来，一个科技
+产品必须能处理和互相交易数据就行了。然后呢，GUI界面就有用户者来自选服务就行了。
+'''
+Plain = '''
+GUI界面元件主要是给那些没有科技文学的顾客可以方便使用某个科技。如此以来，一个科技
+产品必须能处理和互相交易数据就行了。然后呢，GUI界面就有用户者来自选服务就行了。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Display'
+HTML = '''
+Affects the display mode of the rendered component.
+'''
+Plain = '''
+Affects the display mode of the rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-display
+CSS PROPERTY : display
+DEFAULT      : block (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Display'
+HTML = '''
+影响元件的显示模式。
+'''
+Plain = '''
+影响元件的显示模式。
+'''
+Code = '''
+变化值     : --ulist-display
+CSS属性    : display
+默认数码   : block (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Margin'
+HTML = '''
+Affects the margin of the rendered component.
+'''
+Plain = '''
+Affects the margin of the rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-margin
+CSS PROPERTY : margin
+DEFAULT      : 0 (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Margin'
+HTML = '''
+影响元件的外向边距空间。
+'''
+Plain = '''
+影响元件的外向边距空间。
+'''
+Code = '''
+变化值     : --ulist-margin
+CSS属性    : margin
+默认数码   : 0 (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Padding'
+HTML = '''
+Affects the padding of the rendered component.
+'''
+Plain = '''
+Affects the padding of the rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-padding
+CSS PROPERTY : padding
+DEFAULT      : 0 (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Padding'
+HTML = '''
+影响元件的内向边距空间。
+'''
+Plain = '''
+影响元件的内向边距空间。
+'''
+Code = '''
+变化值     : --ulist-padding
+CSS属性    : padding
+默认数码   : 0 (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Spacing'
+HTML = '''
+Affects the margin and padding's spacing value of the rendered component.
+'''
+Plain = '''
+Affects the margin and padding's spacing value of the rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-spacing
+CSS PROPERTY : margin; padding
+DEFAULT      : 2rem (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Spacing'
+HTML = '''
+影响元件的外向和内向边距空间。
+'''
+Plain = '''
+影响元件的外向和内向边距空间。
+'''
+Code = '''
+变化值     : --ulist-spacing
+CSS属性    : margin; padding
+默认数码   : 2rem (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Text Align'
+HTML = '''
+Affects the text alignment of the rendered component.
+'''
+Plain = '''
+Affects the text alignment of the rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-text-align
+CSS PROPERTY : text-align
+DEFAULT      : left (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Text Align'
+HTML = '''
+影响元件的文字对齐方式。
+'''
+Plain = '''
+影响元件的文字对齐方式。
+'''
+Code = '''
+变化值     : --ulist-text-align
+CSS属性    : text-align
+默认数码   : left (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Content'
+HTML = '''
+Affects the before-pseudo-element's content of the list item (bullet) for the
+rendered component.
+'''
+Plain = '''
+Affects the before-pseudo-element's content of the list item (bullet) for the
+rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-li-before-content
+CSS PROPERTY : content
+DEFAULT      : \"Ψ\" (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '目符号内容'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）的内容。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）的内容。
+'''
+Code = '''
+变化值     : --ulist-li-before-content
+CSS属性    : content
+默认数码   : \"Ψ\" (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Display'
+HTML = '''
+Affects the before-pseudo-element's display mode of the list item (bullet) for
+the rendered component.
+'''
+Plain = '''
+Affects the before-pseudo-element's display mode of the list item (bullet) for
+the rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-li-before-display
+CSS PROPERTY : display
+DEFAULT      : block (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '目符号Display'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）的显示模式。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）的显示模式。
+'''
+Code = '''
+变化值     : --ulist-li-before-display
+CSS属性    : display
+默认数码   : block (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Size'
+HTML = '''
+Affects the before-pseudo-element's width and height dimensional value of the
+list item (bullet) for the rendered component.
+'''
+Plain = '''
+Affects the before-pseudo-element's width and height dimensional value of the
+list item (bullet) for the rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-li-before-size
+CSS PROPERTY : width; height
+DEFAULT      : 3rem (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '目符号大小'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）的长度和宽度。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）的长度和宽度。
+'''
+Code = '''
+变化值     : --ulist-li-before-size
+CSS属性    : width; height
+默认数码   : 3rem (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Margin'
+HTML = '''
+Affects the before-pseudo-element's margin of the list item (bullet) for the
+rendered component.
+'''
+Plain = '''
+Affects the before-pseudo-element's margin of the list item (bullet) for the
+rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-li-before-margin
+CSS PROPERTY : margin
+DEFAULT      : .5rem auto (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '目符号Margin'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）的外向边距空间。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）的外向边距空间。
+'''
+Code = '''
+变化值     : --ulist-li-before-margin
+CSS属性    : margin
+默认数码   : .5rem auto (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Padding'
+HTML = '''
+Affects the before-pseudo-element's padding of the list item (bullet) for the
+rendered component.
+'''
+Plain = '''
+Affects the before-pseudo-element's padding of the list item (bullet) for the
+rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-li-before-padding
+CSS PROPERTY : padding
+DEFAULT      : 0 (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '目符号Padding'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）的内向边距空间。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）的内向边距空间。
+'''
+Code = '''
+变化值     : --ulist-li-before-padding
+CSS属性    : padding
+默认数码   : 0 (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Border'
+HTML = '''
+Affects the before-pseudo-element's border of the list item (bullet) for the
+rendered component.
+'''
+Plain = '''
+Affects the before-pseudo-element's border of the list item (bullet) for the
+rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-li-before-border
+CSS PROPERTY : border
+DEFAULT      : 1px solid transparent (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '目符号Border'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）的边界线。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）的边界线。
+'''
+Code = '''
+变化值     : --ulist-li-before-border-radius
+CSS属性    : border-radius
+默认数码   : 1px solid transparent (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Border Radius'
+HTML = '''
+Affects the before-pseudo-element's border-radius of the list item (bullet) for
+the rendered component.
+'''
+Plain = '''
+Affects the before-pseudo-element's border-radius of the list item (bullet) for
+the rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-li-before-border-radius
+CSS PROPERTY : border-radius
+DEFAULT      : 50% (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '目符号Border Radius'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）边界线的角落圆形度。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）边界线的角落圆形度。
+'''
+Code = '''
+变化值     : --ulist-li-before-border-radius
+CSS属性    : border-radius
+默认数码   : 50% (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Font Size'
+HTML = '''
+Affects the before-pseudo-element's font size of the list item (bullet) for
+the rendered component.
+'''
+Plain = '''
+Affects the before-pseudo-element's font size of the list item (bullet) for
+the rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-li-before-font-size
+CSS PROPERTY : font-size
+DEFAULT      : 2rem (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '目符号Font Size'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）的字体大小。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）的字体大小。
+'''
+Code = '''
+变化值     : --ulist-li-before-font-size
+CSS属性    : font-size
+默认数码   : 2rem (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Font Weight'
+HTML = '''
+Affects the before-pseudo-element's font weight of the list item (bullet) for
+the rendered component.
+'''
+Plain = '''
+Affects the before-pseudo-element's font weight of the list item (bullet) for
+the rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-li-before-font-weight
+CSS PROPERTY : font-weight
+DEFAULT      : 700 (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '目符号Font Weight'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）的字体厚度。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）的字体厚度。
+'''
+Code = '''
+变化值     : --ulist-li-before-font-weight
+CSS属性    : font-weight
+默认数码   : 700 (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Text Align'
+HTML = '''
+Affects the before-pseudo-element's text alignment of the list item (bullet) for
+the rendered component.
+'''
+Plain = '''
+Affects the before-pseudo-element's text alignment of the list item (bullet) for
+the rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-li-before-text-align
+CSS PROPERTY : text-align
+DEFAULT      : center (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '目符号Text Align'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）的字体对齐条件。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）的字体对齐条件。
+'''
+Code = '''
+变化值     : --ulist-li-before-text-align
+CSS属性    : text-align
+默认数码   : center (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Color'
+HTML = '''
+Affects the before-pseudo-element's color of the list item (bullet) for the
+rendered component.
+'''
+Plain = '''
+Affects the before-pseudo-element's color of the list item (bullet) for the
+rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-li-before-color
+CSS PROPERTY : color
+DEFAULT      : var(--color-typography-50) (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '目符号Color'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）的颜色。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）的颜色。
+'''
+Code = '''
+变化值     : --ulist-li-before-color
+CSS属性    : color
+默认数码   : var(--color-typography-50) (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Color (Inverted Mode)'
+HTML = '''
+Affects the before-pseudo-element's color of the list item (bullet) for the
+rendered component while in inverted mode.
+'''
+Plain = '''
+Affects the before-pseudo-element's color of the list item (bullet) for the
+rendered component while in inverted mode.
+'''
+Code = '''
+VARIABLE     : --ulist-li-color-inverted
+CSS PROPERTY : color
+DEFAULT      : var(--color-contrast-50) (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '目符号Color（反转环境）'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）在反转环境里的颜色。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）在反转环境里的颜色。
+'''
+Code = '''
+变化值     : --ulist-li-color-inverted
+CSS属性    : color
+默认数码   : var(--color-contrast-50) (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Color (Print Mode)'
+HTML = '''
+Affects the before-pseudo-element's color of the list item (bullet) for the
+rendered component while in print mode.
+'''
+Plain = '''
+Affects the before-pseudo-element's color of the list item (bullet) for the
+rendered component while in print mode.
+'''
+Code = '''
+VARIABLE     : --ulist-li-color-print
+CSS PROPERTY : color
+DEFAULT      : var(--body-color-print) (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Color（印刷）'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）在印刷环境里的颜色。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）在印刷环境里的颜色。
+'''
+Code = '''
+变化值     : --ulist-li-color-print
+CSS属性    : color
+默认数码   : var(--body-color-print) (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Background'
+HTML = '''
+Affects the before-pseudo-element's background of the list item (bullet) for the
+rendered component.
+'''
+Plain = '''
+Affects the before-pseudo-element's background of the list item (bullet) for the
+rendered component.
+'''
+Code = '''
+VARIABLE     : --ulist-li-background
+CSS PROPERTY : background
+DEFAULT      : var(--color-primary-400) (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '目符号Background'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）的背景。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）的背景。
+'''
+Code = '''
+变化值     : --ulist-li-background
+CSS属性    : background
+默认数码   : var(--color-primary-400) (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Background (Inverted Mode)'
+HTML = '''
+Affects the before-pseudo-element's background of the list item (bullet) for the
+rendered component while in inverted mode.
+'''
+Plain = '''
+Affects the before-pseudo-element's background of the list item (bullet) for the
+rendered component while in inverted mode.
+'''
+Code = '''
+VARIABLE     : --ulist-li-background-inverted
+CSS PROPERTY : background
+DEFAULT      : var(--color-primary-400) (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Background（反转环境）'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）在反转环境里的背景。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）在反转环境里的背景。
+'''
+Code = '''
+变化值     : --ulist-li-background-inverted
+CSS属性    : background
+默认数码   : var(--color-primary-400) (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bullet Background (Print Mode)'
+HTML = '''
+Affects the before-pseudo-element's background of the list item (bullet) for the
+rendered component while in print mode.
+'''
+Plain = '''
+Affects the before-pseudo-element's background of the list item (bullet) for the
+rendered component while in print mode.
+'''
+Code = '''
+VARIABLE     : --ulist-li-background-print
+CSS PROPERTY : background
+DEFAULT      : var(--body-background-print) (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Bullet Background（印刷）'
+HTML = '''
+影响元件的列表项Before伪元素（目符号）在印刷环境里的背景。
+'''
+Plain = '''
+影响元件的列表项Before伪元素（目符号）在印刷环境里的背景。
+'''
+Code = '''
+变化值     : --ulist-li-background-print
+CSS属性    : background
+默认数码   : var(--body-background-print) (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'JavaScript'
+HTML = '''
+Fortunately, this component does not use any JavaScript. Relax.
+'''
+Plain = '''
+Fortunately, this component does not use any JavaScript. Relax.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'JavaScript'
+HTML = '''
+庆幸的是这个元件没有运用到任何JavaScript。放心吧！
+'''
+Plain = '''
+庆幸的是这个元件没有运用到任何JavaScript。放心吧！
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/data/Specs/hestiaGUI/zoralabULIST/Functions.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabULIST/Functions.toml
@@ -1,0 +1,138 @@
+[[EN.List]]
+Title = 'ToCSS'
+HTML = '''
+Render the CSS output for this UI component.
+'''
+Plain = '''
+Render the CSS output for this UI component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'ToCSS'
+HTML = '''
+渲染呈现CSS的输出数据。
+'''
+Plain = '''
+渲染呈现CSS的输出数据。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+Usage example:
+'''
+Plain = '''
+Usage example:
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabULIST/ToCSS" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+用法：
+'''
+Plain = '''
+用法：
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabULIST/ToCSS" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'ToCSS_VARIABLES'
+HTML = '''
+Render the CSS variables output list for this UI component.
+'''
+Plain = '''
+Render the CSS variables output list for this UI component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'ToCSS_VARIABLES'
+HTML = '''
+渲染呈现CSS变化值数据的输出菜单。
+'''
+Plain = '''
+渲染呈现CSS变化值数据的输出菜单。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+Usage example:
+'''
+Plain = '''
+Usage example:
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabULIST/ToCSS_VARIABLES" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+用法：
+'''
+Plain = '''
+用法：
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabULIST/ToCSS_VARIABLES" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/data/Specs/hestiaGUI/zoralabULIST/Metadata.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabULIST/Metadata.toml
@@ -1,0 +1,14 @@
+[EN.Brand]
+ID = 'zoralabulist'
+SKU = 'zoralabULIST'
+Description = '''
+For styling an unordered list syntax.
+'''
+
+
+[ZH-HANS.Brand]
+ID = 'zoralabulist'
+SKU = 'zoralabULIST'
+Description = '''
+来渲染无序列表。
+'''

--- a/sites/data/Specs/hestiaGUI/zoralabULIST/Purposes.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabULIST/Purposes.toml
@@ -1,0 +1,141 @@
+[[EN.List]]
+Title = 'Main Purpose'
+HTML = '''
+This package's primary purpose is to provide user interface (UI) styling
+specifically for unordered list values. In web UI, it is shown as follows:
+<br/><br/>
+<ul>
+	<li>
+		<p>Sun</p>
+	</li>
+	<li>
+		<p>Earth</p>
+		<ul style="--ulist-li-before-background:red">
+			<li><p>Human</p></li>
+			<li><p>Trees</p></li>
+		</ul>
+	</li>
+	<li>
+		<p>Mars</p>
+	</li>
+</ul>
+'''
+Plain = '''
+This package's primary purpose is to provide user interface (UI) styling
+specifically for unordered values. In web UI, it is shown as follows:
+
+<ul>
+	<li>
+		<p>Sun</p>
+	</li>
+	<li>
+		<p>Earth</p>
+		<ul style="--ulist-li-before-background:red">
+			<li><p>Human</p></li>
+			<li><p>Trees</p></li>
+		</ul>
+	</li>
+	<li>
+		<p>Mars</p>
+	</li>
+</ul>
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = '主要目的'
+HTML = '''
+这个软件包的出生主要是支持渲染无序列表的界面元件。在网络界面世界里，
+这元件的成果如下：
+<br/><br/>
+<ul>
+	<li>
+		<p>太阳</p>
+	</li>
+	<li>
+		<p>地球</p>
+		<ul style="--ulist-li-before-background:red">
+			<li><p>人类</p></li>
+			<li><p>树木</p></li>
+		</ul>
+	</li>
+	<li>
+		<p>木星</p>
+	</li>
+</ul>
+'''
+Plain = '''
+这个软件包的出生主要是支持渲染无序列表的界面元件。在网络界面世界里，
+这元件的成果如下：
+
+<ul>
+	<li>
+		<p>太阳</p>
+	</li>
+	<li>
+		<p>地球</p>
+		<ul style="--ulist-li-before-background:red">
+			<li><p>人类</p></li>
+			<li><p>树木</p></li>
+		</ul>
+	</li>
+	<li>
+		<p>木星</p>
+	</li>
+</ul>
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'Legacy Recording'
+HTML = '''
+This package was known as <code>ulist_hestiaUI</code> before
+ZORALab's Hestia <code>v1.2.0</code>. The transformation was due to someone
+attempting to steal the copyrights and makes way for programming package's
+documentation restructuring.
+'''
+Plain = '''
+This package was known as 'ulist_hestiaUI' before
+ZORALab's Hestia 'v1.2.0'. The transformation was due to someone attempting to
+steal the design copyrights and makes way for programming package's
+documentation restructuring.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = '历史遗录'
+HTML = '''
+这个软件包在ZORALab赫斯提亚<code>v1.2.0</code>版本之前曾经被名为
+<code>ulist_hestiaUI</code>。改名的目的是有人要横行强盗设计的版权和为了编程
+文件编写能力而整理过。
+'''
+Plain = '''
+这个软件包在ZORALab赫斯提亚v1.2.0版本之前曾经被名为ulist_hestiaUI。改名的
+目的是有人要横行强盗设计的版权和为了编程文件编写能力而整理过。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/layouts/content/specs/zoralab/components.toml
+++ b/sites/layouts/content/specs/zoralab/components.toml
@@ -106,3 +106,8 @@ Variables = []
 Name = "zoralabBLOCKQUOTE"
 Include = true
 Variables = []
+
+[[List]]
+Name = "zoralabULIST"
+Include = true
+Variables = []


### PR DESCRIPTION
Since the /en/specs/hestiaGUI/ page is ready, we can proceed to port zoralabULIST spec page. Hence, let's do this.

This patch ports /en/specs/hestiaGUI/zoralabULIST/ spec page into sites/ directory.