### PR TITLE
sites: ported /en/specs/hestiaGUI/zoralabDRAWER_RIGHT/ page

### DIFF
--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__content.hestiaLDJSON
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__content.hestiaLDJSON
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (partial "hestiaJSON/schemaorgLDJSON/WebPage" .) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__contributors.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__contributors.toml
@@ -1,0 +1,78 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...
+[[Contributors]]
+Key = 'ZORALab'
+
+[Contributors.Contribution]
+Creation = true
+Contact = true
+Artwork = false
+Knowledge = false
+Editor = true
+Developer = false
+Maintainer = false
+Producer = true
+Provider = true
+Publisher = true
+Funder = false
+Sponsor = true
+
+
+
+
+[[Contributors]]
+Key = 'HollowayKeanHo'
+
+[Contributors.Contribution]
+Creation = true
+Contact = false
+Artwork = false
+Knowledge = true
+Editor = true
+Developer = false
+Maintainer = false
+Producer = false
+Provider = false
+Publisher = false
+Funder = false
+Sponsor = false

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__data.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__data.toml
@@ -1,0 +1,2 @@
+[Dataset]
+Path = 'hestiaGUI.zoralabDRAWER_RIGHT'

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__languages.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = '/en/specs/hestiagui/zoralabdrawer_right'
+
+[zh-Hans]
+URL = '/zh-hans/specs/hestiagui/zoralabdrawer_right'

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__page.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__page.toml
@@ -1,0 +1,125 @@
+# PAGE METADATA
+# =============
+# Date fields.
+#
+# NOTE:
+#   1. You can generate date easily on linux using '$ date' command.
+#   2. If date field is left blank, the current time shall be used instead.
+#   3. Date should ONLY comply to this pattern when manually constructed:
+#                    Thu 21 Jul 2022 14:27:39 PM +08
+[Date]
+Created   = "Fri 16 Dec 2022 06:01:48 AM +08"
+Published = "Fri 16 Dec 2022 06:01:48 AM +08"
+
+
+
+
+# Content fields.
+# NOTE:
+#   1. For .Title, Hestia's string processing using page variables are allowed
+#      and only limited to .Titles sub-fields.
+#   2. For .Keywords, Hestia's string processing using page variables are
+#      allowed but strongly discouraged.
+[Content]
+Title = "zoralabDRAWER_RIGHT Technical Specification - ZORALab's Hestia"
+Keywords = [
+	'zoralabDRAWER_RIGHT',
+	'hestiaGUI',
+	'Technical Specifications',
+	'Specifications',
+	'Web',
+	'Tech',
+	'PWA',
+	'WASM',
+	'Software Libraries',
+	'Hugo',
+	'Go',
+	'TinyGo',
+	'Nim',
+	'ZORALab',
+	"ZORALab's Hestia",
+]
+
+
+
+
+# Description fields.
+# NOTE:
+#   1. Hestia's string processing using page variables are allowed.
+#   2. The .Description.Pitch is at maximum 160 characters.
+#   3. The .Description.Summary is at maximum of 250 characters.
+#   4. All fields shall have their whitespace cleansed during the processing.
+[Description]
+Pitch = '''
+The technical specifications to refer when using the package.
+'''
+Summary = '''
+Easy-going, offline supported (via web PWA installation), and detailed oriented.
+Courtesy from ZORALab's Hestia.
+'''
+
+
+
+
+# Redirect fields.
+# NOTE:
+#   1. Hestia's URL processing is allowed for .URL field.
+#   2. .Delay timing sets the delay time before redirect. Setting to '0' means
+#      an immediate redirect is requested.
+#   3. Redirect is only available if .Enabled is set to 'true'.
+#   4. Redirect.Language is to redirect the current page to its
+#      language-specific page when Javascript is made available on client side
+#      or fallback to default language.
+[Redirect]
+Delay = 0 # second
+URL = ''
+Enabled = false
+
+[Redirect.Language]
+Enabled = false
+
+
+
+
+# Content Files' Sourcing Location
+# NOTE:
+#   1. To denote where are the content sources.
+#   2. If you're sourcing from assets directory, prefix 'assets/'.
+#   3. If you're sourcing from layouts directory, prefix 'layouts/'.
+#   2. If you're sourcing from static directory, prefix 'static/'.
+#   3. If you're sourcing from partial directory, prefix 'layouts/partials/'.
+[Sources]
+HTML = 'layouts/content/specs/zoralab/index.html'
+JSON = 'layouts/content/specs/zoralab/index.json'
+CSS = 'layouts/content/specs/zoralab/index.css'
+JS = 'layouts/content/specs/zoralab/index.js'
+LDJSON = '__content.hestiaLDJSON'
+Contributors = '__contributors.toml'
+Thumbnails = '__thumbnails.toml'
+Languages = '__languages.toml'
+Assets = 'layouts/content/specs/zoralab/assets.toml'
+Components = 'layouts/content/specs/zoralab/components.toml'
+
+
+
+
+# Data fields.
+# NOTE:
+#   1. List only the page-level data files. It can be in any of the following
+#      formats: '.json', '.toml', or '.yaml'.
+#   2. Hestia string processing is available and shall be processed prior to
+#      dataset transformation.
+#   3. Sequences of the .Data array dictates sequences of loading and overriding
+#      (the latter shall overwrite the former for the same data fields).
+#   4. The final processed dataset shall be served as main data content in
+#      supported output format (e.g. index.json).
+#   5. Missing data file shall be ignored.
+#   6. To add more data files, simply duplicate and add more .Data array entry.
+#      Example:
+#                             [[data]]
+#                             Filename = 'file1.json'
+#
+#                             [[data]]
+#                             Filename = 'file2.toml'
+[[Data]]
+Filename = '__data.toml'

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__robots.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__thumbnails.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/thumbnails-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/thumbnails-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/thumbnails-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__twitter.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__wasm.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/_index.html
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_RIGHT/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++

