### PR TITLE
sites: ported /en/specs/hestiaGUI/zoralabBUTTON/ page

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabBUTTON/CSS
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabBUTTON/CSS
@@ -28,11 +28,6 @@ button,
 
 	border: var(--button-border);
 	border-radius: var(--button-border-radius);
-	box-shadow: var(--button-box-shadow);
-
-	color: var(--button-color);
-	background: var(--button-background);
-	border-color: var(--button-color);
 
 	font-size: var(--button-font-size);
 	font-weight: var(--button-font-weight);
@@ -44,56 +39,61 @@ button,
 	word-break: var(--button-word-break);
 	line-height: var(--button-line-height);
 
+	color: var(--button-color);
+	background: var(--button-background);
+	border-color: var(--button-color);
+	box-shadow: var(--button-box-shadow);
+
 	transition: var(--button-transition);
 }
 
-input[type='button'].emphasize,
-input[type='reset'].emphasize,
-input[type='submit'].emphasize,
-button.emphasize,
-.button.emphasize {
+:is(input[type='button'],
+	input[type='reset'],
+	input[type='submit'],
+	button,
+	.button
+).emphasize {
 	color: var(--button-color-inverted);
 	background: var(--button-color);
 }
 
-input[type='button']:disabled,
-input[type='reset']:disabled,
-input[type='submit']:disabled,
-button:disabled,
-.button:disabled {
+:is(input[type='button'],
+	input[type='reset'],
+	input[type='submit'],
+	button,
+	.button
+):disabled {
 	box-shadow: none;
 	opacity: var(--button-opacity-disabled);
 }
 
-input[type='button']:not([disabled]):hover, input[type='button']:not([disabled]):focus,
-input[type='reset']:not([disabled]):hover, input[type='reset']:not([disabled]):focus,
-input[type='submit']:not([disabled]):hover, input[type='submit']:not([disabled]):focus,
-button:not([disabled]):hover, button:not([disabled]):focus,
-.button:not([disabled]):hover, .button:not([disabled]):focus {
+:is(input[type='button'],
+	input[type='reset'],
+	input[type='submit'],
+	button,
+	.button
+):not([disabled]):is(:hover, :focus) {
 	border: var(--button-border);
 	border-color: var(--button-color);
 	transform: var(--button-transform-focus);
 }
 
-input[type='button']:not(.emphasize):not([disabled]):hover,
-input[type='button']:not(.emphasize):not([disabled]):focus,
-input[type='reset']:not(.emphasize):not([disabled]):hover,
-input[type='reset']:not(.emphasize):not([disabled]):focus,
-input[type='submit']:not(.emphasize):not([disabled]):hover,
-input[type='submit']:not(.emphasize):not([disabled]):focus,
-button:not(.emphasize):not([disabled]):hover,
-button:not(.emphasize):not([disabled]):focus,
-.button:not(.emphasize):not([disabled]):hover,
-.button:not(.emphasize):not([disabled]):focus {
+:is(input[type='button'],
+	input[type='reset'],
+	input[type='submit'],
+	button,
+	.button
+):not(.emphasize):not([disabled]):is(:hover, :focus) {
 	color: var(--button-color-inverted);
 	background: var(--button-color);
 }
 
-input[type='button']:not([disabled]):active,
-input[type='reset']:not([disabled]):active,
-input[type='submit']:not([disabled]):active,
-button:not(disabled):active,
-.button:not(disabled):active {
+:is(input[type='button'],
+	input[type='reset'],
+	input[type='submit'],
+	button,
+	.button
+):not([disabled]):active {
 	box-shadow: none;
 }
 

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabBUTTON/CSSVariables
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabBUTTON/CSSVariables
@@ -3,18 +3,20 @@
 "--button-opacity" = "1"
 "--button-opacity-disabled" = ".3"
 
+
+
+
 "--button-margin" = ".5rem 1.2rem"
 "--button-padding" = "1.3rem"
 
+
+
+
 "--button-border" = "2px solid var(--button-color)"
 "--button-border-radius" = ".5rem"
-"--button-box-shadow" = "0 .5rem 1rem var(--color-typography-400)"
 
-"--button-color" = "var(--color-primary-600)"
-"--button-color-inverted" = "var(--color-typography-100)"
-"--button-color-print" = "var(--body-color-print)"
-"--button-background" = "var(--body-background)"
-"--button-background-print" = "var(--body-background-print)"
+
+
 
 "--button-font-size" = "var(--body-font-size)"
 "--button-font-weight" = "700"
@@ -26,5 +28,18 @@
 "--button-word-break" = "normal"
 "--button-line-height" = "var(--body-line-height)"
 
+
+
+
+"--button-color" = "var(--color-primary-600)"
+"--button-color-inverted" = "var(--color-typography-100)"
+"--button-color-print" = "var(--body-color-print)"
+"--button-background" = "color-mix(in srgb, var(--button-color) 9%, #fff)"
+"--button-background-print" = "var(--body-background-print)"
+"--button-box-shadow" = "0 .5rem 1rem var(--color-typography-400)"
+
+
+
+
 "--button-transition" = "var(--timing-rapid)"
-"--button-transform-focus" = "scale(1.1)"
+"--button-transform-focus" = "scale(1.2)"

--- a/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__content.hestiaLDJSON
+++ b/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__content.hestiaLDJSON
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (partial "hestiaJSON/schemaorgLDJSON/WebPage" .) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__contributors.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__contributors.toml
@@ -1,0 +1,78 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...
+[[Contributors]]
+Key = 'ZORALab'
+
+[Contributors.Contribution]
+Creation = true
+Contact = true
+Artwork = false
+Knowledge = false
+Editor = true
+Developer = false
+Maintainer = false
+Producer = true
+Provider = true
+Publisher = true
+Funder = false
+Sponsor = true
+
+
+
+
+[[Contributors]]
+Key = 'HollowayKeanHo'
+
+[Contributors.Contribution]
+Creation = true
+Contact = false
+Artwork = false
+Knowledge = true
+Editor = true
+Developer = false
+Maintainer = false
+Producer = false
+Provider = false
+Publisher = false
+Funder = false
+Sponsor = false

--- a/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__data.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__data.toml
@@ -1,0 +1,2 @@
+[Dataset]
+Path = 'hestiaGUI.zoralabBUTTON'

--- a/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__languages.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = '/en/specs/hestiagui/zoralabbutton'
+
+[zh-Hans]
+URL = '/zh-hans/specs/hestiagui/zoralabbutton'

--- a/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__page.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__page.toml
@@ -1,0 +1,125 @@
+# PAGE METADATA
+# =============
+# Date fields.
+#
+# NOTE:
+#   1. You can generate date easily on linux using '$ date' command.
+#   2. If date field is left blank, the current time shall be used instead.
+#   3. Date should ONLY comply to this pattern when manually constructed:
+#                    Thu 21 Jul 2022 14:27:39 PM +08
+[Date]
+Created   = "Tue 13 Dec 2022 10:32:03 AM +08"
+Published = "Tue 13 Dec 2022 10:32:03 AM +08"
+
+
+
+
+# Content fields.
+# NOTE:
+#   1. For .Title, Hestia's string processing using page variables are allowed
+#      and only limited to .Titles sub-fields.
+#   2. For .Keywords, Hestia's string processing using page variables are
+#      allowed but strongly discouraged.
+[Content]
+Title = "zoralabBUTTON Technical Specification - ZORALab's Hestia"
+Keywords = [
+	'zoralabBUTTON',
+	'hestiaGUI',
+	'Technical Specifications',
+	'Specifications',
+	'Web',
+	'Tech',
+	'PWA',
+	'WASM',
+	'Software Libraries',
+	'Hugo',
+	'Go',
+	'TinyGo',
+	'Nim',
+	'ZORALab',
+	"ZORALab's Hestia",
+]
+
+
+
+
+# Description fields.
+# NOTE:
+#   1. Hestia's string processing using page variables are allowed.
+#   2. The .Description.Pitch is at maximum 160 characters.
+#   3. The .Description.Summary is at maximum of 250 characters.
+#   4. All fields shall have their whitespace cleansed during the processing.
+[Description]
+Pitch = '''
+The technical specifications to refer when using the package.
+'''
+Summary = '''
+Easy-going, offline supported (via web PWA installation), and detailed oriented.
+Courtesy from ZORALab's Hestia.
+'''
+
+
+
+
+# Redirect fields.
+# NOTE:
+#   1. Hestia's URL processing is allowed for .URL field.
+#   2. .Delay timing sets the delay time before redirect. Setting to '0' means
+#      an immediate redirect is requested.
+#   3. Redirect is only available if .Enabled is set to 'true'.
+#   4. Redirect.Language is to redirect the current page to its
+#      language-specific page when Javascript is made available on client side
+#      or fallback to default language.
+[Redirect]
+Delay = 0 # second
+URL = ''
+Enabled = false
+
+[Redirect.Language]
+Enabled = false
+
+
+
+
+# Content Files' Sourcing Location
+# NOTE:
+#   1. To denote where are the content sources.
+#   2. If you're sourcing from assets directory, prefix 'assets/'.
+#   3. If you're sourcing from layouts directory, prefix 'layouts/'.
+#   2. If you're sourcing from static directory, prefix 'static/'.
+#   3. If you're sourcing from partial directory, prefix 'layouts/partials/'.
+[Sources]
+HTML = 'layouts/content/specs/zoralab/index.html'
+JSON = 'layouts/content/specs/zoralab/index.json'
+CSS = 'layouts/content/specs/zoralab/index.css'
+JS = 'layouts/content/specs/zoralab/index.js'
+LDJSON = '__content.hestiaLDJSON'
+Contributors = '__contributors.toml'
+Thumbnails = '__thumbnails.toml'
+Languages = '__languages.toml'
+Assets = 'layouts/content/specs/zoralab/assets.toml'
+Components = 'layouts/content/specs/zoralab/components.toml'
+
+
+
+
+# Data fields.
+# NOTE:
+#   1. List only the page-level data files. It can be in any of the following
+#      formats: '.json', '.toml', or '.yaml'.
+#   2. Hestia string processing is available and shall be processed prior to
+#      dataset transformation.
+#   3. Sequences of the .Data array dictates sequences of loading and overriding
+#      (the latter shall overwrite the former for the same data fields).
+#   4. The final processed dataset shall be served as main data content in
+#      supported output format (e.g. index.json).
+#   5. Missing data file shall be ignored.
+#   6. To add more data files, simply duplicate and add more .Data array entry.
+#      Example:
+#                             [[data]]
+#                             Filename = 'file1.json'
+#
+#                             [[data]]
+#                             Filename = 'file2.toml'
+[[Data]]
+Filename = '__data.toml'

--- a/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__robots.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__thumbnails.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/thumbnails-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/thumbnails-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/thumbnails-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__twitter.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__wasm.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabBUTTON/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/en/specs/hestiaGUI/zoralabBUTTON/_index.html
+++ b/sites/content/en/specs/hestiaGUI/zoralabBUTTON/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++

--- a/sites/data/Specs/hestiaGUI/zoralabBUTTON/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabBUTTON/Designs.toml
@@ -114,7 +114,11 @@ Plain = '''
 The minimum required HTML codes are shown below:
 '''
 Code = '''
-<pre>...</pre>
+<a class="button" ...>...</a>
+
+<button>...</button>
+
+<input type="submit" ... />
 '''
 
 [[EN.List.SubList.URL]]
@@ -131,7 +135,11 @@ Plain = '''
 在最小的HTML代码运用方法如下：
 '''
 Code = '''
-<pre>...</pre>
+<a class="button" ...>...</a>
+
+<button>...</button>
+
+<input type="submit" ... />
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -141,15 +149,15 @@ Label = ''
 
 
 [[EN.List.SubList]]
-Title = 'Recommended HTML'
+Title = 'Disabled Button HTML'
 HTML = '''
-The recomemnded HTML codes are shown below:
+The disabled button HTML codes are shown below:
 '''
 Plain = '''
-The recommended HTML codes are shown below:
+The disabled button HTML codes are shown below:
 '''
 Code = '''
-<pre><code>...</code></pre>
+<button disabled>...</button>
 '''
 
 [[EN.List.SubList.URL]]
@@ -158,15 +166,15 @@ Label = ''
 
 
 [[ZH-HANS.List.SubList]]
-Title = '推荐的HTML'
+Title = '禁用按钮的HTML'
 HTML = '''
-推荐的HTML代码运用方法如下：
+禁用按钮的HTML代码运用方法如下：
 '''
 Plain = '''
-推荐的HTML代码运用方法如下：
+禁用按钮的HTML代码运用方法如下：
 '''
 Code = '''
-<pre><code>...</code></pre>
+<button disabled>...</button>
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -224,9 +232,9 @@ Plain = '''
 Affects the display mode of the rendered component.
 '''
 Code = '''
-VARIABLE     : --pre-display
+VARIABLE     : --button-display
 CSS PROPERTY : display
-DEFAULT      : block (>= v1.0.0)
+DEFAULT      : inline-block (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -243,9 +251,9 @@ Plain = '''
 影响元件的显示模式。
 '''
 Code = '''
-变化值     : --pre-display
+变化值     : --button-display
 CSS属性    : display
-默认数码   : block (>= v1.0.0)
+默认数码   : inline-block (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -255,17 +263,17 @@ Label = ''
 
 
 [[EN.List.SubList]]
-Title = 'Box-Sizing'
+Title = 'Opacity'
 HTML = '''
-Affects the box-sizing behavior of the rendered component.
+Affects the opacity of the rendered component.
 '''
 Plain = '''
-Affects the box-sizing behavior of the rendered component.
+Affects the opacity of the rendered component.
 '''
 Code = '''
-VARIABLE     : --pre-box-sizing
-CSS PROPERTY : box-sizing
-DEFAULT      : border-box (>= v1.0.0)
+VARIABLE     : --button-opacity
+CSS PROPERTY : opacity
+DEFAULT      : 1 (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -274,17 +282,56 @@ Label = ''
 
 
 [[ZH-HANS.List.SubList]]
-Title = 'Box-Sizing'
+Title = 'Opacity'
 HTML = '''
-影响元件的大小控制态度。
+影响元件的显示透明度。
 '''
 Plain = '''
-影响元件的大小控制态度。
+影响元件的显示透明度。
 '''
 Code = '''
-变化值     : --pre-box-sizing
-CSS属性    : box-sizing
-默认数码   : border-box (>= v1.0.0)
+变化值     : --button-opacity
+CSS属性    : opacity
+默认数码   : 1 (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Opacity (Disabled)'
+HTML = '''
+Affects the opacity of the rendered component when disabled.
+'''
+Plain = '''
+Affects the opacity of the rendered component when disabled.
+'''
+Code = '''
+VARIABLE     : --button-opacity-disabled
+CSS PROPERTY : opacity
+DEFAULT      : .3 (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Opacity（被禁用）'
+HTML = '''
+影响元件在被禁用时的显示透明度。
+'''
+Plain = '''
+影响元件在被禁用时的显示透明度。
+'''
+Code = '''
+变化值     : --button-opacity-disabled
+CSS属性    : opacity
+默认数码   : .3 (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -302,9 +349,9 @@ Plain = '''
 Affects the margin of the rendered component.
 '''
 Code = '''
-VARIABLE     : --pre-margin
+VARIABLE     : --button-margin
 CSS PROPERTY : margin
-DEFAULT      : 2rem auto (>= v1.0.0)
+DEFAULT      : .5rem 1.2rem (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -321,9 +368,9 @@ Plain = '''
 影响元件的外向边距空间。
 '''
 Code = '''
-变化值     : --pre-margin
+变化值     : --button-margin
 CSS属性    : margin
-默认数码   : 2rem auto (>= v1.0.0)
+默认数码   : .5rem 1.2rem (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -341,9 +388,9 @@ Plain = '''
 Affects the padding of the rendered component.
 '''
 Code = '''
-VARIABLE     : --pre-padding
+VARIABLE     : --button-padding
 CSS PROPERTY : padding
-DEFAULT      : 2rem (>= v1.0.0)
+DEFAULT      : 1.3rem (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -360,48 +407,9 @@ Plain = '''
 影响元件的内向边距空间。
 '''
 Code = '''
-变化值     : --pre-padding
+变化值     : --button-padding
 CSS属性    : padding
-默认数码   : 2rem (>= v1.0.0)
-'''
-
-[[ZH-HANS.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-
-[[EN.List.SubList]]
-Title = 'Overflow'
-HTML = '''
-Affects the overflow behavior of the rendered component.
-'''
-Plain = '''
-Affects the overflow behavior of the rendered component.
-'''
-Code = '''
-VARIABLE     : --pre-overflow
-CSS PROPERTY : overflow
-DEFAULT      : auto auto (>= v1.0.0)
-'''
-
-[[EN.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-[[ZH-HANS.List.SubList]]
-Title = 'Overflow'
-HTML = '''
-影响元件的在溢出包装时的反应条件。
-'''
-Plain = '''
-影响元件的在溢出包装时的反应条件。
-'''
-Code = '''
-变化值     : --pre-overflow
-CSS属性    : overflow
-默认数码   : auto auto (>= v1.0.0)
+默认数码   : 1.3rem (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -419,9 +427,9 @@ Plain = '''
 Affects the border of the rendered component.
 '''
 Code = '''
-VARIABLE     : --pre-border
+VARIABLE     : --button-border
 CSS PROPERTY : border
-DEFAULT      : .3rem solid var(--pre-color) (>= v1.0.0)
+DEFAULT      : 2px solid var(--button-color) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -438,9 +446,9 @@ Plain = '''
 影响元件的边界线。
 '''
 Code = '''
-变化值     : --pre-border
+变化值     : --button-border
 CSS属性    : border
-默认数码   : .3rem solid var(--pre-color) (>= v1.0.0)
+默认数码   : 2px solid var(--button-color) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -458,9 +466,9 @@ Plain = '''
 Affects the border radius of the rendered component.
 '''
 Code = '''
-VARIABLE     : --pre-border-radius
+VARIABLE     : --button-border-radius
 CSS PROPERTY : border-radius
-DEFAULT      : .5rem (>= v1.0.0)
+DEFAULT      : .5rem (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -477,243 +485,9 @@ Plain = '''
 影响元件边界线的角落圆形度。
 '''
 Code = '''
-变化值     : --pre-border-radius
+变化值     : --button-border-radius
 CSS属性    : border-radius
-默认数码   : .5rem (>= v1.0.0)
-'''
-
-[[ZH-HANS.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-
-[[EN.List.SubList]]
-Title = 'Min-Width'
-HTML = '''
-Affects the minimum width of the rendered component.
-'''
-Plain = '''
-Affects the minimum width of the rendered component.
-'''
-Code = '''
-VARIABLE     : --pre-min-width
-CSS PROPERTY : min-width
-DEFAULT      : initial (>= v1.0.0)
-'''
-
-[[EN.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-[[ZH-HANS.List.SubList]]
-Title = 'Min-Width'
-HTML = '''
-影响元件的最少宽度。
-'''
-Plain = '''
-影响元件的最少宽度。
-'''
-Code = '''
-变化值     : --pre-min-width
-CSS属性    : min-width
-默认数码   : initial (>= v1.0.0)
-'''
-
-[[ZH-HANS.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-
-[[EN.List.SubList]]
-Title = 'Width'
-HTML = '''
-Affects the width of the rendered component.
-'''
-Plain = '''
-Affects the width of the rendered component.
-'''
-Code = '''
-VARIABLE     : --pre-width
-CSS PROPERTY : width
-DEFAULT      : 100% (>= v1.2.0), 80% (<= v1.1.0)
-'''
-
-[[EN.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-[[ZH-HANS.List.SubList]]
-Title = 'Width'
-HTML = '''
-影响元件的宽度。
-'''
-Plain = '''
-影响元件的宽度。
-'''
-Code = '''
-变化值     : --pre-width
-CSS属性    : width
-默认数码   : 100% (>= v1.2.0), 80% (<= v1.1.0)
-'''
-
-[[ZH-HANS.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-
-[[EN.List.SubList]]
-Title = 'Max-Width'
-HTML = '''
-Affects the maximum width of the rendered component.
-'''
-Plain = '''
-Affects the maximum width of the rendered component.
-'''
-Code = '''
-VARIABLE     : --pre-max-width
-CSS PROPERTY : max-width
-DEFAULT      : 100% (>= v1.2.0), 80% (<= v1.1.0)
-'''
-
-[[EN.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-[[ZH-HANS.List.SubList]]
-Title = 'Max-Width'
-HTML = '''
-影响元件的宽度。
-'''
-Plain = '''
-影响元件的宽度。
-'''
-Code = '''
-变化值     : --pre-max-width
-CSS属性    : max-width
-默认数码   : 100% (>= v1.2.0), 80% (<= v1.1.0)
-'''
-
-[[ZH-HANS.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-
-[[EN.List.SubList]]
-Title = 'Min-Height'
-HTML = '''
-Affects the minimum height of the rendered component.
-'''
-Plain = '''
-Affects the minimum height of the rendered component.
-'''
-Code = '''
-VARIABLE     : --pre-min-height
-CSS PROPERTY : min-height
-DEFAULT      : initial (>= v1.0.0)
-'''
-
-[[EN.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-[[ZH-HANS.List.SubList]]
-Title = 'Min-Height'
-HTML = '''
-影响元件的最少高度。
-'''
-Plain = '''
-影响元件的最少高度。
-'''
-Code = '''
-变化值     : --pre-min-height
-CSS属性    : min-hieght
-默认数码   : initial (>= v1.0.0)
-'''
-
-[[ZH-HANS.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-
-[[EN.List.SubList]]
-Title = 'Height'
-HTML = '''
-Affects the height of the rendered component.
-'''
-Plain = '''
-Affects the height of the rendered component.
-'''
-Code = '''
-VARIABLE     : --pre-height
-CSS PROPERTY : height
-DEFAULT      : initial (>= v1.0.0)
-'''
-
-[[EN.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-[[ZH-HANS.List.SubList]]
-Title = 'Height'
-HTML = '''
-影响元件的高度。
-'''
-Plain = '''
-影响元件的高度。
-'''
-Code = '''
-变化值     : --pre-height
-CSS属性    : height
-默认数码   : initial (>= v1.0.0)
-'''
-
-[[ZH-HANS.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-
-[[EN.List.SubList]]
-Title = 'Max-Height'
-HTML = '''
-Affects the maximum height of the rendered component.
-'''
-Plain = '''
-Affects the maximum height of the rendered component.
-'''
-Code = '''
-VARIABLE     : --pre-max-height
-CSS PROPERTY : max-height
-DEFAULT      : initial (>= v1.0.0)
-'''
-
-[[EN.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-[[ZH-HANS.List.SubList]]
-Title = 'Max-Height'
-HTML = '''
-影响元件的最大高度。
-'''
-Plain = '''
-影响元件的最大高度。
-'''
-Code = '''
-变化值     : --pre-max-height
-CSS属性    : max-height
-默认数码   : initial (>= v1.0.0)
+默认数码   : .5rem (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -731,9 +505,9 @@ Plain = '''
 Affects the font size of the rendered component.
 '''
 Code = '''
-VARIABLE     : --pre-font-size
+VARIABLE     : --button-font-size
 CSS PROPERTY : font-size
-DEFAULT      : var(--body-font-size) (>= v1.0.0)
+DEFAULT      : var(--body-font-size) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -750,9 +524,9 @@ Plain = '''
 影响元件的字体大小。
 '''
 Code = '''
-变化值     : --pre-font-size
+变化值     : --button-font-size
 CSS属性    : font-size
-默认数码   : var(--body-font-size) (>= v1.0.0)
+默认数码   : var(--body-font-size) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -762,17 +536,17 @@ Label = ''
 
 
 [[EN.List.SubList]]
-Title = 'Font Family'
+Title = 'Font Weight'
 HTML = '''
-Affects the font family of the rendered component.
+Affects the font weight of the rendered component.
 '''
 Plain = '''
-Affects the font family of the rendered component.
+Affects the font weight of the rendered component.
 '''
 Code = '''
-VARIABLE     : --pre-font-family
-CSS PROPERTY : font-family
-DEFAULT      : monospace (>= v1.0.0)
+VARIABLE     : --button-font-weight
+CSS PROPERTY : font-weight
+DEFAULT      : 700 (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -781,173 +555,17 @@ Label = ''
 
 
 [[ZH-HANS.List.SubList]]
-Title = 'Font Family'
+Title = 'Font Weight'
 HTML = '''
-影响元件的字体系列。
+影响元件的字体厚度。
 '''
 Plain = '''
-影响元件的字体系列。
+影响元件的字体厚度。
 '''
 Code = '''
-变化值     : --pre-font-family
-CSS属性    : font-family
-默认数码   : monospace (>= v1.0.0)
-'''
-
-[[ZH-HANS.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-
-[[EN.List.SubList]]
-Title = 'Text Decoration'
-HTML = '''
-Affects the text decoration of the rendered component.
-'''
-Plain = '''
-Affects the text decoration of the rendered component.
-'''
-Code = '''
-VARIABLE     : --pre-text-decoration
-CSS PROPERTY : text-decoration
-DEFAULT      : normal (>= v1.0.0)
-'''
-
-[[EN.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-[[ZH-HANS.List.SubList]]
-Title = 'Text Decoration'
-HTML = '''
-影响元件的字体装饰。
-'''
-Plain = '''
-影响元件的字体装饰。
-'''
-Code = '''
-变化值     : --pre-text-decoration
-CSS属性    : text-decoration
-默认数码   : normal (>= v1.0.0)
-'''
-
-[[ZH-HANS.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-
-[[EN.List.SubList]]
-Title = 'Word Break'
-HTML = '''
-Affects the word breaking behavior of the rendered component.
-'''
-Plain = '''
-Affects the word breaking behavior of the rendered component.
-'''
-Code = '''
-VARIABLE     : --pre-word-break
-CSS PROPERTY : word-break
-DEFAULT      : keep-all (>= v1.0.0)
-'''
-
-[[EN.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-[[ZH-HANS.List.SubList]]
-Title = 'Word Break'
-HTML = '''
-影响元件的字体分裂条件。
-'''
-Plain = '''
-影响元件的字体分裂条件。
-'''
-Code = '''
-变化值     : --pre-word-break
-CSS属性    : word-break
-默认数码   : keep-all (>= v1.0.0)
-'''
-
-[[ZH-HANS.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-
-[[EN.List.SubList]]
-Title = 'Letter Spacing'
-HTML = '''
-Affects the letter spacing of the rendered component.
-'''
-Plain = '''
-Affects the letter spacing of the rendered component.
-'''
-Code = '''
-VARIABLE     : --pre-letter-spacing
-CSS PROPERTY : letter-spacing
-DEFAULT      : 0 (>= v1.0.0)
-'''
-
-[[EN.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-[[ZH-HANS.List.SubList]]
-Title = 'Letter Spacing'
-HTML = '''
-影响元件的每个字体的空间距离。
-'''
-Plain = '''
-影响元件的每个字体的空间距离。
-'''
-Code = '''
-变化值     : --pre-letter-spacing
-CSS属性    : letter-spacing
-默认数码   : 0 (>= v1.0.0)
-'''
-
-[[ZH-HANS.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-
-[[EN.List.SubList]]
-Title = 'Line Height'
-HTML = '''
-Affects the line height of the rendered component.
-'''
-Plain = '''
-Affects the line height of the rendered component.
-'''
-Code = '''
-VARIABLE     : --pre-line-height
-CSS PROPERTY : line-height
-DEFAULT      : var(--body-line-height) (>= v1.0.0)
-'''
-
-[[EN.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-[[ZH-HANS.List.SubList]]
-Title = 'Line Height'
-HTML = '''
-影响元件的字体的高度。
-'''
-Plain = '''
-影响元件的字体的高度。
-'''
-Code = '''
-变化值     : --pre-line-height
-CSS属性    : line-height
-默认数码   : var(--body-line-height) (>= v1.0.0)
+变化值     : --button-font-weight
+CSS属性    : font-weight
+默认数码   : 700 (>= v1.0.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -965,9 +583,9 @@ Plain = '''
 Affects the text alignment of the rendered component.
 '''
 Code = '''
-VARIABLE     : --pre-text-align
+VARIABLE     : --button-text-align
 CSS PROPERTY : text-align
-DEFAULT      : justify (>= v1.0.0)
+DEFAULT      : center (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -978,15 +596,15 @@ Label = ''
 [[ZH-HANS.List.SubList]]
 Title = 'Text Align'
 HTML = '''
-影响元件的文字对齐方式。
+影响元件的字体对齐方式。
 '''
 Plain = '''
-影响元件的文字对齐方式。
+影响元件的字体对齐方式。
 '''
 Code = '''
-变化值     : --pre-text-align
+变化值     : --button-text-align
 CSS属性    : text-align
-默认数码   : justify (>= v1.0.0)
+默认数码   : center (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -996,17 +614,17 @@ Label = ''
 
 
 [[EN.List.SubList]]
-Title = 'White-space'
+Title = 'Text Decoration'
 HTML = '''
-Affects the white-spacing behavior of the rendered component.
+Affects the text decoration of the rendered component.
 '''
 Plain = '''
-Affects the white-spacing behavior of the rendered component.
+Affects the text decoration of the rendered component.
 '''
 Code = '''
-VARIABLE     : --pre-white-space
-CSS PROPERTY : white-space
-DEFAULT      : pre (>= v1.0.0)
+VARIABLE     : --button-text-decoration
+CSS PROPERTY : text-decoration
+DEFAULT      : none (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -1015,17 +633,173 @@ Label = ''
 
 
 [[ZH-HANS.List.SubList]]
-Title = 'White-space'
+Title = 'Text Decoration'
 HTML = '''
-影响元件的空白字体处理条件。
+影响元件的字体装饰。
 '''
 Plain = '''
-影响元件的空白字体处理条件。
+影响元件的字体装饰。
 '''
 Code = '''
-变化值     : --pre-white-space
-CSS属性    : white-space
-默认数码   : pre (>= v1.0.0)
+变化值     : --button-text-decoration
+CSS属性    : text-decoration
+默认数码   : none (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Text Transform'
+HTML = '''
+Affects the text transformation of the rendered component.
+'''
+Plain = '''
+Affects the text transformation of the rendered component.
+'''
+Code = '''
+VARIABLE     : --button-text-transform
+CSS PROPERTY : text-transform
+DEFAULT      : uppercase (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Text Transform'
+HTML = '''
+影响元件的字体变形条件。
+'''
+Plain = '''
+影响元件的字体变形条件。
+'''
+Code = '''
+变化值     : --button-text-transform
+CSS属性    : text-transform
+默认数码   : uppercase (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Word Break'
+HTML = '''
+Affects the word breaking behavior of the rendered component.
+'''
+Plain = '''
+Affects the word breaking behavior of the rendered component.
+'''
+Code = '''
+VARIABLE     : --button-word-break
+CSS PROPERTY : word-break
+DEFAULT      : normal (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Word Break'
+HTML = '''
+影响元件的字体分裂条件。
+'''
+Plain = '''
+影响元件的字体分裂条件。
+'''
+Code = '''
+变化值     : --button-word-break
+CSS属性    : word-break
+默认数码   : normal (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Overflow Wrap'
+HTML = '''
+Affects the overflow wrapping behavior of the rendered component.
+'''
+Plain = '''
+Affects the overflow wrapping behavior of the rendered component.
+'''
+Code = '''
+VARIABLE     : --button-overflow-wrap
+CSS PROPERTY : overflow-wrap
+DEFAULT      : normal (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Overflow Wrap'
+HTML = '''
+影响元件的在溢出包装时的反应。
+'''
+Plain = '''
+影响元件的在溢出包装时的反应。
+'''
+Code = '''
+变化值     : --button-overflow-wrap
+CSS属性    : overflow-wrap
+默认数码   : normal (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Line Height'
+HTML = '''
+Affects the line height of the rendered component.
+'''
+Plain = '''
+Affects the line height of the rendered component.
+'''
+Code = '''
+VARIABLE     : --button-line-height
+CSS PROPERTY : line-height
+DEFAULT      : var(--body-line-height) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Line Height'
+HTML = '''
+影响元件的字体的高度。
+'''
+Plain = '''
+影响元件的字体的高度。
+'''
+Code = '''
+变化值     : --button-line-height
+CSS属性    : line-height
+默认数码   : var(--body-line-height) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -1043,9 +817,9 @@ Plain = '''
 Affects the color of the rendered component.
 '''
 Code = '''
-VARIABLE     : --pre-color
+VARIABLE     : --button-color
 CSS PROPERTY : color
-DEFAULT      : var(--color-primary-300) (>= v1.0.0)
+DEFAULT      : var(--color-primary-600) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -1062,9 +836,9 @@ Plain = '''
 影响元件的颜色。
 '''
 Code = '''
-变化值     : --pre-color
+变化值     : --button-color
 CSS属性    : color
-默认数码   : var(--color-primary-300) (>= v1.0.0)
+默认数码   : var(--color-primary-600) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -1082,9 +856,9 @@ Plain = '''
 Affects the color of the rendered component while in inverted mode.
 '''
 Code = '''
-VARIABLE     : --pre-color-inverted
+VARIABLE     : --button-color-inverted
 CSS PROPERTY : color
-DEFAULT      : var(--color-primary-300) (>= v1.0.0)
+DEFAULT      : var(--color-typography-100) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -1101,9 +875,9 @@ Plain = '''
 影响元件在反转环境里的颜色。
 '''
 Code = '''
-变化值     : --pre-color-inverted
+变化值     : --button-color-inverted
 CSS属性    : color
-默认数码   : var(--color-primary-300) (>= v1.0.0)
+默认数码   : var(--color-typography-100) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -1121,9 +895,9 @@ Plain = '''
 Affects the color of the rendered component when in print mode.
 '''
 Code = '''
-VARIABLE     : --pre-color-print
+VARIABLE     : --button-color-print
 CSS PROPERTY : color
-DEFAULT      : var(--color-primary-300) (>= v1.0.0)
+DEFAULT      : var(--body-color-print) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -1140,9 +914,9 @@ Plain = '''
 影响元件在印刷环境里的颜色。
 '''
 Code = '''
-变化值     : --pre-color-print
+变化值     : --button-color-print
 CSS属性    : color
-默认数码   : var(--color-primary-300) (>= v1.0.0)
+默认数码   : var(--body-color-print) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -1160,9 +934,9 @@ Plain = '''
 Affects the background of the rendered component.
 '''
 Code = '''
-VARIABLE     : --pre-background
+VARIABLE     : --button-background
 CSS PROPERTY : background
-DEFAULT      : var(--color-contrast-50) (>= v1.0.0)
+DEFAULT      : color-mix(in srgb, var(--button-color) 9%, #fff) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -1179,48 +953,9 @@ Plain = '''
 影响元件的背景。
 '''
 Code = '''
-变化值     : --pre-background
+变化值     : --button-background
 CSS属性    : background
-默认数码   : var(--color-contrast-50) (>= v1.0.0)
-'''
-
-[[ZH-HANS.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-
-[[EN.List.SubList]]
-Title = 'Background (Inverted Mode)'
-HTML = '''
-Affects the background of the rendered component while in inverted mode.
-'''
-Plain = '''
-Affects the background of the rendered component while in inverted mode.
-'''
-Code = '''
-VARIABLE     : --pre-background-inverted
-CSS PROPERTY : background
-DEFAULT      : var(--color-contrast-50) (>= v1.0.0)
-'''
-
-[[EN.List.SubList.URL]]
-Value = ''
-Label = ''
-
-
-[[ZH-HANS.List.SubList]]
-Title = 'Background （反转环境）'
-HTML = '''
-影响元件在反转环境里的背景。
-'''
-Plain = '''
-影响元件在反转环境里的背景。
-'''
-Code = '''
-变化值     : --pre-background-inverted
-CSS属性    : background
-默认数码   : var(--color-contrast-50) (>= v1.0.0)
+默认数码   : color-mix(in srgb, var(--button-color) 9%, #fff) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -1238,9 +973,9 @@ Plain = '''
 Affects the background of the rendered component when in print mode.
 '''
 Code = '''
-VARIABLE     : --pre-background-print
+VARIABLE     : --button-background-print
 CSS PROPERTY : background
-DEFAULT      : var(--body-background-print) (>= v1.0.0)
+DEFAULT      : var(--body-background-print) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -1257,9 +992,48 @@ Plain = '''
 影响元件在印刷环境里的背景。
 '''
 Code = '''
-变化值     : --pre-background-print
+变化值     : --button-background-print
 CSS属性    : background
-默认数码   : var(--body-background-print) (>= v1.0.0)
+默认数码   : var(--body-background-print) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Box Shadow'
+HTML = '''
+Affects the box shadow of the rendered component when in print mode.
+'''
+Plain = '''
+Affects the box shadow of the rendered component when in print mode.
+'''
+Code = '''
+VARIABLE     : --button-box-shadow
+CSS PROPERTY : box-shadow
+DEFAULT      : 0 .5rem 1rem var(--color-typography-400) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Box Shadow'
+HTML = '''
+影响元件的影子。
+'''
+Plain = '''
+影响元件的影子。
+'''
+Code = '''
+变化值     : --button-box-shadow
+CSS属性    : box-shadow
+默认数码   : 0 .5rem 1rem var(--color-typography-400) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -1277,7 +1051,7 @@ Plain = '''
 Affects the animation timing of the rendered component.
 '''
 Code = '''
-VARIABLE     : --pre-transition
+VARIABLE     : --button-transition
 CSS PROPERTY : transition
 DEFAULT      : var(--timing-rapid) (>= v1.2.0)
 '''
@@ -1296,9 +1070,48 @@ Plain = '''
 影响元件的动画定时。
 '''
 Code = '''
-变化值     : --pre-transition
+变化值     : --button-transition
 CSS属性    : transition
 默认数码   : var(--timing-rapid) (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Transform (Focused)'
+HTML = '''
+Affects the transformation of the rendered component when focused.
+'''
+Plain = '''
+Affects the transformation of the rendered component when focused.
+'''
+Code = '''
+VARIABLE     : --button-transform-focus
+CSS PROPERTY : transform
+DEFAULT      : scale(1.2) (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Transform（被关注）'
+HTML = '''
+影响元件在被关注时的变换方式。
+'''
+Plain = '''
+影响元件在被关注时的变换方式。
+'''
+Code = '''
+变化值     : --button-transform-focus
+CSS属性    : transform
+默认数码   : scale(1.2) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]

--- a/sites/data/Specs/hestiaGUI/zoralabBUTTON/Functions.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabBUTTON/Functions.toml
@@ -1,0 +1,138 @@
+[[EN.List]]
+Title = 'ToCSS'
+HTML = '''
+Render the CSS output for this UI component.
+'''
+Plain = '''
+Render the CSS output for this UI component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'ToCSS'
+HTML = '''
+渲染呈现CSS的输出数据。
+'''
+Plain = '''
+渲染呈现CSS的输出数据。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+Usage example:
+'''
+Plain = '''
+Usage example:
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabBUTTON/ToCSS" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+用法：
+'''
+Plain = '''
+用法：
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabBUTTON/ToCSS" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'ToCSS_VARIABLES'
+HTML = '''
+Render the CSS variables output list for this UI component.
+'''
+Plain = '''
+Render the CSS variables output list for this UI component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'ToCSS_VARIABLES'
+HTML = '''
+渲染呈现CSS变化值数据的输出菜单。
+'''
+Plain = '''
+渲染呈现CSS变化值数据的输出菜单。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+Usage example:
+'''
+Plain = '''
+Usage example:
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabBUTTON/ToCSS_VARIABLES" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+用法：
+'''
+Plain = '''
+用法：
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabBUTTON/ToCSS_VARIABLES" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/data/Specs/hestiaGUI/zoralabBUTTON/Metadata.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabBUTTON/Metadata.toml
@@ -1,0 +1,14 @@
+[EN.Brand]
+ID = 'zoralabbutton'
+SKU = 'zoralabBUTTON'
+Description = '''
+For styling a button syntax.
+'''
+
+
+[ZH-HANS.Brand]
+ID = 'zoralabbutton'
+SKU = 'zoralabBUTTON'
+Description = '''
+来渲染按钮。
+'''

--- a/sites/data/Specs/hestiaGUI/zoralabBUTTON/Purposes.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabBUTTON/Purposes.toml
@@ -1,0 +1,88 @@
+[[EN.List]]
+Title = 'Main Purpose'
+HTML = '''
+This package's primary purpose is to provide user interface (UI) styling
+specifically for button values. In web UI, it is shown as follows:
+<br/><br/>
+<a href='#' class='button'>An Enabled Button</a>
+<button disabled>A Disabled Button</button>
+'''
+Plain = '''
+This package's primary purpose is to provide user interface (UI) styling
+specifically for button values. In web UI, it is shown as follows:
+
+<a href='#' class='button'>An Enabled Button</a>
+<button disabled>A Disabled Button</button>
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = '主要目的'
+HTML = '''
+这个软件包的出生主要是支持渲染按钮的界面元件。在网络界面世界里，
+这元件的成果如下：
+<br/><br/>
+<a href='#' class='button'>一个启用的按钮</a>
+<button disabled>一个禁用的按钮</button>
+'''
+Plain = '''
+这个软件包的出生主要是支持渲染按钮的界面元件。在网络界面世界里，
+这元件的成果如下：
+
+<a href='#' class='button'>一个启用的按钮</a>
+<button disabled>一个禁用的按钮</button>
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'Legacy Recording'
+HTML = '''
+This package was known as <code>button_hestiaUI</code> before ZORALab's Hestia
+<code>v1.2.0</code>. The transformation was due to someone attempting to steal
+the copyrights and makes way for programming package's documentation
+restructuring.
+'''
+Plain = '''
+This package was known as 'button_hestiaUI' before ZORALab's Hestia 'v1.2.0'.
+The transformation was due to someone attempting to steal the design copyrights
+and makes way for programming package's documentation restructuring.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = '历史遗录'
+HTML = '''
+这个软件包在ZORALab赫斯提亚<code>v1.2.0</code>版本之前曾经被名为
+<code>button_hestiaUI</code>。改名的目的是有人要横行强盗设计的版权和为了编程文件
+编写能力而整理过。
+'''
+Plain = '''
+这个软件包在ZORALab赫斯提亚v1.2.0版本之前曾经被名为button_hestiaUI。改名的目的是
+有人要横行强盗设计的版权和为了编程文件编写能力而整理过。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''


### PR DESCRIPTION
Since the /en/specs/hestiaGUI page is ready, we can proceed to port zoralabBUTTON spec page. Hence, let's do this.

This patch ports /en/specs/hestiaGUI/zoralabBUTTON/ spec page into sites/ directory.