### PR TITLE
hestiaHUGO: 3rd attempt to workaround hugo memory leak symptom

### DIFF
--- a/hestiaHUGO/server.cmd
+++ b/hestiaHUGO/server.cmd
@@ -6,14 +6,20 @@ echo >/dev/null # >nul & GOTO WINDOWS & rem ^
 ################################################################################
 # Unix Main Codes                                                              #
 ################################################################################
-hugo server --noBuildLock \
-        --disableFastRender \
-        --port 8080 \
-        --gc
-exit $?
+while true; do
+        pgrep hugo | xargs kill -9 &> /dev/null
+        sleep 3
+        hugo server --noBuildLock \
+                --disableFastRender \
+                --port 8080 \
+                --renderToDisk \
+                --gc &
+        sleep 120
+done
 ################################################################################
 # Unix Main Codes                                                              #
 ################################################################################
+exit $?
 
 
 
@@ -22,10 +28,17 @@ exit $?
 ::##############################################################################
 :: Windows Main Codes                                                          #
 ::##############################################################################
+:loop
+taskkill /f /im hugo >NUL &
+timeout /t 3
 hugo server --noBuildLock ^
         --disableFastRender ^
         --port 8080 ^
-        --gc
+        --renderToDisk ^
+        --gc &
+timeout /t 120
+goto loop
 ::##############################################################################
 :: Windows Main Codes                                                          #
 ::##############################################################################
+EXIT /B

--- a/sites/server.cmd
+++ b/sites/server.cmd
@@ -6,15 +6,20 @@ echo >/dev/null # >nul & GOTO WINDOWS & rem ^
 ################################################################################
 # Unix Main Codes                                                              #
 ################################################################################
-hugo server --noBuildLock \
-        --disableFastRender \
-        --port 8080 \
-        --renderToDisk \
-        --gc
-exit $?
+while true; do
+        pgrep hugo | xargs kill -9 &> /dev/null
+        sleep 3
+        hugo server --noBuildLock \
+                --disableFastRender \
+                --port 8080 \
+                --renderToDisk \
+                --gc &
+        sleep 120
+done
 ################################################################################
 # Unix Main Codes                                                              #
 ################################################################################
+exit $?
 
 
 
@@ -23,10 +28,17 @@ exit $?
 ::##############################################################################
 :: Windows Main Codes                                                          #
 ::##############################################################################
+:loop
+taskkill /f /im hugo >NUL &
+timeout /t 3
 hugo server --noBuildLock ^
         --disableFastRender ^
         --port 8080 ^
-        --gc
+        --renderToDisk ^
+        --gc &
+timeout /t 120
+goto loop
 ::##############################################################################
 :: Windows Main Codes                                                          #
 ::##############################################################################
+EXIT /B


### PR DESCRIPTION
Appearently, Hugo somehow still fails to garbage collect properly in time until the memory reaches 99% consumption and entering swap file. This is not usable at all and it's outside ZORALab's Hestia control. Fortunately, killing the server allows the memory restoration immediately.

We already purged all memory related algorithms (.Store & partialCached) already so the bug should highly related to Hugo Pipe itself. We do not have a choice but to periodically kill the hugo server.

This patch applies 3rd attempt to workaround hugo memory leak symptom in hestiaHUGO/ directory.