### PR TITLE
sites: ported /en/specs/hestiaGUI/zoralabNOTE_SUCCESS/ page

### DIFF
--- a/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__content.hestiaLDJSON
+++ b/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__content.hestiaLDJSON
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (partial "hestiaJSON/schemaorgLDJSON/WebPage" .) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__contributors.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__contributors.toml
@@ -1,0 +1,78 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...
+[[Contributors]]
+Key = 'ZORALab'
+
+[Contributors.Contribution]
+Creation = true
+Contact = true
+Artwork = false
+Knowledge = false
+Editor = true
+Developer = false
+Maintainer = false
+Producer = true
+Provider = true
+Publisher = true
+Funder = false
+Sponsor = true
+
+
+
+
+[[Contributors]]
+Key = 'HollowayKeanHo'
+
+[Contributors.Contribution]
+Creation = true
+Contact = false
+Artwork = false
+Knowledge = true
+Editor = true
+Developer = false
+Maintainer = false
+Producer = false
+Provider = false
+Publisher = false
+Funder = false
+Sponsor = false

--- a/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__data.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__data.toml
@@ -1,0 +1,2 @@
+[Dataset]
+Path = 'hestiaGUI.zoralabNOTE_SUCCESS'

--- a/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__languages.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = '/en/specs/hestiagui/zoralabnote_success'
+
+[zh-Hans]
+URL = '/zh-hans/specs/hestiagui/zoralabnote_success'

--- a/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__page.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__page.toml
@@ -1,0 +1,125 @@
+# PAGE METADATA
+# =============
+# Date fields.
+#
+# NOTE:
+#   1. You can generate date easily on linux using '$ date' command.
+#   2. If date field is left blank, the current time shall be used instead.
+#   3. Date should ONLY comply to this pattern when manually constructed:
+#                    Thu 21 Jul 2022 14:27:39 PM +08
+[Date]
+Created   = "Tue 13 Dec 2022 01:31:05 PM +08"
+Published = "Tue 13 Dec 2022 01:31:05 PM +08"
+
+
+
+
+# Content fields.
+# NOTE:
+#   1. For .Title, Hestia's string processing using page variables are allowed
+#      and only limited to .Titles sub-fields.
+#   2. For .Keywords, Hestia's string processing using page variables are
+#      allowed but strongly discouraged.
+[Content]
+Title = "zoralabNOTE_SUCCESS Technical Specification - ZORALab's Hestia"
+Keywords = [
+	'zoralabNOTE_SUCCESS',
+	'hestiaGUI',
+	'Technical Specifications',
+	'Specifications',
+	'Web',
+	'Tech',
+	'PWA',
+	'WASM',
+	'Software Libraries',
+	'Hugo',
+	'Go',
+	'TinyGo',
+	'Nim',
+	'ZORALab',
+	"ZORALab's Hestia",
+]
+
+
+
+
+# Description fields.
+# NOTE:
+#   1. Hestia's string processing using page variables are allowed.
+#   2. The .Description.Pitch is at maximum 160 characters.
+#   3. The .Description.Summary is at maximum of 250 characters.
+#   4. All fields shall have their whitespace cleansed during the processing.
+[Description]
+Pitch = '''
+The technical specifications to refer when using the package.
+'''
+Summary = '''
+Easy-going, offline supported (via web PWA installation), and detailed oriented.
+Courtesy from ZORALab's Hestia.
+'''
+
+
+
+
+# Redirect fields.
+# NOTE:
+#   1. Hestia's URL processing is allowed for .URL field.
+#   2. .Delay timing sets the delay time before redirect. Setting to '0' means
+#      an immediate redirect is requested.
+#   3. Redirect is only available if .Enabled is set to 'true'.
+#   4. Redirect.Language is to redirect the current page to its
+#      language-specific page when Javascript is made available on client side
+#      or fallback to default language.
+[Redirect]
+Delay = 0 # second
+URL = ''
+Enabled = false
+
+[Redirect.Language]
+Enabled = false
+
+
+
+
+# Content Files' Sourcing Location
+# NOTE:
+#   1. To denote where are the content sources.
+#   2. If you're sourcing from assets directory, prefix 'assets/'.
+#   3. If you're sourcing from layouts directory, prefix 'layouts/'.
+#   2. If you're sourcing from static directory, prefix 'static/'.
+#   3. If you're sourcing from partial directory, prefix 'layouts/partials/'.
+[Sources]
+HTML = 'layouts/content/specs/zoralab/index.html'
+JSON = 'layouts/content/specs/zoralab/index.json'
+CSS = 'layouts/content/specs/zoralab/index.css'
+JS = 'layouts/content/specs/zoralab/index.js'
+LDJSON = '__content.hestiaLDJSON'
+Contributors = '__contributors.toml'
+Thumbnails = '__thumbnails.toml'
+Languages = '__languages.toml'
+Assets = 'layouts/content/specs/zoralab/assets.toml'
+Components = 'layouts/content/specs/zoralab/components.toml'
+
+
+
+
+# Data fields.
+# NOTE:
+#   1. List only the page-level data files. It can be in any of the following
+#      formats: '.json', '.toml', or '.yaml'.
+#   2. Hestia string processing is available and shall be processed prior to
+#      dataset transformation.
+#   3. Sequences of the .Data array dictates sequences of loading and overriding
+#      (the latter shall overwrite the former for the same data fields).
+#   4. The final processed dataset shall be served as main data content in
+#      supported output format (e.g. index.json).
+#   5. Missing data file shall be ignored.
+#   6. To add more data files, simply duplicate and add more .Data array entry.
+#      Example:
+#                             [[data]]
+#                             Filename = 'file1.json'
+#
+#                             [[data]]
+#                             Filename = 'file2.toml'
+[[Data]]
+Filename = '__data.toml'

