### PR TITLE
sites: ported /en/specs/hestiaGUI/zoralabDRAWER_TOP/ page

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabCORE/CSSVariables
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabCORE/CSSVariables
@@ -179,7 +179,7 @@
 "--h4-margin" = "4.5rem 0 0"
 "--h4-padding" = "0"
 "--h4-text-decoration" = "underline"
-"--h4-text-align" = "center"
+"--h4-text-align" = "left"
 "--h4-decoration-color" = "initial"
 "--h4-border-bottom" = "initial"
 "--h4-before-content" = ""

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_LEFT/CSS
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_LEFT/CSS
@@ -26,7 +26,7 @@ specific language governing permissions and limitations under the License.
 	grid-area: var(--leftnav-grid-area);
 
 	width: fit-content;
-	height: 200vh;
+	height: 100vh;
 
 	position: fixed;
 	top: 0;
@@ -53,7 +53,9 @@ specific language governing permissions and limitations under the License.
 	width: var(--left-drawer-width);
 	height: var(--left-drawer-height);
 
+	border-top: var(--left-drawer-border);
 	border-right: var(--left-drawer-border);
+	border-bottom: var(--left-drawer-border);
 	border-radius: var(--left-drawer-border-radius);
 
 	color: var(--left-drawer-color);
@@ -75,6 +77,7 @@ specific language governing permissions and limitations under the License.
 
 .left-drawer > input[type='checkbox']:checked ~ *:not(label) {
 	z-index: var(--left-drawer-z-index-opened);
+
 	visibility: visible;
 	opacity: 1;
 }

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_LEFT/CSSVariables
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_LEFT/CSSVariables
@@ -3,10 +3,11 @@
 "--left-drawer-z-index-opened" = "var(--drawer-z-index-opened)"
 
 "--left-drawer-width" = "0"
-"--left-drawer-width-opened" = "90vw"
+"--left-drawer-width-opened" = "85vw"
 "--left-drawer-height" = "100%"
 "--left-drawer-height-opened" = "var(--left-drawer-height)"
 "--left-drawer-overflow" = "hidden auto"
+
 "--left-drawer-border" = "var(--drawer-border)"
 "--left-drawer-border-radius" = "0 var(--drawer-border-radius) var(--drawer-border-radius) 0"
 
@@ -22,7 +23,7 @@
 "--left-drawer-trigger-width" = "var(--drawer-trigger-width)"
 "--left-drawer-trigger-height" = "var(--drawer-trigger-height)"
 
-"--left-drawer-trigger-position-top" = "50%"
+"--left-drawer-trigger-position-top" = "0"
 "--left-drawer-trigger-position-left" = "0"
 "--left-drawer-trigger-position-bottom" = "unset"
 "--left-drawer-trigger-position-right" = "unset"

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_RIGHT/CSS
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_RIGHT/CSS
@@ -26,7 +26,7 @@ specific language governing permissions and limitations under the License.
 	grid-area: var(--rightnav-grid-area);
 
 	width: fit-content;
-	height: 200vh;
+	height: 100vh;
 
 	position: fixed;
 	top: 0;
@@ -53,7 +53,9 @@ specific language governing permissions and limitations under the License.
 	width: var(--right-drawer-width);
 	height: var(--right-drawer-height);
 
+	border-top: var(--right-drawer-border);
 	border-left: var(--right-drawer-border);
+	border-bottom: var(--right-drawer-border);
 	border-radius: var(--right-drawer-border-radius);
 
 	color: var(--right-drawer-color);

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_RIGHT/CSSVariables
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_RIGHT/CSSVariables
@@ -3,7 +3,7 @@
 "--right-drawer-z-index-opened" = "var(--drawer-z-index-opened)"
 
 "--right-drawer-width" = "0"
-"--right-drawer-width-opened" = "90vw"
+"--right-drawer-width-opened" = "85vw"
 "--right-drawer-height" = "100%"
 "--right-drawer-height-opened" = "var(--right-drawer-height)"
 "--right-drawer-overflow" = "hidden auto"
@@ -22,7 +22,7 @@
 "--right-drawer-trigger-width" = "var(--drawer-trigger-width)"
 "--right-drawer-trigger-height" = "var(--drawer-trigger-height)"
 
-"--right-drawer-trigger-position-top" = "50%"
+"--right-drawer-trigger-position-top" = "0"
 "--right-drawer-trigger-position-left" = "unset"
 "--right-drawer-trigger-position-bottom" = "unset"
 "--right-drawer-trigger-position-right" = "0"

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_TOP/CSS
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_TOP/CSS
@@ -112,8 +112,8 @@ specific language governing permissions and limitations under the License.
 	width: var(--top-drawer-trigger-width);
 	height: var(--top-drawer-trigger-height);
 
-	font-size: var(--drawer-trigger-font-size);
-	font-style: var(--drawer-trigger-font-style);
+	font-size: var(--top-drawer-trigger-font-size);
+	font-style: var(--top-drawer-trigger-font-style);
 
 	border: var(--top-drawer-trigger-border);
 	border-radius: var(--top-drawer-trigger-border-radius);

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_TOP/CSSVariables
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDRAWER_TOP/CSSVariables
@@ -5,7 +5,7 @@
 "--top-drawer-width" = "100vw"
 "--top-drawer-width-opened" = "var(--top-drawer-width)"
 "--top-drawer-height" = "0"
-"--top-drawer-height-opened" = "70vh"
+"--top-drawer-height-opened" = "85vh"
 "--top-drawer-overflow" = "auto hidden"
 
 "--top-drawer-border" = "var(--drawer-border)"
