### PR TITLE
sites: translated /zh-hans/specs/hestiaGUI/shieldsBADGE/ page

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaGUI/shieldsBADGE/CSSVariables
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/shieldsBADGE/CSSVariables
@@ -10,14 +10,14 @@
 "--badge-width-shine" = ".6rem"
 
 
-"--badge-font-size" = "var(--body-font-size)"
+"--badge-font-size" = "18px"
 
 
-"--badge-color" = "var(--color-typography-50)"
-"--badge-color-shine" = "var(--color-contrast-400)"
-"--badge-color-print" = "var(--body-color-print)"
-"--badge-background" = "var(--color-primary-400)"
-"--badge-background-print" = "var(--body-background-print)"
+"--badge-color" = "#fafafa"
+"--badge-color-shine" = "#ffff27"
+"--badge-color-print" = "#101010"
+"--badge-background" = "#0000d1"
+"--badge-background-print" = "#fff"
 "--badge-box-shadow" = "0 .2rem 1rem transparent"
 "--badge-box-shadow-shine" = "0 .2rem 1rem var(--badge-color-shine)"
 
@@ -35,8 +35,8 @@
 "--badge-title-text-align" = "left"
 
 
-"--badge-title-color" = "var(--color-typography-50)"
-"--badge-title-background" = "var(--color-typography-900)"
+"--badge-title-color" = "#fafafa"
+"--badge-title-background" = "#282828"
 
 
 

--- a/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__content.hestiaLDJSON
+++ b/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__content.hestiaLDJSON
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (partial "hestiaJSON/schemaorgLDJSON/WebPage" .) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__contributors.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__contributors.toml
@@ -1,0 +1,78 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...
+[[Contributors]]
+Key = 'ZORALab'
+
+[Contributors.Contribution]
+Creation = true
+Contact = true
+Artwork = false
+Knowledge = false
+Editor = true
+Developer = false
+Maintainer = false
+Producer = true
+Provider = true
+Publisher = true
+Funder = false
+Sponsor = true
+
+
+
+
+[[Contributors]]
+Key = 'HollowayKeanHo'
+
+[Contributors.Contribution]
+Creation = true
+Contact = false
+Artwork = false
+Knowledge = true
+Editor = true
+Developer = false
+Maintainer = false
+Producer = false
+Provider = false
+Publisher = false
+Funder = false
+Sponsor = false

--- a/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__data.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__data.toml
@@ -1,0 +1,2 @@
+[Dataset]
+Path = 'hestiaGUI.shieldsBADGE'

--- a/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__languages.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = '/en/specs/hestiagui/shieldsbadge'
+
+[zh-Hans]
+URL = '/zh-hans/specs/hestiagui/shieldsbadge'

--- a/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__page.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__page.toml
@@ -1,0 +1,124 @@
+# PAGE METADATA
+# =============
+# Date fields.
+#
+# NOTE:
+#   1. You can generate date easily on linux using '$ date' command.
+#   2. If date field is left blank, the current time shall be used instead.
+#   3. Date should ONLY comply to this pattern when manually constructed:
+#                    Thu 21 Jul 2022 14:27:39 PM +08
+[Date]
+Created   = "Mon 12 Dec 2022 05:32:05 PM +08"
+Published = "Mon 12 Dec 2022 05:32:05 PM +08"
+
+
+
+
+# Content fields.
+# NOTE:
+#   1. For .Title, Hestia's string processing using page variables are allowed
+#      and only limited to .Titles sub-fields.
+#   2. For .Keywords, Hestia's string processing using page variables are
+#      allowed but strongly discouraged.
+[Content]
+Title = "shieldsBADGE科技规范 - ZORALab赫斯提亚"
+Keywords = [
+	'shieldsBADGE',
+	'hestiaGUI',
+	'科技规范',
+	'规范',
+	'网站',
+	'科技',
+	'PWA',
+	'WASM',
+	'代码库',
+	'Hugo',
+	'Go',
+	'TinyGo',
+	'Nim',
+	'ZORALab',
+	'ZORALab赫斯提亚',
+]
+
+
+
+
+# Description fields.
+# NOTE:
+#   1. Hestia's string processing using page variables are allowed.
+#   2. The .Description.Pitch is at maximum 160 characters.
+#   3. The .Description.Summary is at maximum of 250 characters.
+#   4. All fields shall have their whitespace cleansed during the processing.
+[Description]
+Pitch = '''
+当用着这份代码包时所需的科技规范。
+'''
+Summary = '''
+随和、支持离线（通过PWA安装）和非常注重细节的。
+'''
+
+
+
+
+# Redirect fields.
+# NOTE:
+#   1. Hestia's URL processing is allowed for .URL field.
+#   2. .Delay timing sets the delay time before redirect. Setting to '0' means
+#      an immediate redirect is requested.
+#   3. Redirect is only available if .Enabled is set to 'true'.
+#   4. Redirect.Language is to redirect the current page to its
+#      language-specific page when Javascript is made available on client side
+#      or fallback to default language.
+[Redirect]
+Delay = 0 # second
+URL = ''
+Enabled = false
+
+[Redirect.Language]
+Enabled = false
+
+
+
+
+# Content Files' Sourcing Location
+# NOTE:
+#   1. To denote where are the content sources.
+#   2. If you're sourcing from assets directory, prefix 'assets/'.
+#   3. If you're sourcing from layouts directory, prefix 'layouts/'.
+#   2. If you're sourcing from static directory, prefix 'static/'.
+#   3. If you're sourcing from partial directory, prefix 'layouts/partials/'.
+[Sources]
+HTML = 'layouts/content/specs/zoralab/index.html'
+JSON = 'layouts/content/specs/zoralab/index.json'
+CSS = 'layouts/content/specs/zoralab/index.css'
+JS = 'layouts/content/specs/zoralab/index.js'
+LDJSON = '__content.hestiaLDJSON'
+Contributors = '__contributors.toml'
+Thumbnails = '__thumbnails.toml'
+Languages = '__languages.toml'
+Assets = 'layouts/content/specs/zoralab/assets.toml'
+Components = 'layouts/content/specs/zoralab/components.toml'
+
+
+
+
+# Data fields.
+# NOTE:
+#   1. List only the page-level data files. It can be in any of the following
+#      formats: '.json', '.toml', or '.yaml'.
+#   2. Hestia string processing is available and shall be processed prior to
+#      dataset transformation.
+#   3. Sequences of the .Data array dictates sequences of loading and overriding
+#      (the latter shall overwrite the former for the same data fields).
+#   4. The final processed dataset shall be served as main data content in
+#      supported output format (e.g. index.json).
+#   5. Missing data file shall be ignored.
+#   6. To add more data files, simply duplicate and add more .Data array entry.
+#      Example:
+#                             [[data]]
+#                             Filename = 'file1.json'
+#
+#                             [[data]]
+#                             Filename = 'file2.toml'
+[[Data]]
+Filename = '__data.toml'

--- a/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__robots.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__thumbnails.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/thumbnails-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/thumbnails-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/thumbnails-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__twitter.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__wasm.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/_index.html
+++ b/sites/content/zh-hans/specs/hestiaGUI/shieldsBADGE/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++


### PR DESCRIPTION
Since the /en/specs/hestiaGUI/shieldsBADGE/ page is ready, we can proceed to translate it. Hence, let's do this.

This patch translates /zh-hans/specs/shieldsBADGE/ page in sites/ directory.