### PR TITLE
hestiaHUGO: updated zoralabBUTTON to use currentColor as value

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabBUTTON/CSSVariables
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabBUTTON/CSSVariables
@@ -34,7 +34,7 @@
 "--button-color" = "var(--color-primary-600)"
 "--button-color-inverted" = "var(--color-typography-100)"
 "--button-color-print" = "var(--body-color-print)"
-"--button-background" = "color-mix(in srgb, var(--button-color) 9%, #fff)"
+"--button-background" = "color-mix(in srgb, currentColor 9%, #fff)"
 "--button-background-print" = "var(--body-background-print)"
 "--button-box-shadow" = "0 .5rem 1rem var(--color-typography-400)"
 

--- a/sites/data/Specs/hestiaGUI/zoralabBUTTON/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabBUTTON/Designs.toml
@@ -936,7 +936,7 @@ Affects the background of the rendered component.
 Code = '''
 VARIABLE     : --button-background
 CSS PROPERTY : background
-DEFAULT      : color-mix(in srgb, var(--button-color) 9%, #fff) (>= v1.2.0)
+DEFAULT      : color-mix(in srgb, currentColor 9%, #fff) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -955,7 +955,7 @@ Plain = '''
 Code = '''
 变化值     : --button-background
 CSS属性    : background
-默认数码   : color-mix(in srgb, var(--button-color) 9%, #fff) (>= v1.2.0)
+默认数码   : color-mix(in srgb, currentColor 9%, #fff) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]


### PR DESCRIPTION
Since CSS provides a more stable currentColor value for dynamic background rendering, we should use it instead of variable declaration. Hence, let's do this.

This patch updates zoralabBUTTON to use currentColor as value in hestiaHUGO/ directory.