@@ -22,6 +22,7 @@
 
 "--top-drawer-trigger-width" = "var(--drawer-trigger-width)"
 "--top-drawer-trigger-height" = "var(--drawer-trigger-height)"
+
 "--top-drawer-trigger-position-top" = "0"
 "--top-drawer-trigger-position-left" = "50%"
 "--top-drawer-trigger-position-bottom" = "unset"
@@ -32,9 +33,14 @@
 "--top-drawer-trigger-border-radius" = """
 0 0 var(--drawer-trigger-border-radius) var(--drawer-trigger-border-radius)
 """
+
+"--top-drawer-trigger-font-size" = "var(--drawer-trigger-font-size)"
+"--top-drawer-trigger-font-style" = "var(--drawer-trigger-font-style)"
+
 "--top-drawer-trigger-color" = "var(--drawer-trigger-color)"
 "--top-drawer-trigger-background" = "var(--drawer-background)"
 "--top-drawer-trigger-box-shadow" = "0 0 2rem var(--drawer-trigger-color)"
+
 "--top-drawer-trigger-transform" = "translateX(-50%)"
 "--top-drawer-trigger-transform-focus" = "scale(1.1) translateX(-50%)"
 

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__content.hestiaLDJSON
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__content.hestiaLDJSON
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (partial "hestiaJSON/schemaorgLDJSON/WebPage" .) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__contributors.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__contributors.toml
@@ -1,0 +1,78 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...
+[[Contributors]]
+Key = 'ZORALab'
+
+[Contributors.Contribution]
+Creation = true
+Contact = true
+Artwork = false
+Knowledge = false
+Editor = true
+Developer = false
+Maintainer = false
+Producer = true
+Provider = true
+Publisher = true
+Funder = false
+Sponsor = true
+
+
+
+
+[[Contributors]]
+Key = 'HollowayKeanHo'
+
+[Contributors.Contribution]
+Creation = true
+Contact = false
+Artwork = false
+Knowledge = true
+Editor = true
+Developer = false
+Maintainer = false
+Producer = false
+Provider = false
+Publisher = false
+Funder = false
+Sponsor = false

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__data.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__data.toml
@@ -1,0 +1,2 @@
+[Dataset]
+Path = 'hestiaGUI.zoralabDRAWER_TOP'

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__languages.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = '/en/specs/hestiagui/zoralabdrawer_top'
+
+[zh-Hans]
+URL = '/zh-hans/specs/hestiagui/zoralabdrawer_top'

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__page.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__page.toml
@@ -1,0 +1,125 @@
+# PAGE METADATA
+# =============
+# Date fields.
+#
+# NOTE:
+#   1. You can generate date easily on linux using '$ date' command.
+#   2. If date field is left blank, the current time shall be used instead.
+#   3. Date should ONLY comply to this pattern when manually constructed:
+#                    Thu 21 Jul 2022 14:27:39 PM +08
+[Date]
+Created   = "Fri 16 Dec 2022 06:01:48 AM +08"
+Published = "Fri 16 Dec 2022 06:01:48 AM +08"
+
+
+
+
+# Content fields.
+# NOTE:
+#   1. For .Title, Hestia's string processing using page variables are allowed
+#      and only limited to .Titles sub-fields.
+#   2. For .Keywords, Hestia's string processing using page variables are
+#      allowed but strongly discouraged.
+[Content]
+Title = "zoralabDRAWER_TOP Technical Specification - ZORALab's Hestia"
+Keywords = [
+	'zoralabDRAWER_TOP',
+	'hestiaGUI',
+	'Technical Specifications',
+	'Specifications',
+	'Web',
+	'Tech',
+	'PWA',
+	'WASM',
+	'Software Libraries',
+	'Hugo',
+	'Go',
+	'TinyGo',
+	'Nim',
+	'ZORALab',
+	"ZORALab's Hestia",
+]
+
+
+
+
+# Description fields.
+# NOTE:
+#   1. Hestia's string processing using page variables are allowed.
+#   2. The .Description.Pitch is at maximum 160 characters.
+#   3. The .Description.Summary is at maximum of 250 characters.
+#   4. All fields shall have their whitespace cleansed during the processing.
+[Description]
+Pitch = '''
+The technical specifications to refer when using the package.
+'''
+Summary = '''
+Easy-going, offline supported (via web PWA installation), and detailed oriented.
+Courtesy from ZORALab's Hestia.
+'''
+
+
+
+
+# Redirect fields.
+# NOTE:
+#   1. Hestia's URL processing is allowed for .URL field.
+#   2. .Delay timing sets the delay time before redirect. Setting to '0' means
+#      an immediate redirect is requested.
+#   3. Redirect is only available if .Enabled is set to 'true'.
+#   4. Redirect.Language is to redirect the current page to its
+#      language-specific page when Javascript is made available on client side
+#      or fallback to default language.
+[Redirect]
+Delay = 0 # second
+URL = ''
+Enabled = false
+
+[Redirect.Language]
+Enabled = false
+
+
+
+
+# Content Files' Sourcing Location
+# NOTE:
+#   1. To denote where are the content sources.
+#   2. If you're sourcing from assets directory, prefix 'assets/'.
+#   3. If you're sourcing from layouts directory, prefix 'layouts/'.
+#   2. If you're sourcing from static directory, prefix 'static/'.
+#   3. If you're sourcing from partial directory, prefix 'layouts/partials/'.
+[Sources]
+HTML = 'layouts/content/specs/zoralab/index.html'
+JSON = 'layouts/content/specs/zoralab/index.json'
+CSS = 'layouts/content/specs/zoralab/index.css'
+JS = 'layouts/content/specs/zoralab/index.js'
+LDJSON = '__content.hestiaLDJSON'
+Contributors = '__contributors.toml'
+Thumbnails = '__thumbnails.toml'
+Languages = '__languages.toml'
+Assets = 'layouts/content/specs/zoralab/assets.toml'
+Components = 'layouts/content/specs/zoralab/components.toml'
+
+
+
+
+# Data fields.
+# NOTE:
+#   1. List only the page-level data files. It can be in any of the following
+#      formats: '.json', '.toml', or '.yaml'.
+#   2. Hestia string processing is available and shall be processed prior to
+#      dataset transformation.
+#   3. Sequences of the .Data array dictates sequences of loading and overriding
+#      (the latter shall overwrite the former for the same data fields).
+#   4. The final processed dataset shall be served as main data content in
+#      supported output format (e.g. index.json).
+#   5. Missing data file shall be ignored.
+#   6. To add more data files, simply duplicate and add more .Data array entry.
+#      Example:
+#                             [[data]]
+#                             Filename = 'file1.json'
+#
+#                             [[data]]
+#                             Filename = 'file2.toml'
+[[Data]]
+Filename = '__data.toml'

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__robots.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__thumbnails.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/thumbnails-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/thumbnails-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/thumbnails-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__twitter.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__wasm.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/_index.html
+++ b/sites/content/en/specs/hestiaGUI/zoralabDRAWER_TOP/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++

