### PR TITLE
sites: ported /en/specs/hestiaGUI/zoralabTOC/ page

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabTOC/CSS
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabTOC/CSS
@@ -15,9 +15,8 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 */ -}}
 {{- /* WARNING: Auto-generated file. DO NOT EDIT! */ -}}
-
 .toc {
-	display: block;
+	display: var(--toc-display);
 
 	margin: var(--toc-margin);
 	padding: var(--toc-padding);
@@ -36,54 +35,16 @@ specific language governing permissions and limitations under the License.
 	background: var(--toc-background);
 }
 
-.toc > * {
-	display: block;
-
-	margin: var(--toc-content-margin);
-
-	min-width: var(--toc-content-min-width);
-	width: var(--toc-content-width);
-	max-width: var(--toc-content-max-width);
-	min-height: var(--toc-content-min-height);
-	height: var(--toc-content-height);
-	max-height: var(--toc-content-max-height);
-}
-
-.toc:before {
-	content: var(--toc-title-content);
-	display: block;
-
-	margin: var(--toc-title-margin);
-	padding: var(--toc-title-padding);
-
-	font-size: var(--toc-title-font-size);
-	font-weight: var(--toc-title-font-weight);
-
-	color: var(--toc-title-color);
-	background: var(--toc-title-background);
-}
-
-footer .toc {
+footer .toc,
+.inverted .toc {
 	color: var(--toc-color-inverted);
-	border-color: var(--toc-color-inverted);
 	background: var(--toc-background-inverted);
 }
-
-footer .toc:before {
-	color: var(--toc-title-color-inverted);
-	background: var(--toc-title-background-inverted);
-}
-
 
 @media print {
 	.toc {
 		color: var(--toc-color-print) !important;
 		border-color: var(--toc-color-print) !important;
-		background: var(--toc-background-print) !important;
-	}
-
-	.toc:before {
-		color: var(--toc-color-print) !important;
 		background: var(--toc-background-print) !important;
 	}
 }

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabTOC/CSSVariables
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabTOC/CSSVariables
@@ -1,6 +1,13 @@
 [CSS.Variables]
+"--toc-display" = "block"
+
+
+
 "--toc-margin" = "2rem auto"
 "--toc-padding" = "2rem"
+
+
+
 
 "--toc-min-width" = "20rem"
 "--toc-width" = "fit-content"
@@ -9,8 +16,14 @@
 "--toc-height" = "fit-content"
 "--toc-max-height" = "initial"
 
+
+
+
 "--toc-border" = "1px solid var(--toc-color)"
 "--toc-border-radius" = ".5rem"
+
+
+
 
 "--toc-color" = "var(--body-color)"
 "--toc-color-inverted" = "var(--body-color-inverted)"
@@ -18,31 +31,3 @@
 "--toc-background" = "transparent"
 "--toc-background-inverted" = "transparent"
 "--toc-background-print" = "transparent"
-
-
-
-
-"--toc-content-margin" = "2rem auto"
-
-"--toc-content-min-width" = "initial"
-"--toc-content-width" = "fit-content"
-"--toc-content-max-width" = "initial"
-"--toc-content-min-height" = "initial"
-"--toc-content-height" = "initial"
-"--toc-content-max-height" = "initial"
-
-
-
-
-"--toc-title-content" = "\"Synopsis\""
-
-"--toc-title-margin" = "0 auto 2.5rem"
-"--toc-title-padding" = "0"
-
-"--toc-title-font-size" = "2rem"
-"--toc-title-font-weight" = "600"
-
-"--toc-title-color" = "var(--toc-color)"
-"--toc-title-color-inverted" = "var(--toc-color-inverted)"
-"--toc-title-background" = "transparent"
-"--toc-title-background-inverted" = "transparent"

--- a/sites/content/en/specs/hestiaGUI/zoralabTOC/__content.hestiaLDJSON
+++ b/sites/content/en/specs/hestiaGUI/zoralabTOC/__content.hestiaLDJSON
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (partial "hestiaJSON/schemaorgLDJSON/WebPage" .) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/en/specs/hestiaGUI/zoralabTOC/__contributors.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabTOC/__contributors.toml
@@ -1,0 +1,78 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...
+[[Contributors]]
+Key = 'ZORALab'
+
+[Contributors.Contribution]
+Creation = true
+Contact = true
+Artwork = false
+Knowledge = false
+Editor = true
+Developer = false
+Maintainer = false
+Producer = true
+Provider = true
+Publisher = true
+Funder = false
+Sponsor = true
+
+
+
+
+[[Contributors]]
+Key = 'HollowayKeanHo'
+
+[Contributors.Contribution]
+Creation = true
+Contact = false
+Artwork = false
+Knowledge = true
+Editor = true
+Developer = false
+Maintainer = false
+Producer = false
+Provider = false
+Publisher = false
+Funder = false
+Sponsor = false

--- a/sites/content/en/specs/hestiaGUI/zoralabTOC/__data.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabTOC/__data.toml
@@ -1,0 +1,2 @@
+[Dataset]
+Path = 'hestiaGUI.zoralabTOC'

--- a/sites/content/en/specs/hestiaGUI/zoralabTOC/__languages.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabTOC/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = '/en/specs/hestiagui/zoralabtoc'
+
+[zh-Hans]
+URL = '/zh-hans/specs/hestiagui/zoralabtoc'

--- a/sites/content/en/specs/hestiaGUI/zoralabTOC/__page.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabTOC/__page.toml
@@ -1,0 +1,124 @@
+# PAGE METADATA
+# =============
+# Date fields.
+#
+# NOTE:
+#   1. You can generate date easily on linux using '$ date' command.
+#   2. If date field is left blank, the current time shall be used instead.
+#   3. Date should ONLY comply to this pattern when manually constructed:
+#                    Thu 21 Jul 2022 14:27:39 PM +08
+[Date]
+Created   = "Fri 09 Dec 2022 09:09:02 PM +08"
+Published = "Fri 09 Dec 2022 09:09:02 PM +08"
+
+
+
+# Content fields.
+# NOTE:
+#   1. For .Title, Hestia's string processing using page variables are allowed
+#      and only limited to .Titles sub-fields.
+#   2. For .Keywords, Hestia's string processing using page variables are
+#      allowed but strongly discouraged.
+[Content]
+Title = "zoralabTOC Technical Specification - ZORALab's Hestia"
+Keywords = [
+	'zoralabTOC',
+	'hestiaGUI',
+	'Technical Specifications',
+	'Specifications',
+	'Web',
+	'Tech',
+	'PWA',
+	'WASM',
+	'Software Libraries',
+	'Hugo',
+	'Go',
+	'TinyGo',
+	'Nim',
+	'ZORALab',
+	"ZORALab's Hestia",
+]
+
+
+
+
+# Description fields.
+# NOTE:
+#   1. Hestia's string processing using page variables are allowed.
+#   2. The .Description.Pitch is at maximum 160 characters.
+#   3. The .Description.Summary is at maximum of 250 characters.
+#   4. All fields shall have their whitespace cleansed during the processing.
+[Description]
+Pitch = '''
+The technical specifications to refer when using the package.
+'''
+Summary = '''
+Easy-going, offline supported (via web PWA installation), and detailed oriented.
+Courtesy from ZORALab's Hestia.
+'''
+
+
+
+
+# Redirect fields.
+# NOTE:
+#   1. Hestia's URL processing is allowed for .URL field.
+#   2. .Delay timing sets the delay time before redirect. Setting to '0' means
+#      an immediate redirect is requested.
+#   3. Redirect is only available if .Enabled is set to 'true'.
+#   4. Redirect.Language is to redirect the current page to its
+#      language-specific page when Javascript is made available on client side
+#      or fallback to default language.
+[Redirect]
+Delay = 0 # second
+URL = ''
+Enabled = false
+
+[Redirect.Language]
+Enabled = false
+
+
+
+
+# Content Files' Sourcing Location
+# NOTE:
+#   1. To denote where are the content sources.
+#   2. If you're sourcing from assets directory, prefix 'assets/'.
+#   3. If you're sourcing from layouts directory, prefix 'layouts/'.
+#   2. If you're sourcing from static directory, prefix 'static/'.
+#   3. If you're sourcing from partial directory, prefix 'layouts/partials/'.
+[Sources]
+HTML = 'layouts/content/specs/zoralab/index.html'
+JSON = 'layouts/content/specs/zoralab/index.json'
+CSS = 'layouts/content/specs/zoralab/index.css'
+JS = 'layouts/content/specs/zoralab/index.js'
+LDJSON = '__content.hestiaLDJSON'
+Contributors = '__contributors.toml'
+Thumbnails = '__thumbnails.toml'
+Languages = '__languages.toml'
+Assets = 'layouts/content/specs/zoralab/assets.toml'
+Components = 'layouts/content/specs/zoralab/components.toml'
+
+
+
+
+# Data fields.
+# NOTE:
+#   1. List only the page-level data files. It can be in any of the following
+#      formats: '.json', '.toml', or '.yaml'.
+#   2. Hestia string processing is available and shall be processed prior to
+#      dataset transformation.
+#   3. Sequences of the .Data array dictates sequences of loading and overriding
+#      (the latter shall overwrite the former for the same data fields).
+#   4. The final processed dataset shall be served as main data content in
+#      supported output format (e.g. index.json).
+#   5. Missing data file shall be ignored.
+#   6. To add more data files, simply duplicate and add more .Data array entry.
+#      Example:
+#                             [[data]]
+#                             Filename = 'file1.json'
+#
+#                             [[data]]
+#                             Filename = 'file2.toml'
+[[Data]]
+Filename = '__data.toml'

--- a/sites/content/en/specs/hestiaGUI/zoralabTOC/__robots.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabTOC/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/en/specs/hestiaGUI/zoralabTOC/__thumbnails.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabTOC/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/thumbnails-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/thumbnails-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/thumbnails-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/en/specs/hestiaGUI/zoralabTOC/__twitter.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabTOC/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/en/specs/hestiaGUI/zoralabTOC/__wasm.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabTOC/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/en/specs/hestiaGUI/zoralabTOC/_index.html
+++ b/sites/content/en/specs/hestiaGUI/zoralabTOC/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++

--- a/sites/data/Specs/hestiaGUI/zoralabTOC/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabTOC/Designs.toml
@@ -1,0 +1,879 @@
+[[EN.List]]
+Title = 'Designers'
+HTML = '''
+This component was designed by the following creators:
+'''
+Plain = '''
+This component was designed by the following creators:
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = 'https://www.hollowaykeanho.com/en/'
+Label = '(Holloway) Chew, Kean Ho'
+
+
+[[ZH-HANS.List]]
+Title = '设计师'
+HTML = '''
+这个元件的设计是由以下的创造者所建设的：
+'''
+Plain = '''
+这个元件的设计是由以下的创造者所建设的：
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = 'https://www.hollowaykeanho.com/zh-hans/'
+Label = '(Holloway) 周健豪'
+
+
+
+
+[[EN.List]]
+Title = 'Dependencies'
+HTML = '''
+This component has the following dependencies (arranged in the order from
+left-top to right-bottom):
+'''
+Plain = '''
+This component has the following dependencies (arranged in the order from
+left-top to right-bottom):
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = '/en/specs/hestiagui/zoralabcore/'
+Label = 'zoralabCORE'
+
+
+[[ZH-HANS.List]]
+Title = '依赖其他元件'
+HTML = '''
+这个元件是需要以下的其他元件才能好好的运行 (排序从‘左上到右下’）：
+'''
+Plain = '''
+这个元件是需要以下的其他元件才能好好的运行 (排序从‘左上到右下’）：
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = '/zh-hans/specs/hestiagui/zoralabcore/'
+Label = 'zoralabCORE'
+
+
+
+
+[[EN.List]]
+Title = 'HTML'
+HTML = '''
+For HTML, ZORALab's Hestia employs the W3C native syntax for simplicity and
+maximum compatibility sakes. ZORALab's Hestia recommends the following HTML code
+structure for this component.
+'''
+Plain = '''
+For HTML, ZORALab's Hestia employs the W3C native syntax for simplicity and
+maximum compatibility sakes. ZORALab's Hestia recommends the following HTML code
+structure for this component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'HTML'
+HTML = '''
+至于HTML，为了简单化和最大的兼容性整个用法，ZORALab赫斯提亚运用W3C的语法。我们
+推荐您用以下的HTML代码来运用这个界面元件。
+'''
+Plain = '''
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Minimum HTML'
+HTML = '''
+The minimum required HTML codes are shown below:
+'''
+Plain = '''
+The minimum required HTML codes are shown below:
+'''
+Code = '''
+<nav class='toc'>
+	...
+</nav>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '最小的HTML'
+HTML = '''
+在最小的HTML代码运用方法如下：
+'''
+Plain = '''
+在最小的HTML代码运用方法如下：
+'''
+Code = '''
+<nav class='toc'>
+	...
+</nav>
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List]]
+Title = 'CSS'
+HTML = '''
+ZORALab's Hestia heavily rely on CSS to style this component and offering its
+css variables for customizations. Below are the list of available CSS variables
+at your disposal.
+'''
+Plain = '''
+ZORALab's Hestia heavily rely on CSS to style this component and offering its
+css variables for customizations. Below are the list of available CSS variables
+at your disposal.
+'''
+Code = '''
+'''
+
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+[[ZH-HANS.List]]
+Title = 'GUI界面一定要自选性'
+HTML = '''
+GUI界面元件主要是给那些没有科技文学的顾客可以方便使用某个科技。如此以来，一个科技
+产品必须能处理和互相交易数据就行了。然后呢，GUI界面就有用户者来自选服务就行了。
+'''
+Plain = '''
+GUI界面元件主要是给那些没有科技文学的顾客可以方便使用某个科技。如此以来，一个科技
+产品必须能处理和互相交易数据就行了。然后呢，GUI界面就有用户者来自选服务就行了。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Display'
+HTML = '''
+Affects the display mode of the rendered component.
+'''
+Plain = '''
+Affects the display mode of the rendered component.
+'''
+Code = '''
+VARIABLE     : --toc-display
+CSS PROPERTY : display
+DEFAULT      : block (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Display'
+HTML = '''
+影响元件的显示模式。
+'''
+Plain = '''
+影响元件的显示模式。
+'''
+Code = '''
+变化值     : --toc-display
+CSS属性    : display
+默认数码   : block (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Margin'
+HTML = '''
+Affects the margin of the rendered component.
+'''
+Plain = '''
+Affects the margin of the rendered component.
+'''
+Code = '''
+VARIABLE     : --toc-margin
+CSS PROPERTY : margin
+DEFAULT      : 2rem auto (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Margin'
+HTML = '''
+影响元件的外向边距空间。
+'''
+Plain = '''
+影响元件的外向边距空间。
+'''
+Code = '''
+变化值     : --toc-margin
+CSS属性    : margin
+默认数码   : 2rem auto (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Padding'
+HTML = '''
+Affects the padding of the rendered component.
+'''
+Plain = '''
+Affects the padding of the rendered component.
+'''
+Code = '''
+VARIABLE     : --toc-padding
+CSS PROPERTY : padding
+DEFAULT      : 2rem auto (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Padding'
+HTML = '''
+影响元件的内向边距空间。
+'''
+Plain = '''
+影响元件的内向边距空间。
+'''
+Code = '''
+变化值     : --toc-padding
+CSS属性    : padding
+默认数码   : 2rem auto (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Min-Width'
+HTML = '''
+Affects the minimum width of the rendered component.
+'''
+Plain = '''
+Affects the minimum width of the rendered component.
+'''
+Code = '''
+VARIABLE     : --toc-min-width
+CSS PROPERTY : min-width
+DEFAULT      : 20rem (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Min-Width'
+HTML = '''
+影响元件的最少宽度。
+'''
+Plain = '''
+影响元件的最少宽度。
+'''
+Code = '''
+变化值     : --toc-min-width
+CSS属性    : min-width
+默认数码   : 20rem (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Width'
+HTML = '''
+Affects the width of the rendered component.
+'''
+Plain = '''
+Affects the width of the rendered component.
+'''
+Code = '''
+VARIABLE     : --toc-width
+CSS PROPERTY : width
+DEFAULT      : fit-content (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Width'
+HTML = '''
+影响元件的宽度。
+'''
+Plain = '''
+影响元件的宽度。
+'''
+Code = '''
+变化值     : --toc-width
+CSS属性    : width
+默认数码   : fit-content (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Max-Width'
+HTML = '''
+Affects the maximum width of the rendered component.
+'''
+Plain = '''
+Affects the maximum width of the rendered component.
+'''
+Code = '''
+VARIABLE     : --toc-max-width
+CSS PROPERTY : max-width
+DEFAULT      : 100% (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Max-Width'
+HTML = '''
+影响元件的宽度。
+'''
+Plain = '''
+影响元件的宽度。
+'''
+Code = '''
+变化值     : --toc-max-width
+CSS属性    : max-width
+默认数码   : 100% (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Min-Height'
+HTML = '''
+Affects the minimum height of the rendered component.
+'''
+Plain = '''
+Affects the minimum height of the rendered component.
+'''
+Code = '''
+VARIABLE     : --toc-min-height
+CSS PROPERTY : min-height
+DEFAULT      : initial (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Min-Height'
+HTML = '''
+影响元件的最少高度。
+'''
+Plain = '''
+影响元件的最少高度。
+'''
+Code = '''
+变化值     : --toc-min-height
+CSS属性    : min-hieght
+默认数码   : initial (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Height'
+HTML = '''
+Affects the height of the rendered component.
+'''
+Plain = '''
+Affects the height of the rendered component.
+'''
+Code = '''
+VARIABLE     : --toc-height
+CSS PROPERTY : height
+DEFAULT      : fit-content (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Height'
+HTML = '''
+影响元件的高度。
+'''
+Plain = '''
+影响元件的高度。
+'''
+Code = '''
+变化值     : --toc-height
+CSS属性    : height
+默认数码   : fit-content (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Max-Height'
+HTML = '''
+Affects the maximum height of the rendered component.
+'''
+Plain = '''
+Affects the maximum height of the rendered component.
+'''
+Code = '''
+VARIABLE     : --toc-max-height
+CSS PROPERTY : max-height
+DEFAULT      : initial (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Max-Height'
+HTML = '''
+影响元件的最大高度。
+'''
+Plain = '''
+影响元件的最大高度。
+'''
+Code = '''
+变化值     : --toc-max-height
+CSS属性    : max-height
+默认数码   : initial (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Border'
+HTML = '''
+Affects the border of the rendered component.
+'''
+Plain = '''
+Affects the border of the rendered component.
+'''
+Code = '''
+VARIABLE     : --toc-border
+CSS PROPERTY : border
+DEFAULT      : initial (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Border'
+HTML = '''
+影响元件的边界线。
+'''
+Plain = '''
+影响元件的边界线。
+'''
+Code = '''
+变化值     : --toc-border
+CSS属性    : border
+默认数码   : initial (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Border Radius'
+HTML = '''
+Affects the border radius of the rendered component.
+'''
+Plain = '''
+Affects the border radius of the rendered component.
+'''
+Code = '''
+VARIABLE     : --toc-border-radius
+CSS PROPERTY : border-radius
+DEFAULT      : .5rem (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Border Radius'
+HTML = '''
+影响元件边界线的角落圆形度。
+'''
+Plain = '''
+影响元件边界线的角落圆形度。
+'''
+Code = '''
+变化值     : --toc-border-radius
+CSS属性    : border-radius
+默认数码   : .5rem (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Color'
+HTML = '''
+Affects the color of the rendered component.
+'''
+Plain = '''
+Affects the color of the rendered component.
+'''
+Code = '''
+VARIABLE     : --toc-color
+CSS PROPERTY : color
+DEFAULT      : var(--body-color) (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Color'
+HTML = '''
+影响元件的颜色。
+'''
+Plain = '''
+影响元件的颜色。
+'''
+Code = '''
+变化值     : --toc-color
+CSS属性    : color
+默认数码   : var(--body-color) (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Color (Inverted Mode)'
+HTML = '''
+Affects the color of the rendered component while in inverted mode.
+'''
+Plain = '''
+Affects the color of the rendered component while in inverted mode.
+'''
+Code = '''
+VARIABLE     : --toc-color-inverted
+CSS PROPERTY : color
+DEFAULT      : var(--body-color-inverted) (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Color （反转环境）'
+HTML = '''
+影响元件在反转环境里的颜色。
+'''
+Plain = '''
+影响元件在反转环境里的颜色。
+'''
+Code = '''
+变化值     : --toc-color-inverted
+CSS属性    : color
+默认数码   : var(--body-color-inverted) (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Color (Print Mode)'
+HTML = '''
+Affects the color of the rendered component when in print mode.
+'''
+Plain = '''
+Affects the color of the rendered component when in print mode.
+'''
+Code = '''
+VARIABLE     : --toc-color-print
+CSS PROPERTY : color
+DEFAULT      : var(--body-color-print) (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Color （印刷）'
+HTML = '''
+影响元件在印刷环境里的颜色。
+'''
+Plain = '''
+影响元件在印刷环境里的颜色。
+'''
+Code = '''
+变化值     : --toc-color-print
+CSS属性    : color
+默认数码   : var(--body-color-print) (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Background'
+HTML = '''
+Affects the background of the rendered component.
+'''
+Plain = '''
+Affects the background of the rendered component.
+'''
+Code = '''
+VARIABLE     : --toc-background
+CSS PROPERTY : background
+DEFAULT      : transparent (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Background'
+HTML = '''
+影响元件的背景。
+'''
+Plain = '''
+影响元件的背景。
+'''
+Code = '''
+变化值     : --toc-background
+CSS属性    : background
+默认数码   : transparent (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Background (Inverted Mode)'
+HTML = '''
+Affects the background of the rendered component while in inverted mode.
+'''
+Plain = '''
+Affects the background of the rendered component while in inverted mode.
+'''
+Code = '''
+VARIABLE     : --toc-background-inverted
+CSS PROPERTY : background
+DEFAULT      : transparent (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Background （反转环境）'
+HTML = '''
+影响元件在反转环境里的背景。
+'''
+Plain = '''
+影响元件在反转环境里的背景。
+'''
+Code = '''
+变化值     : --toc-background-inverted
+CSS属性    : background
+默认数码   : transparent (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Background (Print Mode)'
+HTML = '''
+Affects the background of the rendered component when in print mode.
+'''
+Plain = '''
+Affects the background of the rendered component when in print mode.
+'''
+Code = '''
+VARIABLE     : --toc-background-print
+CSS PROPERTY : background
+DEFAULT      : transparent (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Background （印刷）'
+HTML = '''
+影响元件在印刷环境里的背景。
+'''
+Plain = '''
+影响元件在印刷环境里的背景。
+'''
+Code = '''
+变化值     : --toc-background-print
+CSS属性    : background
+默认数码   : transparent (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'JavaScript'
+HTML = '''
+Fortunately, this component does not use any JavaScript. Relax.
+'''
+Plain = '''
+Fortunately, this component does not use any JavaScript. Relax.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'JavaScript'
+HTML = '''
+庆幸的是这个元件没有运用到任何JavaScript。放心吧！
+'''
+Plain = '''
+庆幸的是这个元件没有运用到任何JavaScript。放心吧！
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/data/Specs/hestiaGUI/zoralabTOC/Functions.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabTOC/Functions.toml
@@ -1,0 +1,138 @@
+[[EN.List]]
+Title = 'ToCSS'
+HTML = '''
+Render the CSS output for this UI component.
+'''
+Plain = '''
+Render the CSS output for this UI component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'ToCSS'
+HTML = '''
+渲染呈现CSS的输出数据。
+'''
+Plain = '''
+渲染呈现CSS的输出数据。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+Usage example:
+'''
+Plain = '''
+Usage example:
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabTOC/ToCSS" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+用法：
+'''
+Plain = '''
+用法：
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabTOC/ToCSS" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'ToCSS_VARIABLES'
+HTML = '''
+Render the CSS variables output list for this UI component.
+'''
+Plain = '''
+Render the CSS variables output list for this UI component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'ToCSS_VARIABLES'
+HTML = '''
+渲染呈现CSS变化值数据的输出菜单。
+'''
+Plain = '''
+渲染呈现CSS变化值数据的输出菜单。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+Usage example:
+'''
+Plain = '''
+Usage example:
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabTOC/ToCSS_VARIABLES" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+用法：
+'''
+Plain = '''
+用法：
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabTOC/ToCSS_VARIABLES" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/data/Specs/hestiaGUI/zoralabTOC/Metadata.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabTOC/Metadata.toml
@@ -1,0 +1,14 @@
+[EN.Brand]
+ID = 'zoralabtoc'
+SKU = 'zoralabTOC'
+Description = '''
+For styling a table of content syntax.
+'''
+
+
+[ZH-HANS.Brand]
+ID = 'zoralabtoc'
+SKU = 'zoralabTOC'
+Description = '''
+来渲染目录列表。
+'''

--- a/sites/data/Specs/hestiaGUI/zoralabTOC/Purposes.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabTOC/Purposes.toml
@@ -1,0 +1,104 @@
+[[EN.List]]
+Title = 'Main Purpose'
+HTML = '''
+This package's primary purpose is to provide user interface (UI) styling
+specifically for table of content values. In web UI, it is shown as follows:
+<br/><br/>
+<nav class='toc'>
+	<p class='h3'>Synopsis</p>
+	<p>Item 1</p>
+	<p>Item 2</p>
+	<p>Item 3</p>
+</nav>
+'''
+Plain = '''
+This package's primary purpose is to provide user interface (UI) styling
+specifically for table of content values. In web UI, it is shown as follows:
+
+<nav class='toc'>
+	<p class='h3'>Synopsis</p>
+	<p>Item 1</p>
+	<p>Item 2</p>
+	<p>Item 3</p>
+</nav>
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = '主要目的'
+HTML = '''
+这个软件包的出生主要是支持渲染目录列单的界面元件。在网络界面世界里，
+这元件的成果如下：
+<br/><br/>
+<nav class='toc'>
+	<p class='h3'>大纲</p>
+	<p>Item 1</p>
+	<p>Item 2</p>
+	<p>Item 3</p>
+</nav>
+'''
+Plain = '''
+这个软件包的出生主要是支持渲染无序列表的界面元件。在网络界面世界里，
+这元件的成果如下：
+
+<nav class='toc'>
+	<p>条文1</p>
+	<p>条文2</p>
+	<p>条文3</p>
+</nav>
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'Legacy Recording'
+HTML = '''
+This package was known as <code>toc_hestiaUI</code> before
+ZORALab's Hestia <code>v1.2.0</code>. The transformation was due to someone
+attempting to steal the copyrights and makes way for programming package's
+documentation restructuring.
+'''
+Plain = '''
+This package was known as 'toc_hestiaUI' before
+ZORALab's Hestia 'v1.2.0'. The transformation was due to someone attempting to
+steal the design copyrights and makes way for programming package's
+documentation restructuring.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = '历史遗录'
+HTML = '''
+这个软件包在ZORALab赫斯提亚<code>v1.2.0</code>版本之前曾经被名为
+<code>toc_hestiaUI</code>。改名的目的是有人要横行强盗设计的版权和为了编程
+文件编写能力而整理过。
+'''
+Plain = '''
+这个软件包在ZORALab赫斯提亚v1.2.0版本之前曾经被名为toc_hestiaUI。改名的
+目的是有人要横行强盗设计的版权和为了编程文件编写能力而整理过。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/layouts/content/specs/zoralab/components.toml
+++ b/sites/layouts/content/specs/zoralab/components.toml
@@ -116,3 +116,8 @@ Variables = []
 Name = "zoralabOLIST"
 Include = true
 Variables = []
+
+[[List]]
+Name = "zoralabTOC"
+Include = true
+Variables = []


### PR DESCRIPTION
Since the /en/specs/hestiaGUI/ page is ready, we can proceed to port zoralabTOC spec page. Hence, let's do this.

This patch ports /en/specs/hestiaGUI/zoralabTOC/ spec page into sites/ directory.