--- a/sites/data/Specs/hestiaGUI/zoralabDRAWER_RIGHT/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabDRAWER_RIGHT/Designs.toml
@@ -1,0 +1,1469 @@
+[[EN.List]]
+Title = 'Designers'
+HTML = '''
+This component was designed by the following creators:
+'''
+Plain = '''
+This component was designed by the following creators:
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = 'https://www.hollowaykeanho.com/en/'
+Label = '(Holloway) Chew, Kean Ho'
+
+
+[[ZH-HANS.List]]
+Title = '设计师'
+HTML = '''
+这个元件的设计是由以下的创造者所建设的：
+'''
+Plain = '''
+这个元件的设计是由以下的创造者所建设的：
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = 'https://www.hollowaykeanho.com/zh-hans/'
+Label = '(Holloway) 周健豪'
+
+
+
+
+[[EN.List]]
+Title = 'Dependencies'
+HTML = '''
+This component has the following dependencies (arranged in the order from
+left-top to right-bottom):
+'''
+Plain = '''
+This component has the following dependencies (arranged in the order from
+left-top to right-bottom):
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = '/en/specs/hestiagui/zoralabcore/'
+Label = 'zoralabCORE'
+
+[[EN.List.URL]]
+Value = '/en/specs/hestiagui/zoralabdrawer/'
+Label = 'zoralabDRAWER'
+
+
+[[ZH-HANS.List]]
+Title = '依赖其他元件'
+HTML = '''
+这个元件是需要以下的其他元件才能好好的运行 (排序从‘左上到右下’）：
+'''
+Plain = '''
+这个元件是需要以下的其他元件才能好好的运行 (排序从‘左上到右下’）：
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = '/zh-hans/specs/hestiagui/zoralabcore/'
+Label = 'zoralabCORE'
+
+[[ZH-HANS.List.URL]]
+Value = '/zh-hans/specs/hestiagui/zoralabdrawer/'
+Label = 'zoralabDRAWER'
+
+
+
+
+[[EN.List]]
+Title = 'HTML'
+HTML = '''
+This component does not need any HTML codes. Relax.
+'''
+Plain = '''
+This component does not need any HTML codes. Relax.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'HTML'
+HTML = '''
+这个元件是没有需要任何HTML代码。放心吧！
+'''
+Plain = '''
+这个元件是没有需要任何HTML代码。放心吧！
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'CSS'
+HTML = '''
+ZORALab's Hestia heavily rely on CSS to style this component and offering its
+css variables for customizations. Below are the list of available CSS variables
+at your disposal.
+'''
+Plain = '''
+ZORALab's Hestia heavily rely on CSS to style this component and offering its
+css variables for customizations. Below are the list of available CSS variables
+at your disposal.
+'''
+Code = '''
+'''
+
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+[[ZH-HANS.List]]
+Title = 'GUI界面一定要自选性'
+HTML = '''
+GUI界面元件主要是给那些没有科技文学的顾客可以方便使用某个科技。如此以来，一个科技
+产品必须能处理和互相交易数据就行了。然后呢，GUI界面就有用户者来自选服务就行了。
+'''
+Plain = '''
+GUI界面元件主要是给那些没有科技文学的顾客可以方便使用某个科技。如此以来，一个科技
+产品必须能处理和互相交易数据就行了。然后呢，GUI界面就有用户者来自选服务就行了。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Z-Index'
+HTML = '''
+Affects the z-index of the rendered component.
+'''
+Plain = '''
+Affects the z-index of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-z-index
+CSS PROPERTY : z-index
+DEFAULT      : var(--drawer-z-index) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Z-Index'
+HTML = '''
+影响元件的z-index设置。
+'''
+Plain = '''
+影响元件的z-index设置。
+'''
+Code = '''
+变化值     : --right-drawer-z-index
+CSS属性    : z-index
+默认数码   : var(--drawer-z-index) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Z-Index (Opened)'
+HTML = '''
+Affects the z-index of the rendered component when opened.
+'''
+Plain = '''
+Affects the z-index of the rendered component when opened.
+'''
+Code = '''
+VARIABLE     : --right-drawer-z-index-opened
+CSS PROPERTY : z-index
+DEFAULT      : var(--drawer-z-index-opened) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Z-Index (Opened)'
+HTML = '''
+影响元件在打开情况里的z-index设置。
+'''
+Plain = '''
+影响元件在打开情况里的z-index设置。
+'''
+Code = '''
+变化值     : --right-drawer-z-index-opened
+CSS属性    : z-index
+默认数码   : var(--drawer-z-index-opened) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Width'
+HTML = '''
+Affects the width of the rendered component (when closed).
+'''
+Plain = '''
+Affects the width of the rendered component (when closed).
+'''
+Code = '''
+VARIABLE     : --right-drawer-width
+CSS PROPERTY : width
+DEFAULT      : 0 (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Width'
+HTML = '''
+影响元件（在关闭时）的宽度。
+'''
+Plain = '''
+影响元件（在关闭时）的宽度。
+'''
+Code = '''
+变化值     : --right-drawer-width
+CSS属性    : width
+默认数码   : 0 (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Width (Opened)'
+HTML = '''
+Affects the width of the rendered component when opened.
+'''
+Plain = '''
+Affects the width of the rendered component when opened.
+'''
+Code = '''
+VARIABLE     : --right-drawer-width-opened
+CSS PROPERTY : width
+DEFAULT      : 90vw (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Width (Opened)'
+HTML = '''
+影响元件在打开时的宽度。
+'''
+Plain = '''
+影响元件在打开时的宽度。
+'''
+Code = '''
+变化值     : --right-drawer-width-opened
+CSS属性    : width
+默认数码   : 90vw (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Height'
+HTML = '''
+Affects the height of the rendered component (when closed).
+'''
+Plain = '''
+Affects the height of the rendered component (when closed).
+'''
+Code = '''
+VARIABLE     : --right-drawer-height
+CSS PROPERTY : height
+DEFAULT      : 100% (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Height'
+HTML = '''
+影响元件（在关闭时）的长度。
+'''
+Plain = '''
+影响元件（在关闭时）的长度。
+'''
+Code = '''
+变化值     : --right-drawer-height
+CSS属性    : height
+默认数码   : 100% (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Height (Opened)'
+HTML = '''
+Affects the height of the rendered component when opened.
+'''
+Plain = '''
+Affects the height of the rendered component when opened.
+'''
+Code = '''
+VARIABLE     : --right-drawer-height-opened
+CSS PROPERTY : height
+DEFAULT      : var(--right-drawer-height) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Height (Opened)'
+HTML = '''
+影响元件在打开时的长度。
+'''
+Plain = '''
+影响元件在打开时的长度。
+'''
+Code = '''
+变化值     : --right-drawer-height-opened
+CSS属性    : height
+默认数码   : var(--right-drawer-height) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Overflow'
+HTML = '''
+Affects the overflow behavior of the rendered component.
+'''
+Plain = '''
+Affects the overflow behavior of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-overflow
+CSS PROPERTY : overflow
+DEFAULT      : hidden auto (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Overflow'
+HTML = '''
+影响元件的边界线。
+'''
+Plain = '''
+影响元件的边界线。
+'''
+Code = '''
+变化值     : --right-drawer-overflow
+CSS属性    : overflow
+默认数码   : hidden auto (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Border'
+HTML = '''
+Affects the border of the rendered component.
+'''
+Plain = '''
+Affects the border of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-border
+CSS PROPERTY : border
+DEFAULT      : var(--drawer-border) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Border'
+HTML = '''
+影响元件的边界线。
+'''
+Plain = '''
+影响元件的边界线。
+'''
+Code = '''
+变化值     : --right-drawer-border
+CSS属性    : border
+默认数码   : var(--drawer-border) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Border Radius'
+HTML = '''
+Affects the border radius of the rendered component.
+'''
+Plain = '''
+Affects the border radius of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-border-radius
+CSS PROPERTY : border-radius
+DEFAULT      : 0 var(--drawer-border-radius) var(--drawer-border-radius) 0 (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Border Radius'
+HTML = '''
+影响元件边界线的角落圆形度。
+'''
+Plain = '''
+影响元件边界线的角落圆形度。
+'''
+Code = '''
+变化值     : --right-drawer-border-radius
+CSS属性    : border-radius
+默认数码   : 0 var(--drawer-border-radius) var(--drawer-border-radius) 0 (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Color'
+HTML = '''
+Affects the color of the rendered component.
+'''
+Plain = '''
+Affects the color of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-color
+CSS PROPERTY : color
+DEFAULT      : var(--drawer-color) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Color'
+HTML = '''
+影响元件的颜色。
+'''
+Plain = '''
+影响元件的颜色。
+'''
+Code = '''
+变化值     : --right-drawer-color
+CSS属性    : color
+默认数码   : var(--drawer-color) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Background'
+HTML = '''
+Affects the background of the rendered component.
+'''
+Plain = '''
+Affects the background of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-background
+CSS PROPERTY : background
+DEFAULT      : var(--drawer-background) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Background'
+HTML = '''
+影响元件的背景。
+'''
+Plain = '''
+影响元件的背景。
+'''
+Code = '''
+变化值     : --right-drawer-background
+CSS属性    : background
+默认数码   : var(--drawer-background) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Box Shadow'
+HTML = '''
+Affects the box shadow of the rendered component.
+'''
+Plain = '''
+Affects the box shadow of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-box-shadow
+CSS PROPERTY : box-shadow
+DEFAULT      : var(--drawer-box-shadow) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Box Shadow'
+HTML = '''
+影响元件的影子。
+'''
+Plain = '''
+影响元件的影子。
+'''
+Code = '''
+变化值     : --right-drawer-box-shadow
+CSS属性    : box-shadow
+默认数码   : var(--drawer-box-shadow) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Transition'
+HTML = '''
+Affects the animation timing of the rendered component.
+'''
+Plain = '''
+Affects the animation timing of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-transition
+CSS PROPERTY : transition
+DEFAULT      : var(--drawer-transition) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Transition'
+HTML = '''
+影响元件的动画定时。
+'''
+Plain = '''
+影响元件的动画定时。
+'''
+Code = '''
+变化值     : --right-drawer-transition
+CSS属性    : transition
+默认数码   : var(--drawer-transition) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Width (Trigger)'
+HTML = '''
+Affects the trigger's width of the rendered component.
+'''
+Plain = '''
+Affects the trigger's width of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-width
+CSS PROPERTY : width
+DEFAULT      : var(--drawer-trigger-width) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Width（触发器）'
+HTML = '''
+影响元件触发器的宽度。
+'''
+Plain = '''
+影响元件触发器的宽度。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-width
+CSS属性    : width
+默认数码   : var(--drawer-trigger-width) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Height (Trigger)'
+HTML = '''
+Affects the trigger's height of the rendered component.
+'''
+Plain = '''
+Affects the trigger's height of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-height
+CSS PROPERTY : height
+DEFAULT      : var(--drawer-trigger-height) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Height（触发器）'
+HTML = '''
+影响元件触发器的长度。
+'''
+Plain = '''
+影响元件触发器的长度。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-height
+CSS属性    : height
+默认数码   : var(--drawer-trigger-height) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Top Position (Trigger)'
+HTML = '''
+Affects the trigger's top position of the rendered component.
+'''
+Plain = '''
+Affects the trigger's top position of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-position-top
+CSS PROPERTY : top
+DEFAULT      : 50% (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Top Position (Trigger)'
+HTML = '''
+影响元件触发器的顶向位置。
+'''
+Plain = '''
+影响元件触发器的顶向位置。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-position-top
+CSS属性    : top
+默认数码   : 50% (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Left Position (Trigger)'
+HTML = '''
+Affects the trigger's left position of the rendered component.
+'''
+Plain = '''
+Affects the trigger's left position of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-position-left
+CSS PROPERTY : left
+DEFAULT      : unset (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Left Position (Trigger)'
+HTML = '''
+影响元件触发器的左向位置。
+'''
+Plain = '''
+影响元件触发器的左向位置。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-position-left
+CSS属性    : left
+默认数码   : unset (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Bottom Position (Trigger)'
+HTML = '''
+Affects the trigger's bottom position of the rendered component.
+'''
+Plain = '''
+Affects the trigger's bottom position of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-position-bottom
+CSS PROPERTY : bottom
+DEFAULT      : unset (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Bottom Position (Trigger)'
+HTML = '''
+影响元件触发器的底向位置。
+'''
+Plain = '''
+影响元件触发器的底向位置。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-position-bottom
+CSS属性    : bottom
+默认数码   : unset (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Right Position (Trigger)'
+HTML = '''
+Affects the trigger's right position of the rendered component.
+'''
+Plain = '''
+Affects the trigger's right position of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-position-right
+CSS PROPERTY : right
+DEFAULT      : 0 (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Right Position (Trigger)'
+HTML = '''
+影响元件触发器的右向位置。
+'''
+Plain = '''
+影响元件触发器的右向位置。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-position-right
+CSS属性    : right
+默认数码   : 0 (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Z-Index (Trigger)'
+HTML = '''
+Affects the trigger's z-index of the rendered component.
+'''
+Plain = '''
+Affects the trigger's z-index of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-z-index
+CSS PROPERTY : z-index
+DEFAULT      : var(--drawer-trigger-z-index) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Z-Index (Trigger)'
+HTML = '''
+影响元件触发器的z-index设置。
+'''
+Plain = '''
+影响元件触发器的z-index设置。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-z-index
+CSS属性    : z-index
+默认数码   : var(--drawer-trigger-z-index) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Border (Trigger)'
+HTML = '''
+Affects the trigger's border of the rendered component.
+'''
+Plain = '''
+Affects the trigger's border of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-border
+CSS PROPERTY : border
+DEFAULT      : unset (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Border（触发器）'
+HTML = '''
+影响元件触发器的边界线。
+'''
+Plain = '''
+影响元件触发器的边界线。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-border
+CSS属性    : border
+默认数码   : unset (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Border Radius (Trigger)'
+HTML = '''
+Affects the trigger's border radius of the rendered component.
+'''
+Plain = '''
+Affects the trigger's border radius of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-border-radius
+CSS PROPERTY : border-radius
+DEFAULT      : var(--drawer-trigger-border-radius) 0 0 var(--drawer-trigger-border-radius) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Border Radius（触发器）'
+HTML = '''
+影响元件触发器的角落圆形度。
+'''
+Plain = '''
+影响元件触发器的角落圆形度。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-border-radius
+CSS属性    : border-radius
+默认数码   : var(--drawer-trigger-border-radius) 0 0 var(--drawer-trigger-border-radius) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Font Size (Trigger)'
+HTML = '''
+Affects the trigger's font size of the rendered component.
+'''
+Plain = '''
+Affects the trigger's font size of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-font-size
+CSS PROPERTY : font-size
+DEFAULT      : var(--drawer-trigger-font-size) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Font Size（触发器）'
+HTML = '''
+影响元件触发器的字体大小。
+'''
+Plain = '''
+影响元件触发器的字体大小。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-font-size
+CSS属性    : font-size
+默认数码   : var(--drawer-trigger-font-size) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Font Style (Trigger)'
+HTML = '''
+Affects the trigger's font style of the rendered component.
+'''
+Plain = '''
+Affects the trigger's font style of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-font-style
+CSS PROPERTY : font-style
+DEFAULT      : var(--drawer-trigger-font-style) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Font Style（触发器）'
+HTML = '''
+影响元件触发器的字体风格。
+'''
+Plain = '''
+影响元件触发器的字体风格。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-font-style
+CSS属性    : font-style
+默认数码   : var(--drawer-trigger-font-style) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Color (Trigger)'
+HTML = '''
+Affects the trigger's color of the rendered component.
+'''
+Plain = '''
+Affects the trigger's color of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-color
+CSS PROPERTY : color
+DEFAULT      : var(--drawer-trigger-color) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Color （触发器）'
+HTML = '''
+影响元件触发器的颜色。
+'''
+Plain = '''
+影响元件触发器的颜色。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-color
+CSS属性    : color
+默认数码   : var(--drawer-trigger-color) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Background (Trigger)'
+HTML = '''
+Affects the trigger's background of the rendered component.
+'''
+Plain = '''
+Affects the trigger's background of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-background
+CSS PROPERTY : background
+DEFAULT      : var(--drawer-background) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Background（触发器）'
+HTML = '''
+影响元件触发器的颜色。
+'''
+Plain = '''
+影响元件触发器的颜色。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-background
+CSS属性    : background
+默认数码   : var(--drawer-background) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Box Shadow (Trigger)'
+HTML = '''
+Affects the trigger's box shadow of the rendered component.
+'''
+Plain = '''
+Affects the trigger's box shadow of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-box-shadow
+CSS PROPERTY : box-shadow
+DEFAULT      : 0 0 2rem var(--drawer-trigger-color) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Box Shadow（触发器）'
+HTML = '''
+影响元件触发器的影子。
+'''
+Plain = '''
+影响元件触发器的影子。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-box-shadow
+CSS属性    : box-shadow
+默认数码   : 0 0 2rem var(--drawer-trigger-color) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Transform (Trigger)'
+HTML = '''
+Affects the trigger's transform of the rendered component.
+'''
+Plain = '''
+Affects the trigger's transform of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-transform
+CSS PROPERTY : transform
+DEFAULT      : "" (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Transform（触发器）'
+HTML = '''
+影响元件触发器的变换形态。
+'''
+Plain = '''
+影响元件触发器的变换形态。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-transform
+CSS属性    : transform
+默认数码   : "" (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Transform (Trigger - Focus)'
+HTML = '''
+Affects the trigger's transform of the rendered component while being focused.
+'''
+Plain = '''
+Affects the trigger's transform of the rendered component while being focused.
+'''
+Code = '''
+VARIABLE     : --right-drawer-trigger-transform-focus
+CSS PROPERTY : transform
+DEFAULT      : scale(1.1) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Transform（触发器 - Focus）'
+HTML = '''
+影响元件触发器在被关注时的变换形态。
+'''
+Plain = '''
+影响元件触发器在被关注时的变换形态。
+'''
+Code = '''
+变化值     : --right-drawer-trigger-transform-focus
+CSS属性    : transform
+默认数码   : scale(1.1) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Z-Index (Overlay)'
+HTML = '''
+Affects the overlay layer's z-index of the rendered component.
+'''
+Plain = '''
+Affects the overlay layer's z-index of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-overlay-z-index
+CSS PROPERTY : z-index
+DEFAULT      : var(--drawer-overlay-z-index) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Z-Index (叠加层)'
+HTML = '''
+影响元件叠加层的z-index设置。
+'''
+Plain = '''
+影响元件叠加层的z-index设置。
+'''
+Code = '''
+变化值     : --right-drawer-overlay-z-index
+CSS属性    : z-index
+默认数码   : var(--drawer-overlay-z-index) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Color (Overlay)'
+HTML = '''
+Affects the overlay layer's color of the rendered component.
+'''
+Plain = '''
+Affects the overlay layer's color of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-overlay-color
+CSS PROPERTY : color
+DEFAULT      : var(--drawer-overlay-color) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Color （叠加层）'
+HTML = '''
+影响元件叠加层的颜色。
+'''
+Plain = '''
+影响元件叠加层的颜色。
+'''
+Code = '''
+变化值     : --right-drawer-overlay-color
+CSS属性    : color
+默认数码   : var(--drawer-overlay-color) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Background (Overlay)'
+HTML = '''
+Affects the overlay layer's background of the rendered component.
+'''
+Plain = '''
+Affects the overlay layer's background of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-overlay-background
+CSS PROPERTY : background
+DEFAULT      : var(--drawer-overlay-background) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Background （叠加层）'
+HTML = '''
+影响元件叠加层的背景。
+'''
+Plain = '''
+影响元件叠加层的背景。
+'''
+Code = '''
+变化值     : --right-drawer-overlay-background
+CSS属性    : background
+默认数码   : var(--drawer-overlay-background) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Transition (Overlay)'
+HTML = '''
+Affects the overlay layer's animation timing of the rendered component.
+'''
+Plain = '''
+Affects the overlay layer's animation timing of the rendered component.
+'''
+Code = '''
+VARIABLE     : --right-drawer-overlay-transition
+CSS PROPERTY : transition
+DEFAULT      : var(--drawer-overlay-transition) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Transition (叠加层)'
+HTML = '''
+影响元件叠加层的动画定时。
+'''
+Plain = '''
+影响元件叠加层的动画定时。
+'''
+Code = '''
+变化值     : --right-drawer-overlay-transition
+CSS属性    : transition
+默认数码   : var(--drawer-overlay-transition) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'JavaScript'
+HTML = '''
+Fortunately, this component does not use any JavaScript. Relax.
+'''
+Plain = '''
+Fortunately, this component does not use any JavaScript. Relax.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'JavaScript'
+HTML = '''
+庆幸的是这个元件没有运用到任何JavaScript。放心吧！
+'''
+Plain = '''
+庆幸的是这个元件没有运用到任何JavaScript。放心吧！
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/data/Specs/hestiaGUI/zoralabDRAWER_RIGHT/Functions.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabDRAWER_RIGHT/Functions.toml
@@ -1,0 +1,138 @@
+[[EN.List]]
+Title = 'ToCSS'
+HTML = '''
+Render the CSS output for this UI component.
+'''
+Plain = '''
+Render the CSS output for this UI component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'ToCSS'
+HTML = '''
+渲染呈现CSS的输出数据。
+'''
+Plain = '''
+渲染呈现CSS的输出数据。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+Usage example:
+'''
+Plain = '''
+Usage example:
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabDRAWER_RIGHT/ToCSS" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+用法：
+'''
+Plain = '''
+用法：
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabDRAWER_RIGHT/ToCSS" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'ToCSS_VARIABLES'
+HTML = '''
+Render the CSS variables output list for this UI component.
+'''
+Plain = '''
+Render the CSS variables output list for this UI component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'ToCSS_VARIABLES'
+HTML = '''
+渲染呈现CSS变化值数据的输出菜单。
+'''
+Plain = '''
+渲染呈现CSS变化值数据的输出菜单。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+Usage example:
+'''
+Plain = '''
+Usage example:
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabDRAWER_RIGHT/ToCSS_VARIABLES" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+用法：
+'''
+Plain = '''
+用法：
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabDRAWER_RIGHT/ToCSS_VARIABLES" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/data/Specs/hestiaGUI/zoralabDRAWER_RIGHT/Metadata.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabDRAWER_RIGHT/Metadata.toml
@@ -1,0 +1,14 @@
+[EN.Brand]
+ID = 'zoralabdrawer_right'
+SKU = 'zoralabDRAWER_RIGHT'
+Description = '''
+For styling a right-side navigation drawer.
+'''
+
+
+[ZH-HANS.Brand]
+ID = 'zoralabdrawer_right'
+SKU = 'zoralabDRAWER_RIGHT'
+Description = '''
+来渲染右边的导航抽屉。
+'''

--- a/sites/data/Specs/hestiaGUI/zoralabDRAWER_RIGHT/Purposes.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabDRAWER_RIGHT/Purposes.toml
@@ -1,0 +1,79 @@
+[[EN.List]]
+Title = 'Main Purpose'
+HTML = '''
+This package's primary purpose is to provide user interface (UI) styling
+specifically for right drawer navigator values. This page is already deployed
+all usable drawer already.
+'''
+Plain = '''
+This package's primary purpose is to provide user interface (UI) styling
+specifically for right drawer navigator values. This page is already deployed
+all usable drawer already.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = '主要目的'
+HTML = '''
+这个软件包的出生主要是支持渲染右边导航抽屉的界面元件。这网页已经在运用这个元件
+了。
+'''
+Plain = '''
+这个软件包的出生主要是支持渲染右边导航抽屉的界面元件。这网页已经在运用这个元件
+了。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'Legacy Recording'
+HTML = '''
+This package was known as a part of <code>drawer_hestiaUI</code> before
+ZORALab's Hestia <code>v1.2.0</code>. The transformation was due to someone
+attempting to steal the copyrights and makes way for programming package's
+documentation restructuring.
+'''
+Plain = '''
+This package was known as a part of 'drawer_hestiaUI' before
+ZORALab's Hestia 'v1.2.0'. The transformation was due to someone attempting to
+steal the design copyrights and makes way for programming package's
+documentation restructuring.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = '历史遗录'
+HTML = '''
+这个软件包在ZORALab赫斯提亚<code>v1.2.0</code>版本之前曾经被名为
+<code>drawer_hestiaUI</code>的其中一部。改名的目的是有人要横行强盗设计的版权和
+为了编程文件编写能力而整理过。
+'''
+Plain = '''
+这个软件包在ZORALab赫斯提亚v1.2.0版本之前曾经被名为drawer_hestiaUI的其中一部。
+改名的目的是有人要横行强盗设计的版权和为了编程文件编写能力而整理过。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''


### PR DESCRIPTION
Since the /en/specs/hestiaGUI page and
/en/specs/hestiaGUI/zoralabDRAWER page are ready, we can proceed to port zoralabDRAWER_RIGHT spec page. Hence, let's do this.

This patch ports /en/specs/hestiaGUI/zoralabDRAWER_RIGHT/ spec page into sites/ directory.