--- a/sites/data/Specs/I18n.toml
+++ b/sites/data/Specs/I18n.toml
@@ -28,10 +28,12 @@ SubList = '子点'
 
 [EN.Introduction]
 ID = 'introduction'
+Title = 'Introduction'
 
 
 [ZH-HANS.Introduction]
 ID = '自介'
+Title = '自介'
 
 
 

--- a/sites/data/Specs/hestiaGUI/zoralabDRAWER_LEFT/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabDRAWER_LEFT/Designs.toml
@@ -277,7 +277,7 @@ Affects the width of the rendered component when opened.
 Code = '''
 VARIABLE     : --left-drawer-width-opened
 CSS PROPERTY : width
-DEFAULT      : 90vw (>= v1.2.0)
+DEFAULT      : 85vw (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -296,7 +296,7 @@ Plain = '''
 Code = '''
 变化值     : --left-drawer-width-opened
 CSS属性    : width
-默认数码   : 90vw (>= v1.2.0)
+默认数码   : 85vw (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -745,7 +745,7 @@ Affects the trigger's top position of the rendered component.
 Code = '''
 VARIABLE     : --left-drawer-trigger-position-top
 CSS PROPERTY : top
-DEFAULT      : 50% (>= v1.2.0)
+DEFAULT      : 0 (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -764,7 +764,7 @@ Plain = '''
 Code = '''
 变化值     : --left-drawer-trigger-position-top
 CSS属性    : top
-默认数码   : 50% (>= v1.2.0)
+默认数码   : 0 (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]

--- a/sites/data/Specs/hestiaGUI/zoralabDRAWER_TOP/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabDRAWER_TOP/Designs.toml
@@ -158,7 +158,7 @@ Plain = '''
 Affects the z-index of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-z-index
+VARIABLE     : --top-drawer-z-index
 CSS PROPERTY : z-index
 DEFAULT      : var(--drawer-z-index) (>= v1.2.0)
 '''
@@ -177,7 +177,7 @@ Plain = '''
 影响元件的z-index设置。
 '''
 Code = '''
-变化值     : --right-drawer-z-index
+变化值     : --top-drawer-z-index
 CSS属性    : z-index
 默认数码   : var(--drawer-z-index) (>= v1.2.0)
 '''
@@ -197,7 +197,7 @@ Plain = '''
 Affects the z-index of the rendered component when opened.
 '''
 Code = '''
-VARIABLE     : --right-drawer-z-index-opened
+VARIABLE     : --top-drawer-z-index-opened
 CSS PROPERTY : z-index
 DEFAULT      : var(--drawer-z-index-opened) (>= v1.2.0)
 '''
@@ -216,7 +216,7 @@ Plain = '''
 影响元件在打开情况里的z-index设置。
 '''
 Code = '''
-变化值     : --right-drawer-z-index-opened
+变化值     : --top-drawer-z-index-opened
 CSS属性    : z-index
 默认数码   : var(--drawer-z-index-opened) (>= v1.2.0)
 '''
@@ -236,9 +236,9 @@ Plain = '''
 Affects the width of the rendered component (when closed).
 '''
 Code = '''
-VARIABLE     : --right-drawer-width
+VARIABLE     : --top-drawer-width
 CSS PROPERTY : width
-DEFAULT      : 0 (>= v1.2.0)
+DEFAULT      : 100vw (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -255,8 +255,86 @@ Plain = '''
 影响元件（在关闭时）的宽度。
 '''
 Code = '''
-变化值     : --right-drawer-width
+变化值     : --top-drawer-width
 CSS属性    : width
+默认数码   : 100vw (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Width (Opened)'
+HTML = '''
+Affects the width of the rendered component when opened.
+'''
+Plain = '''
+Affects the width of the rendered component when opened.
+'''
+Code = '''
+VARIABLE     : --top-drawer-width-opened
+CSS PROPERTY : width
+DEFAULT      : var(--top-drawer-width) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Width (Opened)'
+HTML = '''
+影响元件在打开时的宽度。
+'''
+Plain = '''
+影响元件在打开时的宽度。
+'''
+Code = '''
+变化值     : --top-drawer-width-opened
+CSS属性    : width
+默认数码   : var(--top-drawer-width) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Height'
+HTML = '''
+Affects the height of the rendered component (when closed).
+'''
+Plain = '''
+Affects the height of the rendered component (when closed).
+'''
+Code = '''
+VARIABLE     : --top-drawer-height
+CSS PROPERTY : height
+DEFAULT      : 0 (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Height'
+HTML = '''
+影响元件（在关闭时）的长度。
+'''
+Plain = '''
+影响元件（在关闭时）的长度。
+'''
+Code = '''
+变化值     : --top-drawer-height
+CSS属性    : height
 默认数码   : 0 (>= v1.2.0)
 '''
 
@@ -267,84 +345,6 @@ Label = ''
 
 
 [[EN.List.SubList]]
-Title = 'Width (Opened)'
-HTML = '''
-Affects the width of the rendered component when opened.
-'''
-Plain = '''
-Affects the width of the rendered component when opened.
-'''
-Code = '''
-VARIABLE     : --right-drawer-width-opened
-CSS PROPERTY : width
-DEFAULT      : 85vw (>= v1.2.0)
-'''
-
-[[EN.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-[[ZH-HANS.List.SubList]]
-Title = 'Width (Opened)'
-HTML = '''
-影响元件在打开时的宽度。
-'''
-Plain = '''
-影响元件在打开时的宽度。
-'''
-Code = '''
-变化值     : --right-drawer-width-opened
-CSS属性    : width
-默认数码   : 85vw (>= v1.2.0)
-'''
-
-[[ZH-HANS.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-
-[[EN.List.SubList]]
-Title = 'Height'
-HTML = '''
-Affects the height of the rendered component (when closed).
-'''
-Plain = '''
-Affects the height of the rendered component (when closed).
-'''
-Code = '''
-VARIABLE     : --right-drawer-height
-CSS PROPERTY : height
-DEFAULT      : 100% (>= v1.2.0)
-'''
-
-[[EN.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-[[ZH-HANS.List.SubList]]
-Title = 'Height'
-HTML = '''
-影响元件（在关闭时）的长度。
-'''
-Plain = '''
-影响元件（在关闭时）的长度。
-'''
-Code = '''
-变化值     : --right-drawer-height
-CSS属性    : height
-默认数码   : 100% (>= v1.2.0)
-'''
-
-[[ZH-HANS.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-
-[[EN.List.SubList]]
 Title = 'Height (Opened)'
 HTML = '''
 Affects the height of the rendered component when opened.
@@ -353,9 +353,9 @@ Plain = '''
 Affects the height of the rendered component when opened.
 '''
 Code = '''
-VARIABLE     : --right-drawer-height-opened
+VARIABLE     : --top-drawer-height-opened
 CSS PROPERTY : height
-DEFAULT      : var(--right-drawer-height) (>= v1.2.0)
+DEFAULT      : 85vh (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -372,9 +372,9 @@ Plain = '''
 影响元件在打开时的长度。
 '''
 Code = '''
-变化值     : --right-drawer-height-opened
+变化值     : --top-drawer-height-opened
 CSS属性    : height
-默认数码   : var(--right-drawer-height) (>= v1.2.0)
+默认数码   : 85vh (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -392,9 +392,9 @@ Plain = '''
 Affects the overflow behavior of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-overflow
+VARIABLE     : --top-drawer-overflow
 CSS PROPERTY : overflow
-DEFAULT      : hidden auto (>= v1.2.0)
+DEFAULT      : auto hidden (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -411,9 +411,9 @@ Plain = '''
 影响元件的边界线。
 '''
 Code = '''
-变化值     : --right-drawer-overflow
+变化值     : --top-drawer-overflow
 CSS属性    : overflow
-默认数码   : hidden auto (>= v1.2.0)
+默认数码   : auto hidden (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -431,7 +431,7 @@ Plain = '''
 Affects the border of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-border
+VARIABLE     : --top-drawer-border
 CSS PROPERTY : border
 DEFAULT      : var(--drawer-border) (>= v1.2.0)
 '''
@@ -450,7 +450,7 @@ Plain = '''
 影响元件的边界线。
 '''
 Code = '''
-变化值     : --right-drawer-border
+变化值     : --top-drawer-border
 CSS属性    : border
 默认数码   : var(--drawer-border) (>= v1.2.0)
 '''
@@ -470,9 +470,9 @@ Plain = '''
 Affects the border radius of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-border-radius
+VARIABLE     : --top-drawer-border-radius
 CSS PROPERTY : border-radius
-DEFAULT      : var(--drawer-border-radius) 0 0 var(--drawer-border-radius) (>= v1.2.0)
+DEFAULT      : 0 0 var(--drawer-border-radius) var(--drawer-border-radius) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -489,9 +489,9 @@ Plain = '''
 影响元件边界线的角落圆形度。
 '''
 Code = '''
-变化值     : --right-drawer-border-radius
+变化值     : --top-drawer-border-radius
 CSS属性    : border-radius
-默认数码   : var(--drawer-border-radius) 0 0 var(--drawer-border-radius) (>= v1.2.0)
+默认数码   : 0 0 var(--drawer-border-radius) var(--drawer-border-radius) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -509,7 +509,7 @@ Plain = '''
 Affects the color of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-color
+VARIABLE     : --top-drawer-color
 CSS PROPERTY : color
 DEFAULT      : var(--drawer-color) (>= v1.2.0)
 '''
@@ -528,7 +528,7 @@ Plain = '''
 影响元件的颜色。
 '''
 Code = '''
-变化值     : --right-drawer-color
+变化值     : --top-drawer-color
 CSS属性    : color
 默认数码   : var(--drawer-color) (>= v1.2.0)
 '''
@@ -548,7 +548,7 @@ Plain = '''
 Affects the background of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-background
+VARIABLE     : --top-drawer-background
 CSS PROPERTY : background
 DEFAULT      : var(--drawer-background) (>= v1.2.0)
 '''
@@ -567,7 +567,7 @@ Plain = '''
 影响元件的背景。
 '''
 Code = '''
-变化值     : --right-drawer-background
+变化值     : --top-drawer-background
 CSS属性    : background
 默认数码   : var(--drawer-background) (>= v1.2.0)
 '''
@@ -587,7 +587,7 @@ Plain = '''
 Affects the box shadow of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-box-shadow
+VARIABLE     : --top-drawer-box-shadow
 CSS PROPERTY : box-shadow
 DEFAULT      : var(--drawer-box-shadow) (>= v1.2.0)
 '''
@@ -606,7 +606,7 @@ Plain = '''
 影响元件的影子。
 '''
 Code = '''
-变化值     : --right-drawer-box-shadow
+变化值     : --top-drawer-box-shadow
 CSS属性    : box-shadow
 默认数码   : var(--drawer-box-shadow) (>= v1.2.0)
 '''
@@ -626,7 +626,7 @@ Plain = '''
 Affects the animation timing of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-transition
+VARIABLE     : --top-drawer-transition
 CSS PROPERTY : transition
 DEFAULT      : var(--drawer-transition) (>= v1.2.0)
 '''
@@ -645,7 +645,7 @@ Plain = '''
 影响元件的动画定时。
 '''
 Code = '''
-变化值     : --right-drawer-transition
+变化值     : --top-drawer-transition
 CSS属性    : transition
 默认数码   : var(--drawer-transition) (>= v1.2.0)
 '''
@@ -665,7 +665,7 @@ Plain = '''
 Affects the trigger's width of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-width
+VARIABLE     : --top-drawer-trigger-width
 CSS PROPERTY : width
 DEFAULT      : var(--drawer-trigger-width) (>= v1.2.0)
 '''
@@ -684,7 +684,7 @@ Plain = '''
 影响元件触发器的宽度。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-width
+变化值     : --top-drawer-trigger-width
 CSS属性    : width
 默认数码   : var(--drawer-trigger-width) (>= v1.2.0)
 '''
@@ -704,7 +704,7 @@ Plain = '''
 Affects the trigger's height of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-height
+VARIABLE     : --top-drawer-trigger-height
 CSS PROPERTY : height
 DEFAULT      : var(--drawer-trigger-height) (>= v1.2.0)
 '''
@@ -723,7 +723,7 @@ Plain = '''
 影响元件触发器的长度。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-height
+变化值     : --top-drawer-trigger-height
 CSS属性    : height
 默认数码   : var(--drawer-trigger-height) (>= v1.2.0)
 '''
@@ -743,7 +743,7 @@ Plain = '''
 Affects the trigger's top position of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-position-top
+VARIABLE     : --top-drawer-trigger-position-top
 CSS PROPERTY : top
 DEFAULT      : 0 (>= v1.2.0)
 '''
@@ -762,7 +762,7 @@ Plain = '''
 影响元件触发器的顶向位置。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-position-top
+变化值     : --top-drawer-trigger-position-top
 CSS属性    : top
 默认数码   : 0 (>= v1.2.0)
 '''
@@ -782,9 +782,9 @@ Plain = '''
 Affects the trigger's left position of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-position-left
+VARIABLE     : --top-drawer-trigger-position-left
 CSS PROPERTY : left
-DEFAULT      : unset (>= v1.2.0)
+DEFAULT      : 50% (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -801,9 +801,9 @@ Plain = '''
 影响元件触发器的左向位置。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-position-left
+变化值     : --top-drawer-trigger-position-left
 CSS属性    : left
-默认数码   : unset (>= v1.2.0)
+默认数码   : 50% (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -821,7 +821,7 @@ Plain = '''
 Affects the trigger's bottom position of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-position-bottom
+VARIABLE     : --top-drawer-trigger-position-bottom
 CSS PROPERTY : bottom
 DEFAULT      : unset (>= v1.2.0)
 '''
@@ -840,7 +840,7 @@ Plain = '''
 影响元件触发器的底向位置。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-position-bottom
+变化值     : --top-drawer-trigger-position-bottom
 CSS属性    : bottom
 默认数码   : unset (>= v1.2.0)
 '''
@@ -860,9 +860,9 @@ Plain = '''
 Affects the trigger's right position of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-position-right
+VARIABLE     : --top-drawer-trigger-position-right
 CSS PROPERTY : right
-DEFAULT      : 0 (>= v1.2.0)
+DEFAULT      : unset (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -879,9 +879,9 @@ Plain = '''
 影响元件触发器的右向位置。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-position-right
+变化值     : --top-drawer-trigger-position-right
 CSS属性    : right
-默认数码   : 0 (>= v1.2.0)
+默认数码   : unset (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -899,7 +899,7 @@ Plain = '''
 Affects the trigger's z-index of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-z-index
+VARIABLE     : --top-drawer-trigger-z-index
 CSS PROPERTY : z-index
 DEFAULT      : var(--drawer-trigger-z-index) (>= v1.2.0)
 '''
@@ -918,7 +918,7 @@ Plain = '''
 影响元件触发器的z-index设置。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-z-index
+变化值     : --top-drawer-trigger-z-index
 CSS属性    : z-index
 默认数码   : var(--drawer-trigger-z-index) (>= v1.2.0)
 '''
@@ -938,7 +938,7 @@ Plain = '''
 Affects the trigger's border of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-border
+VARIABLE     : --top-drawer-trigger-border
 CSS PROPERTY : border
 DEFAULT      : unset (>= v1.2.0)
 '''
@@ -957,7 +957,7 @@ Plain = '''
 影响元件触发器的边界线。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-border
+变化值     : --top-drawer-trigger-border
 CSS属性    : border
 默认数码   : unset (>= v1.2.0)
 '''
@@ -977,9 +977,9 @@ Plain = '''
 Affects the trigger's border radius of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-border-radius
+VARIABLE     : --top-drawer-trigger-border-radius
 CSS PROPERTY : border-radius
-DEFAULT      : var(--drawer-trigger-border-radius) 0 0 var(--drawer-trigger-border-radius) (>= v1.2.0)
+DEFAULT      : 0 0 var(--drawer-trigger-border-radius) var(--drawer-trigger-border-radius)
 '''
 
 [[EN.List.SubList.URL]]
@@ -996,9 +996,9 @@ Plain = '''
 影响元件触发器的角落圆形度。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-border-radius
+变化值     : --top-drawer-trigger-border-radius
 CSS属性    : border-radius
-默认数码   : var(--drawer-trigger-border-radius) 0 0 var(--drawer-trigger-border-radius) (>= v1.2.0)
+默认数码   : 0 0 var(--drawer-trigger-border-radius) var(--drawer-trigger-border-radius)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -1016,7 +1016,7 @@ Plain = '''
 Affects the trigger's font size of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-font-size
+VARIABLE     : --top-drawer-trigger-font-size
 CSS PROPERTY : font-size
 DEFAULT      : var(--drawer-trigger-font-size) (>= v1.2.0)
 '''
@@ -1035,7 +1035,7 @@ Plain = '''
 影响元件触发器的字体大小。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-font-size
+变化值     : --top-drawer-trigger-font-size
 CSS属性    : font-size
 默认数码   : var(--drawer-trigger-font-size) (>= v1.2.0)
 '''
@@ -1055,7 +1055,7 @@ Plain = '''
 Affects the trigger's font style of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-font-style
+VARIABLE     : --top-drawer-trigger-font-style
 CSS PROPERTY : font-style
 DEFAULT      : var(--drawer-trigger-font-style) (>= v1.2.0)
 '''
@@ -1074,7 +1074,7 @@ Plain = '''
 影响元件触发器的字体风格。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-font-style
+变化值     : --top-drawer-trigger-font-style
 CSS属性    : font-style
 默认数码   : var(--drawer-trigger-font-style) (>= v1.2.0)
 '''
@@ -1094,7 +1094,7 @@ Plain = '''
 Affects the trigger's color of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-color
+VARIABLE     : --top-drawer-trigger-color
 CSS PROPERTY : color
 DEFAULT      : var(--drawer-trigger-color) (>= v1.2.0)
 '''
@@ -1113,7 +1113,7 @@ Plain = '''
 影响元件触发器的颜色。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-color
+变化值     : --top-drawer-trigger-color
 CSS属性    : color
 默认数码   : var(--drawer-trigger-color) (>= v1.2.0)
 '''
@@ -1133,7 +1133,7 @@ Plain = '''
 Affects the trigger's background of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-background
+VARIABLE     : --top-drawer-trigger-background
 CSS PROPERTY : background
 DEFAULT      : var(--drawer-background) (>= v1.2.0)
 '''
@@ -1152,7 +1152,7 @@ Plain = '''
 影响元件触发器的颜色。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-background
+变化值     : --top-drawer-trigger-background
 CSS属性    : background
 默认数码   : var(--drawer-background) (>= v1.2.0)
 '''
@@ -1172,7 +1172,7 @@ Plain = '''
 Affects the trigger's box shadow of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-box-shadow
+VARIABLE     : --top-drawer-trigger-box-shadow
 CSS PROPERTY : box-shadow
 DEFAULT      : 0 0 2rem var(--drawer-trigger-color) (>= v1.2.0)
 '''
@@ -1191,7 +1191,7 @@ Plain = '''
 影响元件触发器的影子。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-box-shadow
+变化值     : --top-drawer-trigger-box-shadow
 CSS属性    : box-shadow
 默认数码   : 0 0 2rem var(--drawer-trigger-color) (>= v1.2.0)
 '''
@@ -1211,9 +1211,9 @@ Plain = '''
 Affects the trigger's transform of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-transform
+VARIABLE     : --top-drawer-trigger-transform
 CSS PROPERTY : transform
-DEFAULT      : "" (>= v1.2.0)
+DEFAULT      : translateX(-50%) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -1230,9 +1230,9 @@ Plain = '''
 影响元件触发器的变换形态。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-transform
+变化值     : --top-drawer-trigger-transform
 CSS属性    : transform
-默认数码   : "" (>= v1.2.0)
+默认数码   : translateX(-50%) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -1250,9 +1250,9 @@ Plain = '''
 Affects the trigger's transform of the rendered component while being focused.
 '''
 Code = '''
-VARIABLE     : --right-drawer-trigger-transform-focus
+VARIABLE     : --top-drawer-trigger-transform-focus
 CSS PROPERTY : transform
-DEFAULT      : scale(1.1) (>= v1.2.0)
+DEFAULT      : scale(1.1) translateX(-50%) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -1269,9 +1269,9 @@ Plain = '''
 影响元件触发器在被关注时的变换形态。
 '''
 Code = '''
-变化值     : --right-drawer-trigger-transform-focus
+变化值     : --top-drawer-trigger-transform-focus
 CSS属性    : transform
-默认数码   : scale(1.1) (>= v1.2.0)
+默认数码   : scale(1.1) translateX(-50%) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -1289,7 +1289,7 @@ Plain = '''
 Affects the overlay layer's z-index of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-overlay-z-index
+VARIABLE     : --top-drawer-overlay-z-index
 CSS PROPERTY : z-index
 DEFAULT      : var(--drawer-overlay-z-index) (>= v1.2.0)
 '''
@@ -1308,7 +1308,7 @@ Plain = '''
 影响元件叠加层的z-index设置。
 '''
 Code = '''
-变化值     : --right-drawer-overlay-z-index
+变化值     : --top-drawer-overlay-z-index
 CSS属性    : z-index
 默认数码   : var(--drawer-overlay-z-index) (>= v1.2.0)
 '''
@@ -1328,7 +1328,7 @@ Plain = '''
 Affects the overlay layer's color of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-overlay-color
+VARIABLE     : --top-drawer-overlay-color
 CSS PROPERTY : color
 DEFAULT      : var(--drawer-overlay-color) (>= v1.2.0)
 '''
@@ -1347,7 +1347,7 @@ Plain = '''
 影响元件叠加层的颜色。
 '''
 Code = '''
-变化值     : --right-drawer-overlay-color
+变化值     : --top-drawer-overlay-color
 CSS属性    : color
 默认数码   : var(--drawer-overlay-color) (>= v1.2.0)
 '''
@@ -1367,7 +1367,7 @@ Plain = '''
 Affects the overlay layer's background of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-overlay-background
+VARIABLE     : --top-drawer-overlay-background
 CSS PROPERTY : background
 DEFAULT      : var(--drawer-overlay-background) (>= v1.2.0)
 '''
@@ -1386,7 +1386,7 @@ Plain = '''
 影响元件叠加层的背景。
 '''
 Code = '''
-变化值     : --right-drawer-overlay-background
+变化值     : --top-drawer-overlay-background
 CSS属性    : background
 默认数码   : var(--drawer-overlay-background) (>= v1.2.0)
 '''
@@ -1406,7 +1406,7 @@ Plain = '''
 Affects the overlay layer's animation timing of the rendered component.
 '''
 Code = '''
-VARIABLE     : --right-drawer-overlay-transition
+VARIABLE     : --top-drawer-overlay-transition
 CSS PROPERTY : transition
 DEFAULT      : var(--drawer-overlay-transition) (>= v1.2.0)
 '''
@@ -1425,7 +1425,7 @@ Plain = '''
 影响元件叠加层的动画定时。
 '''
 Code = '''
-变化值     : --right-drawer-overlay-transition
+变化值     : --top-drawer-overlay-transition
 CSS属性    : transition
 默认数码   : var(--drawer-overlay-transition) (>= v1.2.0)
 '''

--- a/sites/data/Specs/hestiaGUI/zoralabDRAWER_TOP/Functions.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabDRAWER_TOP/Functions.toml
@@ -1,0 +1,138 @@
+[[EN.List]]
+Title = 'ToCSS'
+HTML = '''
+Render the CSS output for this UI component.
+'''
+Plain = '''
+Render the CSS output for this UI component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'ToCSS'
+HTML = '''
+渲染呈现CSS的输出数据。
+'''
+Plain = '''
+渲染呈现CSS的输出数据。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+Usage example:
+'''
+Plain = '''
+Usage example:
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabDRAWER_LEFT/ToCSS" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+用法：
+'''
+Plain = '''
+用法：
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabDRAWER_LEFT/ToCSS" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'ToCSS_VARIABLES'
+HTML = '''
+Render the CSS variables output list for this UI component.
+'''
+Plain = '''
+Render the CSS variables output list for this UI component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'ToCSS_VARIABLES'
+HTML = '''
+渲染呈现CSS变化值数据的输出菜单。
+'''
+Plain = '''
+渲染呈现CSS变化值数据的输出菜单。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+Usage example:
+'''
+Plain = '''
+Usage example:
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabDRAWER_LEFT/ToCSS_VARIABLES" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+用法：
+'''
+Plain = '''
+用法：
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabDRAWER_LEFT/ToCSS_VARIABLES" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/data/Specs/hestiaGUI/zoralabDRAWER_TOP/Metadata.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabDRAWER_TOP/Metadata.toml
@@ -1,0 +1,14 @@
+[EN.Brand]
+ID = 'zoralabdrawer_top'
+SKU = 'zoralabDRAWER_TOP'
+Description = '''
+For styling a top-side navigation drawer.
+'''
+
+
+[ZH-HANS.Brand]
+ID = 'zoralabdrawer_top'
+SKU = 'zoralabDRAWER_TOP'
+Description = '''
+来渲染顶边的导航抽屉。
+'''

--- a/sites/data/Specs/hestiaGUI/zoralabDRAWER_TOP/Purposes.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabDRAWER_TOP/Purposes.toml
@@ -1,0 +1,79 @@
+[[EN.List]]
+Title = 'Main Purpose'
+HTML = '''
+This package's primary purpose is to provide user interface (UI) styling
+specifically for top drawer navigator values. This page is already deployed all
+usable drawer already.
+'''
+Plain = '''
+This package's primary purpose is to provide user interface (UI) styling
+specifically for top drawer navigator values. This page is already deployed all
+usable drawer already.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = '主要目的'
+HTML = '''
+这个软件包的出生主要是支持渲染顶边导航抽屉的界面元件。这网页已经在运用这个元件
+了。
+'''
+Plain = '''
+这个软件包的出生主要是支持渲染定边导航抽屉的界面元件。这网页已经在运用这个元件
+了。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'Legacy Recording'
+HTML = '''
+This package was known as a part of <code>drawer_hestiaUI</code> before
+ZORALab's Hestia <code>v1.2.0</code>. The transformation was due to someone
+attempting to steal the copyrights and makes way for programming package's
+documentation restructuring.
+'''
+Plain = '''
+This package was known as a part of 'drawer_hestiaUI' before
+ZORALab's Hestia 'v1.2.0'. The transformation was due to someone attempting to
+steal the design copyrights and makes way for programming package's
+documentation restructuring.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = '历史遗录'
+HTML = '''
+这个软件包在ZORALab赫斯提亚<code>v1.2.0</code>版本之前曾经被名为
+<code>drawer_hestiaUI</code>的其中一部。改名的目的是有人要横行强盗设计的版权和
+为了编程文件编写能力而整理过。
+'''
+Plain = '''
+这个软件包在ZORALab赫斯提亚v1.2.0版本之前曾经被名为drawer_hestiaUI的其中一部。
+改名的目的是有人要横行强盗设计的版权和为了编程文件编写能力而整理过。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/layouts/content/specs/zoralab/components.toml
+++ b/sites/layouts/content/specs/zoralab/components.toml
@@ -68,8 +68,18 @@ Variables = []
 Name = "zoralabDRAWER_LEFT"
 Include = true
 Variables = [
-	{ "--left-drawer-width-opened" = "80vw" },
-	{ "--left-drawer-trigger-position-top" = "0" },
+]
+
+[[List]]
+Name = "zoralabDRAWER_TOP"
+Include = true
+Variables = [
+]
+
+[[List]]
+Name = "zoralabDRAWER_RIGHT"
+Include = true
+Variables = [
 ]
 
 [[List]]

--- a/sites/layouts/content/specs/zoralab/index.html
+++ b/sites/layouts/content/specs/zoralab/index.html
@@ -5,6 +5,7 @@
 {{- $datastore := false -}}
 {{- $dataset := false -}}
 {{- $lang := false -}}
+{{- $nav := slice -}}
 {{- $ret := false -}}
 
 
@@ -26,6 +27,10 @@
 {{- /* render output */ -}}
 <main style='padding-bottom: 0;'>
 	<section id='{{- $i18n.Introduction.ID -}}'>
+		{{- $nav = append (dict
+			"ID" $i18n.Introduction.ID
+			"Label" $i18n.Introduction.Title
+		) $nav -}}
 		<h1>{{- .Titles.Page -}}</h1>
 		<p>{{- .Descriptions.Page.Pitch }} {{ .Descriptions.Page.Summary -}}</p>
 	</section>
@@ -35,12 +40,17 @@
 		{{- $dataset = default dict (index $datastore $type) -}}
 		{{- $dataset = index $dataset $Page.Languages.Current.ID -}}
 
+	{{- $nav = append (dict "ID" $lang.ID "Label" $lang.Title) $nav -}}
 	<section id='{{- $lang.ID -}}'>
 		<h2>{{- $lang.Title -}}</h2>
 		<p>{{- safeHTML $lang.HTML -}}</p>
 
 		{{ if $dataset.List -}}
-		{{ range $i, $v := $dataset.List }}<section>
+		{{ range $i, $v := $dataset.List }}
+			{{- $ret = merge $Page (dict "Input" (dict "Data" $v.Title)) -}}
+			{{- $ret = partial "hestiaSTRING/ToID" $ret -}}
+			{{- $ret = $ret.Output }}
+		<section id='{{- $ret -}}'>
 			<h3>{{- $v.Title -}}</h3>
 			<p>{{- safeHTML $v.HTML -}}</p>
 
@@ -104,6 +114,10 @@
 
 
 	{{- if (len .Nav.Children) }}
+		{{- $nav = append (dict
+			"ID" $i18n.Catalog.ID
+			"Label" $i18n.Catalog.Title
+		) $nav -}}
 	<section id='{{- $i18n.Catalog.ID -}}'>
 		<h2>{{- $i18n.Catalog.Title -}}</h2>
 		<p>{{- $i18n.Catalog.Description -}}</p>
@@ -137,6 +151,10 @@
 	)) -}}
 	{{- $ret = partial "hestiaURL/Sanitize" $ret -}}
 	{{- $ret = string $ret.Output -}}
+	{{- $nav = append (dict
+		"ID" $i18n.Epilogue.ID
+		"Label" $i18n.Epilogue.Title
+	) $nav -}}
 	<section id='{{- $i18n.Epilogue.ID -}}' class='inverted' style='
 		margin-top: 10rem;
 		background: url({{- $ret -}}),linear-gradient(to top,#010329,#000005)
@@ -158,4 +176,26 @@
 	</section>
 </main>
 {{ partial "common/footer.html" $Page }}
+<nav class='right-drawer'>
+	<input id='nav-secondary-drawer' type='checkbox' />
+	<label class='trigger' for='nav-secondary-drawer'>
+		<span class='open'>¶</span>
+		<span class='close'>𝖷</span>
+	</label>
+	<label class='overlay' for='nav-secondary-drawer'></label>
+
+
+	<div class='content'><div class='row' style='
+		margin-top: 6rem;
+		--grid-flex-direction: column;
+		--grid-gap: 30px;
+		--anchor-color: white;
+	'>
+		{{- range $i, $v := $nav }}
+		<div class='column'>
+			<a href='#{{- $v.ID -}}' class='prestige'>{{- $v.Label -}}</a>
+		</div>
+		{{- end }}
+	</div></div>
+</nav>
 {{ partial "common/nav-prime.html" $Page }}


### PR DESCRIPTION
Since the /en/specs/hestiaGUI page and
/en/specs/hestiaGUI/zoralabDRAWER page are ready, we can proceed to port zoralabDRAWER_TOP spec page. Hence, let's do this.

This patch ports /en/specs/hestiaGUI/zoralabDRAWER_TOP/ spec page into sites/ directory.