--- a/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__robots.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__thumbnails.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/thumbnails-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/thumbnails-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/thumbnails-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__twitter.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__wasm.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/_index.html
+++ b/sites/content/en/specs/hestiaGUI/zoralabNOTE_SUCCESS/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++

--- a/sites/data/Specs/hestiaGUI/zoralabNOTE_SUCCESS/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabNOTE_SUCCESS/Designs.toml
@@ -1,0 +1,459 @@
+[[EN.List]]
+Title = 'Designers'
+HTML = '''
+This component was designed by the following creators:
+'''
+Plain = '''
+This component was designed by the following creators:
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = 'https://www.hollowaykeanho.com/en/'
+Label = '(Holloway) Chew, Kean Ho'
+
+
+[[ZH-HANS.List]]
+Title = '设计师'
+HTML = '''
+这个元件的设计是由以下的创造者所建设的：
+'''
+Plain = '''
+这个元件的设计是由以下的创造者所建设的：
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = 'https://www.hollowaykeanho.com/zh-hans/'
+Label = '(Holloway) 周健豪'
+
+
+
+
+[[EN.List]]
+Title = 'Dependencies'
+HTML = '''
+This component has the following dependencies (arranged in the order from
+left-top to right-bottom):
+'''
+Plain = '''
+This component has the following dependencies (arranged in the order from
+left-top to right-bottom):
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = '/en/specs/hestiagui/zoralabcore/'
+Label = 'zoralabCORE'
+
+[[EN.List.URL]]
+Value = '/en/specs/hestiagui/zoralabnote/'
+Label = 'zoralabNOTE'
+
+
+[[ZH-HANS.List]]
+Title = '依赖其他元件'
+HTML = '''
+这个元件是需要以下的其他元件才能好好的运行 (排序从‘左上到右下’）：
+'''
+Plain = '''
+这个元件是需要以下的其他元件才能好好的运行 (排序从‘左上到右下’）：
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = '/zh-hans/specs/hestiagui/zoralabcore/'
+Label = 'zoralabCORE'
+
+[[ZH-HANS.List.URL]]
+Value = '/zh-hans/specs/hestiagui/zoralabnote/'
+Label = 'zoralabNOTE'
+
+
+
+
+[[EN.List]]
+Title = 'HTML'
+HTML = '''
+For HTML, ZORALab's Hestia employs the W3C native syntax for simplicity and
+maximum compatibility sakes. ZORALab's Hestia recommends the following HTML code
+structure for this component.
+'''
+Plain = '''
+For HTML, ZORALab's Hestia employs the W3C native syntax for simplicity and
+maximum compatibility sakes. ZORALab's Hestia recommends the following HTML code
+structure for this component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'HTML'
+HTML = '''
+至于HTML，为了简单化和最大的兼容性整个用法，ZORALab赫斯提亚运用W3C的语法。我们
+推荐您用以下的HTML代码来运用这个界面元件。
+'''
+Plain = '''
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Minimum HTML'
+HTML = '''
+The minimum required HTML codes are shown below:
+'''
+Plain = '''
+The minimum required HTML codes are shown below:
+'''
+Code = '''
+<div class="note success">
+	... same as zoralabNOTE ...
+</div>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '最小的HTML'
+HTML = '''
+在最小的HTML代码运用方法如下：
+'''
+Plain = '''
+在最小的HTML代码运用方法如下：
+'''
+Code = '''
+<div class="note success">
+	... 与zoralabNOTE一样 ...
+</div>
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'CSS'
+HTML = '''
+ZORALab's Hestia heavily rely on CSS to style this component and offering its
+css variables for customizations. Below are the list of available CSS variables
+at your disposal.
+'''
+Plain = '''
+ZORALab's Hestia heavily rely on CSS to style this component and offering its
+css variables for customizations. Below are the list of available CSS variables
+at your disposal.
+'''
+Code = '''
+'''
+
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+[[ZH-HANS.List]]
+Title = 'GUI界面一定要自选性'
+HTML = '''
+GUI界面元件主要是给那些没有科技文学的顾客可以方便使用某个科技。如此以来，一个科技
+产品必须能处理和互相交易数据就行了。然后呢，GUI界面就有用户者来自选服务就行了。
+'''
+Plain = '''
+GUI界面元件主要是给那些没有科技文学的顾客可以方便使用某个科技。如此以来，一个科技
+产品必须能处理和互相交易数据就行了。然后呢，GUI界面就有用户者来自选服务就行了。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Title Border Color'
+HTML = '''
+Affects the title's border color of the rendered component.
+'''
+Plain = '''
+Affects the title's border color of the rendered component.
+'''
+Code = '''
+VARIABLE     : --note-title-success-border-color
+CSS PROPERTY : border-color
+DEFAULT      : var(--body-color-indicator-green-inverted) (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '标题Border Color'
+HTML = '''
+影响元件标题边界线的颜色。
+'''
+Plain = '''
+影响元件标题边界线的颜色。
+'''
+Code = '''
+变化值     : --note-title-success-border-color
+CSS属性    : border-color
+默认数码   : var(--body-color-indicator-green-inverted) (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Title Color'
+HTML = '''
+Affects the title's color of the rendered component.
+'''
+Plain = '''
+Affects the title's color of the rendered component.
+'''
+Code = '''
+VARIABLE     : --note-title-success-color
+CSS PROPERTY : color
+DEFAULT      : #FFF (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '标题Color'
+HTML = '''
+影响元件标题的颜色。
+'''
+Plain = '''
+影响元件标题的颜色。
+'''
+Code = '''
+变化值     : --note-title-success-color
+CSS属性    : color
+默认数码   : #FFF (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Title Indicator Color'
+HTML = '''
+Affects the title indicator's color of the rendered component.
+'''
+Plain = '''
+Affects the title indicator's color of the rendered component.
+'''
+Code = '''
+VARIABLE     : --note-title-success-indicator-color
+CSS PROPERTY : color
+DEFAULT      : #FFF (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '标题指示器Color'
+HTML = '''
+影响元件标题指示器的颜色。
+'''
+Plain = '''
+影响元件标题指示器的颜色。
+'''
+Code = '''
+变化值     : --note-title-success-indicator-color
+CSS属性    : color
+默认数码   : #FFF (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Title Background'
+HTML = '''
+Affects the title's background of the rendered component.
+'''
+Plain = '''
+Affects the title's background of the rendered component.
+'''
+Code = '''
+VARIABLE     : --note-title-success-background
+CSS PROPERTY : background
+DEFAULT      : var(--body-background-indicator-green-inverted) (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '标题Background'
+HTML = '''
+影响元件标题的背景。
+'''
+Plain = '''
+影响元件标题的背景。
+'''
+Code = '''
+变化值     : --note-title-success-background
+CSS属性    : background
+默认数码   : var(--body-background-indicator-green-inverted) (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Content Color'
+HTML = '''
+Affects the content's color of the rendered component.
+'''
+Plain = '''
+Affects the content's color of the rendered component.
+'''
+Code = '''
+VARIABLE     : --note-content-success-color
+CSS PROPERTY : color
+DEFAULT      : var(--body-color-indicator-green-inverted) (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '内容Color'
+HTML = '''
+影响元件内容的颜色。
+'''
+Plain = '''
+影响元件内容的颜色。
+'''
+Code = '''
+变化值     : --note-content-success-color
+CSS属性    : color
+默认数码   : var(--body-color-indicator-green-inverted) (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Content Background'
+HTML = '''
+Affects the content's background of the rendered component.
+'''
+Plain = '''
+Affects the content's background of the rendered component.
+'''
+Code = '''
+VARIABLE     : --note-content-success-background
+CSS PROPERTY : background
+DEFAULT      : var(--body-background-indicator-green) (>= v1.0.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '内容Background'
+HTML = '''
+影响元件内容的背景。
+'''
+Plain = '''
+影响元件内容的背景。
+'''
+Code = '''
+变化值     : --note-content-success-background
+CSS属性    : background
+默认数码   : var(--body-background-indicator-green) (>= v1.0.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'JavaScript'
+HTML = '''
+Fortunately, this component does not use any JavaScript. Relax.
+'''
+Plain = '''
+Fortunately, this component does not use any JavaScript. Relax.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'JavaScript'
+HTML = '''
+庆幸的是这个元件没有运用到任何JavaScript。放心吧！
+'''
+Plain = '''
+庆幸的是这个元件没有运用到任何JavaScript。放心吧！
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/data/Specs/hestiaGUI/zoralabNOTE_SUCCESS/Functions.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabNOTE_SUCCESS/Functions.toml
@@ -1,0 +1,138 @@
+[[EN.List]]
+Title = 'ToCSS'
+HTML = '''
+Render the CSS output for this UI component.
+'''
+Plain = '''
+Render the CSS output for this UI component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'ToCSS'
+HTML = '''
+渲染呈现CSS的输出数据。
+'''
+Plain = '''
+渲染呈现CSS的输出数据。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+Usage example:
+'''
+Plain = '''
+Usage example:
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabNOTE_SUCCESS/ToCSS" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+用法：
+'''
+Plain = '''
+用法：
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabNOTE_SUCCESS/ToCSS" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'ToCSS_VARIABLES'
+HTML = '''
+Render the CSS variables output list for this UI component.
+'''
+Plain = '''
+Render the CSS variables output list for this UI component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'ToCSS_VARIABLES'
+HTML = '''
+渲染呈现CSS变化值数据的输出菜单。
+'''
+Plain = '''
+渲染呈现CSS变化值数据的输出菜单。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+Usage example:
+'''
+Plain = '''
+Usage example:
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabNOTE_SUCCESS/ToCSS_VARIABLES" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+用法：
+'''
+Plain = '''
+用法：
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabNOTE_SUCCESS/ToCSS_VARIABLES" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/data/Specs/hestiaGUI/zoralabNOTE_SUCCESS/Metadata.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabNOTE_SUCCESS/Metadata.toml
@@ -1,0 +1,14 @@
+[EN.Brand]
+ID = 'zoralabnote_success'
+SKU = 'zoralabNOTE_SUCCESS'
+Description = '''
+For styling a green notice.
+'''
+
+
+[ZH-HANS.Brand]
+ID = 'zoralabnote_success'
+SKU = 'zoralabNOTE_SUCCESS'
+Description = '''
+来渲染青色通告。
+'''

--- a/sites/data/Specs/hestiaGUI/zoralabNOTE_SUCCESS/Purposes.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabNOTE_SUCCESS/Purposes.toml
@@ -1,0 +1,115 @@
+[[EN.List]]
+Title = 'Main Purpose'
+HTML = '''
+This package's primary purpose is to provide user interface (UI) styling
+specifically for green notice values. In web UI, it is shown as follows:
+<br/><br/>
+<div class="note success">
+	<input id="note-example-uid1" type="checkbox" checked="">
+	<label for="note-example-uid1">A Moment Please</label>
+	<p class="content">
+		This is an important note for you to pay attention to. Just in
+		case, you can minimize this note if required. It is set to open
+		by default. Try clicking on the title.
+	</p>
+</div>
+'''
+Plain = '''
+This package's primary purpose is to provide user interface (UI) styling
+specifically for green notice values. In web UI, it is shown as follows:
+
+<div class="note success">
+	<input id="note-example-uid1" type="checkbox" checked="">
+	<label for="note-example-uid1">A Moment Please</label>
+	<p class="content">
+		This is an important note for you to pay attention to. Just in
+		case, you can minimize this note if required. It is set to open
+		by default. Try clicking on the title.
+	</p>
+</div>
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = '主要目的'
+HTML = '''
+这个软件包的出生主要是支持渲染青色通告的界面元件。在网络界面世界里，这元件的成果
+如下：
+<br/><br/>
+<div class="note success">
+	<input id="note-example-uid1" type="checkbox" checked="">
+	<label for="note-example-uid1">请稍等一下</label>
+	<p class="content">
+		这是个很重要的通告。如果您还没注意到，它是可以开关的。请试试往
+		那标题按一按。
+	</p>
+</div>
+'''
+Plain = '''
+这个软件包的出生主要是支持渲染青色通告的界面元件。在网络界面世界里，这元件的成果
+如下：
+
+<div class="note success">
+	<input id="note-example-uid1" type="checkbox" checked="">
+	<label for="note-example-uid1">请稍等一下</label>
+	<p class="content">
+		这是个很重要的通告。如果您还没注意到，它是可以开关的。请试试往
+		那标题按一按。
+	</p>
+</div>
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'Legacy Recording'
+HTML = '''
+This package was known as <code>note-success_hestiaUI</code> before
+ZORALab's Hestia <code>v1.2.0</code>. The transformation was due to someone
+attempting to steal the copyrights and makes way for programming package's
+documentation restructuring.
+'''
+Plain = '''
+This package was known as 'note-success_hestiaUI' before
+ZORALab's Hestia 'v1.2.0'. The transformation was due to someone attempting to
+steal the design copyrights and makes way for programming package's
+documentation restructuring.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = '历史遗录'
+HTML = '''
+这个软件包在ZORALab赫斯提亚<code>v1.2.0</code>版本之前曾经被名为
+<code>note-success_hestiaUI</code>。改名的目的是有人要横行强盗设计的版权和为了
+编程文件编写能力而整理过。
+'''
+Plain = '''
+这个软件包在ZORALab赫斯提亚v1.2.0版本之前曾经被名为note-success_hestiaUI。改名的
+目的是有人要横行强盗设计的版权和为了编程文件编写能力而整理过。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/layouts/content/specs/zoralab/components.toml
+++ b/sites/layouts/content/specs/zoralab/components.toml
@@ -141,3 +141,8 @@ Variables = []
 Name = "zoralabNOTE_WARNING"
 Include = true
 Variables = []
+
+[[List]]
+Name = "zoralabNOTE_SUCCESS"
+Include = true
+Variables = []


### PR DESCRIPTION
Since the /en/specs/hestiaGUI/ page and
/en/specs/hestiaGUI/zoralabNOTE page are ready, we can proceed to port zoralabNOTE_ERROR spec page. Hence, let's do this.

This patch ports /en/specs/hestiaGUI/zoralabNOTE_SUCCESS/ spec page into sites/ directory.