### PR TITLE
sites: ported /en/specs/hestiaGUI/zoralabCORE/ page

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabCORE/CSS
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabCORE/CSS
@@ -19,7 +19,7 @@ specific language governing permissions and limitations under the License.
 	padding: 0;
 	margin: 0;
 
-	box-sizing: var(--html-box-sizing);
+	box-sizing: border-box;
 
 	transition: var(--timing-normal);
 }
@@ -28,16 +28,16 @@ html,
 body {
 	margin: 0;
 	padding: 0;
-	width: 100%;
 }
 
 html {
 	font-size: 62.5%; /* 1.6rem = 16px */
 
+	width: 100%;
 	height: 100%; /* fallback if calc fails */
 	height: calc(100vh - calc(100vh - 100%));
 
-	scroll-behavior: var(--body-scroll-behavior);
+	scroll-behavior: var(--html-scroll-behavior);
 }
 
 body {
@@ -111,12 +111,11 @@ footer, .footer {
 
 .inverted,
 footer, .footer {
-	color: var(--inverted-color);
-	background: var(--inverted-background);
+	color: var(--body-color-inverted);
+	background: var(--body-background-inverted);
 }
 
-main > *,
-footer > * {
+:is(main, footer) > * {
 	flex: 0 1 100%;
 	width: 100%;
 }
@@ -132,30 +131,24 @@ footer > * {
 }
 
 main, .content {
-	grid-area: var(--content-grid-area);
+	grid-area: var(--main-grid-area);
 }
 
 footer, .footer {
 	grid-area: var(--footer-grid-area);
 }
 
-nav.leftnav, .leftnav {
-	grid-area: var(--leftnav-grid-area);
-}
-
-nav.rightnav, .rightnav {
-	grid-area: var(--rightnav-grid-area);
-}
-
-nav.topnav, .topnav {
-	grid-area: var(--topnav-grid-area);
-}
-
-h1, h2, h3, h4, h5, h6, p {
+h1, .h1,
+h2, .h2,
+h3, .h3,
+h4, .h4,
+h5, .h5,
+h6, .h6,
+p {
 	width: 100%;
 }
 
-h1 {
+h1, .h1 {
 	margin: var(--h1-margin);
 
 	border-bottom: var(--h1-border-bottom);
@@ -166,36 +159,16 @@ h1 {
 	letter-spacing: var(--h1-letter-spacing);
 	text-decoration: var(--h1-text-decoration);
 	text-align: var(--h1-text-align);
+	word-wrap: var(--h1-word-wrap);
 
 	text-decoration-color: var(--h1-decoration-color);
 }
 
-h1:before {
-	content: var(--h1-before-content);
-
-	margin: var(--h1-before-margin);
-
-	text-align: var(--h1-before-text-align);
-
-	color: var(--h1-before-color);
-}
-
-h1:after {
-	content: var(--h1-after-content);
-
-	margin: var(--h1-after-margin);
-
-	text-align: var(--h1-after-text-align);
-
-	color: var(--h1-after-color);
-	background: var(--h1-after-background);
-}
-
-h2 {
-	border-bottom: var(--h2-border-bottom);
-
+h2, .h2 {
 	margin: var(--h2-margin);
 	padding: var(--h2-padding);
+
+	border-bottom: var(--h2-border-bottom);
 
 	font-size: var(--h2-font-size);
 	font-style: var(--h2-font-style);
@@ -203,60 +176,16 @@ h2 {
 	letter-spacing: var(--h2-letter-spacing);
 	text-align: var(--h2-text-align);
 	text-decoration: var(--h2-text-decoration);
+	word-wrap: var(--h2-word-wrap);
+
 	text-decoration-color: var(--h2-decoration-color);
 }
 
-h2:before {
-	content: var(--h2-before-content);
-
-	margin: var(--h2-before-margin);
-
-	text-align: var(--h2-before-text-align);
-
-	color: var(--h2-before-color);
-	background: var(--h2-before-background);
-}
-
-h2:after {
-	text-align: var(--h2-after-text-align);
-}
-
-h2:not(.clean):after {
-	display: block;
-	content: var(--h2-after-content);
-
-	margin: 0;
-	padding: .8rem 0 0;
-
-	height: 7rem;
-	width: 7.8rem;
-
-	font-size: 5rem;
-
-	color: var(--h2-after-color);
-	background: var(--h2-after-background);
-
-	border: var(--h2-after-border);
-	border-radius: 50%;
-
-	position: relative;
-	left: 50%;
-	transform: translate(-50%, 50%);
-}
-
-.inverted h2,
-footer h2 {
+:is(.inverted, footer, .footer) h2 {
 	border-bottom: var(--h2-border-bottom-inverted);
 }
 
-.inverted h2:not(.clean):after,
-footer h2:not(.clean):after {
-	color: var(--h2-after-color-inverted);
-	background: var(--h2-after-background-inverted);
-	border: var(--h2-after-border-inverted);
-}
-
-h3 {
+:is(h3, .h3) {
 	margin: var(--h3-margin);
 	padding: var(--h3-padding);
 
@@ -268,38 +197,16 @@ h3 {
 	letter-spacing: var(--h3-letter-spacing);
 	text-decoration: var(--h3-text-decoration);
 	text-align: var(--h3-text-align);
+	word-wrap: var(--h3-word-wrap);
 
 	text-decoration-color: var(--h3-decoration-color);
 }
 
-h3:before {
-	content: var(--h3-before-content);
-
-	margin: var(--h3-before-margin);
-
-	text-align: var(--h3-before-text-align);
-
-	color: var(--h3-before-color);
-	background: var(--h3-before-background);
-}
-
-h3:after {
-	content: var(--h3-after-content);
-
-	margin: var(--h3-after-margin);
-
-	text-align: var(--h3-after-text-align);
-
-	color: var(--h3-after-color);
-	background: var(--h3-after-background);
-}
-
-.inverted h3,
-footer h3 {
+:is(.inverted, footer, .footer) h3 {
 	border-bottom: var(--h3-border-bottom-inverted);
 }
 
-h4 {
+h4, .h4 {
 	margin: var(--h4-margin);
 	padding: var(--h4-padding);
 
@@ -311,33 +218,12 @@ h4 {
 	letter-spacing: var(--h4-letter-spacing);
 	text-decoration: var(--h4-text-decoration);
 	text-align: var(--h4-text-align);
+	word-wrap: var(--h4-word-wrap);
 
 	text-decoration-color: var(--h4-decoration-color);
 }
 
-h4:before {
-	content: var(--h4-before-content);
-
-	margin: var(--h4-before-margin);
-
-	text-align: var(--h4-before-text-align);
-
-	color: var(--h4-before-color);
-	background: var(--h4-before-background);
-}
-
-h4:after {
-	content: var(--h4-after-content);
-
-	margin: var(--h4-after-margin);
-
-	text-align: var(--h4-after-text-align);
-
-	color: var(--h4-after-color);
-	background: var(--h4-after-background);
-}
-
-h5 {
+h5, .h5 {
 	margin: var(--h5-margin);
 	padding: var(--h5-padding);
 
@@ -349,33 +235,12 @@ h5 {
 	letter-spacing: var(--h5-letter-spacing);
 	text-decoration: var(--h5-text-decoration);
 	text-align: var(--h5-text-align);
+	word-wrap: var(--h5-word-wrap);
 
 	text-decoration-color: var(--h5-decoration-color);
 }
 
-h5:before {
-	content: var(--h5-before-content);
-
-	margin: var(--h5-before-margin);
-
-	text-align: var(--h5-before-text-align);
-
-	color: var(--h5-before-color);
-	background: var(--h5-before-background);
-}
-
-h5:after {
-	content: var(--h5-after-content);
-
-	margin: var(--h5-after-margin);
-
-	text-align: var(--h5-after-text-align);
-
-	color: var(--h5-after-color);
-	background: var(--h5-after-background);
-}
-
-h6 {
+h6, .h6 {
 	margin: var(--h6-margin);
 	padding: var(--h6-padding);
 
@@ -387,30 +252,9 @@ h6 {
 	letter-spacing: var(--h6-letter-spacing);
 	text-decoration: var(--h6-text-decoration);
 	text-align: var(--h6-text-align);
+	word-wrap: var(--h6-word-wrap);
 
 	text-decoration-color: var(--h6-decoration-color);
-}
-
-h6:before {
-	content: var(--h6-before-content);
-
-	margin: var(--h6-before-margin);
-
-	text-align: var(--h6-before-text-align);
-
-	color: var(--h6-before-color);
-	background: var(--h6-before-background);
-}
-
-h6:after {
-	content: var(--h6-after-content);
-
-	margin: var(--h6-after-margin);
-
-	text-align: var(--h6-after-text-align);
-
-	color: var(--h6-after-color);
-	background: var(--h6-after-background);
 }
 
 p {
@@ -504,24 +348,35 @@ p {
 		background: var(--body-background-print) !important;
 	}
 
+	.inverted,
 	footer, .footer {
 		break-before: always;
 
 		border-top: 2rem double var(--body-color-print);
 	}
 
-	h1, h2, h3, h4, h5, h6, p {
+	h1, .h1,
+	h2, .h2,
+	h3, .h3,
+	h4, .h4,
+	h5, .h5,
+	h6, .h6,
+	p {
 		break-inside: avoid;
 
 		display: block;
 	}
 
-	h1 {
+	h1, .h1 {
 		break-before: page;
 		break-after: avoid;
 	}
 
-	h2, h3, h4, h5, h6 {
+	h2, .h2,
+	h3, .h3,
+	h4, .h4,
+	h5, .h5,
+	h6, .h6 {
 		break-after: avoid;
 	}
 
@@ -532,9 +387,7 @@ p {
 	}
 
 	h2:after,
-	.inverted h2:after,
-	footer  h2:after,
-	.footer h2:after, {
+	:is(.inverted, footer, .footer) h2:after {
 		color: var(--h2-after-color-print) !important;
 		background: var(--h2--after-background-print);
 		border: var(--h2-after-border-print);

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabCORE/CSSVariables
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabCORE/CSSVariables
@@ -1,31 +1,22 @@
 [CSS.Variables]
-# behaviors
-"--body-scroll-behavior" = "auto"
-
-# layouts
-"--content-grid-area" = "content"
-"--footer-grid-area" = "footer"
-"--leftnav-grid-area" = "leftnav"
-"--rightnav-grid-area" = "rightnav"
-"--topnav-grid-area" = "topnav"
-
 # page layout
-"--html-box-sizing" = "border-box"
-
+"--html-scroll-behavior" = "smooth"
 "--body-grid" = """
 	"content" auto
 	"footer" minmax(0, max-content)
 	"topnav" minmax(0, auto)
 	"leftnav" minmax(0, auto)
 	"rightnav" minmax(0, auto)
-	/ var(--body-width)
+	/ 100%
 """
 "--body-justify-items" = "stretch"
 "--body-align-items" = "stretch"
 "--body-grid-gap" = "0"
-"--body-width" = "100%"
 
-"--main-min-width" = "initial"
+
+"--main-grid-area" = "content"
+
+"--main-min-width" = "100%"
 "--main-width" = "100%"
 "--main-max-width" = "100%"
 
@@ -34,7 +25,10 @@
 "--main-padding-bottom" = "10rem"
 "--main-padding-right" = "10%"
 
-"--footer-min-width" = "initial"
+
+"--footer-grid-area" = "footer"
+
+"--footer-min-width" = "100%"
 "--footer-width" = "100%"
 "--footer-max-width" = "100%"
 
@@ -44,29 +38,24 @@
 "--footer-padding-right" = "10%"
 
 
+"--leftnav-grid-area" = "leftnav"
+
+"--rightnav-grid-area" = "rightnav"
+
+"--topnav-grid-area" = "topnav"
 
 
-# colors
-"--body-color" = "var(--color-typography-800)"
-"--body-color-inverted" = "var(--color-typography-50)"
-"--body-color-print" = "var(--color-typography-950)"
-"--body-color-indicator-red" = "#ff0000"
-"--body-color-indicator-red-inverted" = "#ffc4d0"
-"--body-color-indicator-yellow" = "#ffff00"
-"--body-color-indicator-yellow-inverted" = "#ff4c00"
-"--body-color-indicator-green" = "#00ff00"
-"--body-color-indicator-green-inverted" = "#0f3f0f"
-"--body-background" = "var(--color-typography-50)"
-"--body-background-inverted" = "var(--color-typography-950)"
-"--body-background-print" = "#FFF"
-"--body-background-indicator-red" = "#ffc4d0"
-"--body-background-indicator-red-inverted" = "#ff0000"
-"--body-background-indicator-yellow" = "#fff3c4"
-"--body-background-indicator-yellow-inverted" = "#ffff3b"
-"--body-background-indicator-green" = "#d0f3d0"
-"--body-background-indicator-green-inverted" = "#0c2f0c"
-"--inverted-color" = "var(--body-color-inverted)"
-"--inverted-background" = "var(--body-background-inverted)"
+
+# z-axis system
+"--z-index-max" = 2147483647
+"--z-index-max-overlay" = 1
+"--z-index-nav-top" = 2
+"--z-index-nav" = 3
+"--z-index-nav-overlay" = 4
+"--z-index-content-top" = 5
+"--z-index-content" = 6
+"--z-index-content-overlay" = 7
+"--z-index-hidden" = -1
 
 
 
@@ -83,20 +72,6 @@
 
 
 
-# z-axis system
-"--z-index-max" = 2147483647
-"--z-index-max-overlay" = 1
-"--z-index-nav-top" = 2
-"--z-index-nav" = 3
-"--z-index-nav-overlay" = 4
-"--z-index-content-top" = 5
-"--z-index-content" = 6
-"--z-index-content-overlay" = 7
-"--z-index-hidden" = 0
-
-
-
-
 # typography system
 "--h1-font-size" = "4rem"
 "--h1-font-style" = "normal"
@@ -106,70 +81,38 @@
 "--h1-padding" = "0"
 "--h1-text-decoration" = "underline"
 "--h1-text-align" = "left"
+"--h1-word-wrap" = "break-word"
 "--h1-decoration-color" = "var(--color-primary-300)"
 "--h1-border-bottom" = "none"
-"--h1-before-content" = ""
-"--h1-before-margin" = "initial"
-"--h1-before-text-align" = "center"
-"--h1-before-color" = "initial"
-"--h1-after-content" = ""
-"--h1-after-margin" = "initial"
-"--h1-after-text-align" = "center"
-"--h1-after-color" = "initial"
+"--h1-border-bottom-inverted" = "none"
 
 
-"--h2-font-size" = "3rem"
+"--h2-font-size" = "3.5rem"
 "--h2-font-style" = "normal"
 "--h2-line-height" = "1.25"
 "--h2-letter-spacing" = "-.1rem"
-"--h2-margin" = "10rem 0 5rem"
+"--h2-margin" = "12rem 0 2rem"
 "--h2-padding" = "0"
-"--h2-text-decoration" = "initial"
-"--h2-text-align" = "center"
+"--h2-text-decoration" = "none"
+"--h2-text-align" = "left"
+"--h2-word-wrap" = "break-word"
 "--h2-decoration-color" = "initial"
-"--h2-border-bottom" = "thick double var(--color-primary-800)"
-"--h2-border-bottom-inverted" = "thick double var(--color-contrast-300)"
-"--h2-before-content" = ""
-"--h2-before-margin" = "initial"
-"--h2-before-text-align" = "center"
-"--h2-before-color" = "initial"
-"--h2-before-color-inverted" = "initial"
-"--h2-before-background" = "initial"
-"--h2-before-background-inverted" = "initial"
-"--h2-after-content" = "\"§\""
-"--h2-after-text-align" = "center"
-"--h2-after-color" = "var(--color-primary-950)"
-"--h2-after-color-inverted" = "var(--color-contrast-300)"
-"--h2-after-color-print" = "var(--color-primary-950)"
-"--h2-after-border" = "thick double var(--color-primary-950)"
-"--h2-after-border-inverted" = "thick double var(--color-contrast-300)"
-"--h2-after-border-print" = "2px double var(--color-primary-950)"
-"--h2-after-background" = "var(--body-background)"
-"--h2-after-background-inverted" = "var(--body-background-inverted)"
-"--h2-after-background-print" = "var(--body-background-print)"
+"--h2-border-bottom" = "none"
+"--h2-border-bottom-inverted" = "none"
 
 
 "--h3-font-size" = "2.5rem"
 "--h3-font-style" = "normal"
 "--h3-line-height" = "1.3"
 "--h3-letter-spacing" = "-.1rem"
-"--h3-margin" = "8rem 0 0"
+"--h3-margin" = "7rem 0 0"
 "--h3-padding" = "0"
-"--h3-text-decoration" = "initial"
-"--h3-text-align" = "center"
+"--h3-text-decoration" = "none"
+"--h3-text-align" = "left"
+"--h3-word-wrap" = "break-word"
 "--h3-decoration-color" = "initial"
 "--h3-border-bottom" = "1px solid var(--color-primary-500)"
-"--h3-border-bottom-inverted" = "1px solid var(--color-contrast-300)"
-"--h3-before-content" = ""
-"--h3-before-margin" = "initial"
-"--h3-before-text-align" = "center"
-"--h3-before-color" = "initial"
-"--h3-before-background" = "initial"
-"--h3-after-content" = ""
-"--h3-after-margin" = "initial"
-"--h3-after-text-align" = "center"
-"--h3-after-color" = "initial"
-"--h3-after-background" = "initial"
+"--h3-border-bottom-inverted" = "1px solid var(--color-primary-300)"
 
 
 "--h4-font-size" = "2.2rem"
@@ -180,18 +123,10 @@
 "--h4-padding" = "0"
 "--h4-text-decoration" = "underline"
 "--h4-text-align" = "left"
+"--h4-word-wrap" = "normal"
 "--h4-decoration-color" = "initial"
-"--h4-border-bottom" = "initial"
-"--h4-before-content" = ""
-"--h4-before-margin" = "initial"
-"--h4-before-text-align" = "center"
-"--h4-before-color" = "initial"
-"--h4-before-background" = "initial"
-"--h4-after-content" = ""
-"--h4-after-margin" = "initial"
-"--h4-after-text-align" = "center"
-"--h4-after-color" = "initial"
-"--h4-after-background" = "initial"
+"--h4-border-bottom" = "none"
+"--h4-border-bottom-inverted" = "none"
 
 
 "--h5-font-size" = "1.8rem"
@@ -200,20 +135,12 @@
 "--h5-letter-spacing" = "-.05rem"
 "--h5-margin" = "4.5rem 0 0"
 "--h5-padding" = "0"
-"--h5-text-decoration" = "initial"
+"--h5-text-decoration" = "none"
 "--h5-text-align" = "left"
+"--h5-word-wrap" = "normal"
 "--h5-decoration-color" = "initial"
-"--h5-border-bottom" = "initial"
-"--h5-before-content" = ""
-"--h5-before-margin" = "initial"
-"--h5-before-text-align" = "center"
-"--h5-before-color" = "initial"
-"--h5-before-background" = "initial"
-"--h5-after-content" = ""
-"--h5-after-margin" = "initial"
-"--h5-after-text-align" = "center"
-"--h5-after-color" = "initial"
-"--h5-after-background" = "initial"
+"--h5-border-bottom" = "none"
+"--h5-border-bottom-inverted" = "none"
 
 
 "--h6-font-size" = "1.8rem"
@@ -222,38 +149,39 @@
 "--h6-letter-spacing" = "0"
 "--h6-margin" = "4.5rem 0 0"
 "--h6-padding" = "0"
-"--h6-text-decoration" = "initial"
+"--h6-text-decoration" = "none"
 "--h6-text-align" = "left"
+"--h6-word-wrap" = "normal"
 "--h6-decoration-color" = "initial"
-"--h6-border-bottom" = "initial"
-"--h6-before-content" = ""
-"--h6-before-margin" = "initial"
-"--h6-before-text-align" = "center"
-"--h6-before-color" = "initial"
-"--h6-before-background" = "initial"
-"--h6-after-content" = ""
-"--h6-after-margin" = "initial"
-"--h6-after-text-align" = "center"
-"--h6-after-color" = "initial"
-"--h6-after-background" = "initial"
+"--h6-border-bottom" = "none"
+"--h6-border-bottom-inverted" = "none"
 
-"--paragraph-text-align" = "left"
+
 "--paragraph-margin" = "0"
-"--paragraph-padding" = "0 1rem"
-
-
-
-# timing system
-"--timing-rapid" = ".2s"
-"--timing-fast" = ".3s"
-"--timing-normal" = ".4s"
-"--timing-slow" = ".5s"
-"--timing-slowest" = ".8s"
+"--paragraph-padding" = "1rem"
+"--paragraph-text-align" = "left"
 
 
 
 
-# color system
+# typography color system
+"--body-color" = "var(--color-typography-800)"
+"--body-color-inverted" = "var(--color-typography-50)"
+"--body-color-print" = "var(--color-typography-950)"
+"--body-color-indicator-red" = "#ff0000"
+"--body-color-indicator-yellow" = "#ff4c00"
+"--body-color-indicator-green" = "#2AA727"
+"--body-background" = "var(--color-typography-50)"
+"--body-background-inverted" = "var(--color-typography-950)"
+"--body-background-print" = "#FFF"
+"--body-background-indicator-red" = "#FFC4D0"
+"--body-background-indicator-yellow" = "#FFFF99"
+"--body-background-indicator-green" = "#D0F3D0"
+
+
+
+
+# color scheme system
 "--color-primary-50" = "#e5e5ff"
 "--color-primary-100" = "#bdbdff"
 "--color-primary-200" = "#8282ff"
@@ -333,7 +261,7 @@
 "--grid-width" = "100%"
 "--grid-justify-content" = "center"
 "--grid-align-content" = "center"
-"--grid-align-items" = "stretch"
+"--grid-align-items" = "center"
 "--grid-flex-wrap" = "wrap"
 "--grid-flex-direction" = "row"
 "--grid-gap" = "0"
@@ -347,3 +275,13 @@
 "--grid-column-base" = 10
 "--grid-column-multiplier" = 1
 "--grid-column-flex-basis" = "auto"
+
+
+
+
+# timing system
+"--timing-rapid" = ".2s"
+"--timing-fast" = ".3s"
+"--timing-normal" = ".4s"
+"--timing-slow" = ".5s"
+"--timing-slowest" = ".8s"

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabNOTE_ERROR/CSSVariables
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabNOTE_ERROR/CSSVariables
@@ -2,6 +2,6 @@
 "--note-title-error-border-color" = "var(--body-color-indicator-red)"
 "--note-title-error-color" = "#fff"
 "--note-title-error-indicator-color" = "#fff"
-"--note-title-error-background" = "var(--body-background-indicator-red-inverted)"
+"--note-title-error-background" = "var(--body-color-indicator-red)"
 "--note-content-error-color" = "var(--body-color-indicator-red)"
 "--note-content-error-background" = "var(--body-background-indicator-red)"

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabNOTE_SUCCESS/CSSVariables
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabNOTE_SUCCESS/CSSVariables
@@ -1,7 +1,7 @@
 [CSS.Variables]
-"--note-title-success-border-color" = "var(--body-color-indicator-green-inverted)"
+"--note-title-success-border-color" = "var(--body-color-indicator-green)"
 "--note-title-success-color" = "#fff"
 "--note-title-success-indicator-color" = "#fff"
-"--note-title-success-background" = "var(--body-background-indicator-green-inverted)"
-"--note-content-success-color" = "var(--body-color-indicator-green-inverted)"
+"--note-title-success-background" = "var(--body-color-indicator-green)"
+"--note-content-success-color" = "var(--body-color-indicator-green)"
 "--note-content-success-background" = "var(--body-background-indicator-green)"

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabNOTE_WARNING/CSSVariables
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabNOTE_WARNING/CSSVariables
@@ -1,7 +1,7 @@
 [CSS.Variables]
-"--note-title-warning-border-color" = "var(--body-color-indicator-yellow-inverted)"
-"--note-title-warning-color" = "var(--body-color-indicator-yellow-inverted)"
-"--note-title-warning-indicator-color" = "var(--body-color-indicator-yellow-inverted)"
-"--note-title-warning-background" = "var(--body-background-indicator-yellow-inverted)"
-"--note-content-warning-color" = "var(--body-color-indicator-yellow-inverted)"
+"--note-title-warning-border-color" = "var(--body-color-indicator-yellow)"
+"--note-title-warning-color" = "#FFF"
+"--note-title-warning-indicator-color" = "#FFF"
+"--note-title-warning-background" = "var(--body-color-indicator-yellow)"
+"--note-content-warning-color" = "var(--body-color-indicator-yellow)"
 "--note-content-warning-background" = "var(--body-background-indicator-yellow)"

--- a/sites/content/en/specs/hestiaGUI/zoralabCORE/__content.hestiaLDJSON
+++ b/sites/content/en/specs/hestiaGUI/zoralabCORE/__content.hestiaLDJSON
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (partial "hestiaJSON/schemaorgLDJSON/WebPage" .) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/en/specs/hestiaGUI/zoralabCORE/__contributors.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabCORE/__contributors.toml
@@ -1,0 +1,78 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...
+[[Contributors]]
+Key = 'ZORALab'
+
+[Contributors.Contribution]
+Creation = true
+Contact = true
+Artwork = false
+Knowledge = false
+Editor = true
+Developer = false
+Maintainer = false
+Producer = true
+Provider = true
+Publisher = true
+Funder = false
+Sponsor = true
+
+
+
+
+[[Contributors]]
+Key = 'HollowayKeanHo'
+
+[Contributors.Contribution]
+Creation = true
+Contact = false
+Artwork = false
+Knowledge = true
+Editor = true
+Developer = false
+Maintainer = false
+Producer = false
+Provider = false
+Publisher = false
+Funder = false
+Sponsor = false

--- a/sites/content/en/specs/hestiaGUI/zoralabCORE/__data.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabCORE/__data.toml
@@ -1,0 +1,2 @@
+[Dataset]
+Path = 'hestiaGUI.zoralabCORE'

--- a/sites/content/en/specs/hestiaGUI/zoralabCORE/__languages.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabCORE/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = '/en/specs/hestiagui/zoralabcore'
+
+[zh-Hans]
+URL = '/zh-hans/specs/hestiagui/zoralabcore'

--- a/sites/content/en/specs/hestiaGUI/zoralabCORE/__page.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabCORE/__page.toml
@@ -1,0 +1,125 @@
+# PAGE METADATA
+# =============
+# Date fields.
+#
+# NOTE:
+#   1. You can generate date easily on linux using '$ date' command.
+#   2. If date field is left blank, the current time shall be used instead.
+#   3. Date should ONLY comply to this pattern when manually constructed:
+#                    Thu 21 Jul 2022 14:27:39 PM +08
+[Date]
+Created   = "Sun 18 Dec 2022 05:07:26 AM +08"
+Published = "Sun 18 Dec 2022 05:07:26 AM +08"
+
+
+
+
+# Content fields.
+# NOTE:
+#   1. For .Title, Hestia's string processing using page variables are allowed
+#      and only limited to .Titles sub-fields.
+#   2. For .Keywords, Hestia's string processing using page variables are
+#      allowed but strongly discouraged.
+[Content]
+Title = "zoralabCORE Technical Specification - ZORALab's Hestia"
+Keywords = [
+	'zoralabCORE',
+	'hestiaGUI',
+	'Technical Specifications',
+	'Specifications',
+	'Web',
+	'Tech',
+	'PWA',
+	'WASM',
+	'Software Libraries',
+	'Hugo',
+	'Go',
+	'TinyGo',
+	'Nim',
+	'ZORALab',
+	"ZORALab's Hestia",
+]
+
+
+
+
+# Description fields.
+# NOTE:
+#   1. Hestia's string processing using page variables are allowed.
+#   2. The .Description.Pitch is at maximum 160 characters.
+#   3. The .Description.Summary is at maximum of 250 characters.
+#   4. All fields shall have their whitespace cleansed during the processing.
+[Description]
+Pitch = '''
+The technical specifications to refer when using the package.
+'''
+Summary = '''
+Easy-going, offline supported (via web PWA installation), and detailed oriented.
+Courtesy from ZORALab's Hestia.
+'''
+
+
+
+
+# Redirect fields.
+# NOTE:
+#   1. Hestia's URL processing is allowed for .URL field.
+#   2. .Delay timing sets the delay time before redirect. Setting to '0' means
+#      an immediate redirect is requested.
+#   3. Redirect is only available if .Enabled is set to 'true'.
+#   4. Redirect.Language is to redirect the current page to its
+#      language-specific page when Javascript is made available on client side
+#      or fallback to default language.
+[Redirect]
+Delay = 0 # second
+URL = ''
+Enabled = false
+
+[Redirect.Language]
+Enabled = false
+
+
+
+
+# Content Files' Sourcing Location
+# NOTE:
+#   1. To denote where are the content sources.
+#   2. If you're sourcing from assets directory, prefix 'assets/'.
+#   3. If you're sourcing from layouts directory, prefix 'layouts/'.
+#   2. If you're sourcing from static directory, prefix 'static/'.
+#   3. If you're sourcing from partial directory, prefix 'layouts/partials/'.
+[Sources]
+HTML = 'layouts/content/specs/zoralab/index.html'
+JSON = 'layouts/content/specs/zoralab/index.json'
+CSS = 'layouts/content/specs/zoralab/index.css'
+JS = 'layouts/content/specs/zoralab/index.js'
+LDJSON = '__content.hestiaLDJSON'
+Contributors = '__contributors.toml'
+Thumbnails = '__thumbnails.toml'
+Languages = '__languages.toml'
+Assets = 'layouts/content/specs/zoralab/assets.toml'
+Components = 'layouts/content/specs/zoralab/components.toml'
+
+
+
+
+# Data fields.
+# NOTE:
+#   1. List only the page-level data files. It can be in any of the following
+#      formats: '.json', '.toml', or '.yaml'.
+#   2. Hestia string processing is available and shall be processed prior to
+#      dataset transformation.
+#   3. Sequences of the .Data array dictates sequences of loading and overriding
+#      (the latter shall overwrite the former for the same data fields).
+#   4. The final processed dataset shall be served as main data content in
+#      supported output format (e.g. index.json).
+#   5. Missing data file shall be ignored.
+#   6. To add more data files, simply duplicate and add more .Data array entry.
+#      Example:
+#                             [[data]]
+#                             Filename = 'file1.json'
+#
+#                             [[data]]
+#                             Filename = 'file2.toml'
+[[Data]]
+Filename = '__data.toml'

--- a/sites/content/en/specs/hestiaGUI/zoralabCORE/__robots.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabCORE/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/en/specs/hestiaGUI/zoralabCORE/__thumbnails.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabCORE/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/thumbnails-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/thumbnails-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/thumbnails-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/en/specs/hestiaGUI/zoralabCORE/__twitter.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabCORE/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/en/specs/hestiaGUI/zoralabCORE/__wasm.toml
+++ b/sites/content/en/specs/hestiaGUI/zoralabCORE/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/en/specs/hestiaGUI/zoralabCORE/_index.html
+++ b/sites/content/en/specs/hestiaGUI/zoralabCORE/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++

--- a/sites/data/Specs/hestiaGUI/zoralabCORE/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabCORE/Designs.toml
@@ -1,0 +1,1641 @@
+[[EN.List]]
+Title = 'Designers'
+HTML = '''
+This component was designed by the following creators:
+'''
+Plain = '''
+This component was designed by the following creators:
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = 'https://www.hollowaykeanho.com/en/'
+Label = '(Holloway) Chew, Kean Ho'
+
+
+[[ZH-HANS.List]]
+Title = '设计师'
+HTML = '''
+这个元件的设计是由以下的创造者所建设的：
+'''
+Plain = '''
+这个元件的设计是由以下的创造者所建设的：
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = 'https://www.hollowaykeanho.com/zh-hans/'
+Label = '(Holloway) 周健豪'
+
+
+
+
+[[EN.List]]
+Title = 'Dependencies'
+HTML = '''
+This component has no dependency.
+'''
+Plain = '''
+This component has no dependency.
+'''
+Code = '''
+'''
+
+
+[[ZH-HANS.List]]
+Title = '依赖其他元件'
+HTML = '''
+这个元件是没有依赖其他元件。
+'''
+Plain = '''
+这个元件是没有依赖其他元件。
+'''
+Code = '''
+'''
+
+
+
+
+[[EN.List]]
+Title = 'HTML'
+HTML = '''
+For HTML, ZORALab's Hestia employs the W3C native syntax for simplicity and
+maximum compatibility sakes. ZORALab's Hestia recommends the following HTML code
+structure for this component.
+'''
+Plain = '''
+For HTML, ZORALab's Hestia employs the W3C native syntax for simplicity and
+maximum compatibility sakes. ZORALab's Hestia recommends the following HTML code
+structure for this component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'HTML'
+HTML = '''
+至于HTML，为了简单化和最大的兼容性整个用法，ZORALab赫斯提亚运用W3C的语法。我们
+推荐您用以下的HTML代码来运用这个界面元件。
+'''
+Plain = '''
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Page Structure HTML'
+HTML = '''
+The compliant HTML page structure is shown below:
+'''
+Plain = '''
+The compliant HTML page structure is shown below:
+'''
+Code = '''
+<!DOCTYPE html>
+<html lang="...">
+<head>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>...</title>
+	...
+	<style>...</style>
+	<script defer>...</script>
+	...
+</head>
+<body>
+	<main>
+		<section ...>
+			...
+		</section>
+
+		<section ...>
+			...
+		</section>
+
+		...
+	</main>
+
+	<footer>
+		<section ...>
+			...
+		</section>
+
+		<section ...>
+			...
+		</section>
+
+		...
+	</footer>
+
+	<nav class='top-drawer'>
+		...
+	</nav>
+
+	<nav class='left-drawer'>
+		...
+	</nav>
+
+	<nav class='right-drawer'>
+		...  <!-- THE LAST DRAWER HAS THE HIGHEST PRIORITY -->
+	</nav>
+</body>
+</html>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '兼容的网页面结构HTML'
+HTML = '''
+兼容的网页面结构的HTML代码如下：
+'''
+Plain = '''
+兼容的网页面结构的HTML代码如下：
+'''
+Code = '''
+<!DOCTYPE html>
+<html lang="...">
+<head>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>...</title>
+	...
+	<style>...</style>
+	<script defer>...</script>
+	...
+</head>
+<body>
+	<main>
+		<section ...>
+			...
+		</section>
+
+		<section ...>
+			...
+		</section>
+
+		...
+	</main>
+
+	<footer>
+		<section ...>
+			...
+		</section>
+
+		<section ...>
+			...
+		</section>
+
+		...
+	</footer>
+
+	<nav class='top-drawer'>
+		...
+	</nav>
+
+	<nav class='left-drawer'>
+		...
+	</nav>
+
+	<nav class='right-drawer'>
+		...  <!-- 最后一个柜是最大权利 -->
+	</nav>
+</body>
+</html>
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Grid System HTML'
+HTML = '''
+The grid system HTML codes are shown below:
+'''
+Plain = '''
+The grid system HTML codes are shown below:
+'''
+Code = '''
+<!-- NOTE: PLEASE USE <div> FOR PROPER AND CONSISTENT CONTAINMENT. -->
+<div class='row'>
+	<div class='column'>
+		...
+	</div>
+
+	<div class='column'>
+		...
+	</div>
+
+	<div class='column'>
+		...
+	</div>
+
+	...
+</div>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '网格空间控制系统HTML'
+HTML = '''
+网格空间控制系统的HTML代码如下：
+'''
+Plain = '''
+网格空间控制系统的HTML代码如下：
+'''
+Code = '''
+<!-- 切记：请运用<div>来适当和一致的遏制内容代码 -->
+<div class='row'>
+	<div class='column'>
+		...
+	</div>
+
+
+	<div class='column'>
+		...
+	</div>
+
+
+	<div class='column'>
+		...
+	</div>
+
+
+	...
+</div>
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'CSS'
+HTML = '''
+ZORALab's Hestia heavily rely on CSS to style this component and offering its
+css variables for customizations. Below are the list of available CSS variables
+at your disposal.
+'''
+Plain = '''
+ZORALab's Hestia heavily rely on CSS to style this component and offering its
+css variables for customizations. Below are the list of available CSS variables
+at your disposal.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'GUI界面一定要自选性'
+HTML = '''
+GUI界面元件主要是给那些没有科技文学的顾客可以方便使用某个科技。如此以来，一个科技
+产品必须能处理和互相交易数据就行了。然后呢，GUI界面就有用户者来自选服务就行了。
+'''
+Plain = '''
+GUI界面元件主要是给那些没有科技文学的顾客可以方便使用某个科技。如此以来，一个科技
+产品必须能处理和互相交易数据就行了。然后呢，GUI界面就有用户者来自选服务就行了。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Color System'
+HTML = '''
+ZORALab's Hestia heavily rely on CSS to style this component and offering its
+css variables for customizations. Below are the list of available CSS variables
+at your disposal. (Example: row 1 column 2 is
+<code>--color-typography-100</code>).
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>Variant</th>
+		<th><code>50</code></th>
+		<th><code>100</code></th>
+		<th><code>200</code></th>
+		<th><code>300</code></th>
+		<th><code>400</code></th>
+		<th><code>500</code></th>
+		<th><code>600</code></th>
+		<th><code>700</code></th>
+		<th><code>800</code></th>
+		<th><code>900</code></th>
+		<th><code>950</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--color-typography-</code></th>
+		<td style="background:var(--color-typography-50)"></td>
+		<td style="background:var(--color-typography-100)"></td>
+		<td style="background:var(--color-typography-200)"></td>
+		<td style="background:var(--color-typography-300)"></td>
+		<td style="background:var(--color-typography-400)"></td>
+		<td style="background:var(--color-typography-500)"></td>
+		<td style="background:var(--color-typography-600)"></td>
+		<td style="background:var(--color-typography-700)"></td>
+		<td style="background:var(--color-typography-800)"></td>
+		<td style="background:var(--color-typography-900)"></td>
+		<td style="background:var(--color-typography-950)"></td>
+	</tr>
+	<tr>
+		<th><code>--color-dark-typography-</code></th>
+		<td style="background:var(--color-dark-typography-50)"></td>
+		<td style="background:var(--color-dark-typography-100)"></td>
+		<td style="background:var(--color-dark-typography-200)"></td>
+		<td style="background:var(--color-dark-typography-300)"></td>
+		<td style="background:var(--color-dark-typography-400)"></td>
+		<td style="background:var(--color-dark-typography-500)"></td>
+		<td style="background:var(--color-dark-typography-600)"></td>
+		<td style="background:var(--color-dark-typography-700)"></td>
+		<td style="background:var(--color-dark-typography-800)"></td>
+		<td style="background:var(--color-dark-typography-900)"></td>
+		<td style="background:var(--color-dark-typography-950)"></td>
+	</tr>
+	<tr>
+		<th><code>--color-contrast-</code></th>
+		<td style="background:var(--color-contrast-50)"></td>
+		<td style="background:var(--color-contrast-100)"></td>
+		<td style="background:var(--color-contrast-200)"></td>
+		<td style="background:var(--color-contrast-300)"></td>
+		<td style="background:var(--color-contrast-400)"></td>
+		<td style="background:var(--color-contrast-500)"></td>
+		<td style="background:var(--color-contrast-600)"></td>
+		<td style="background:var(--color-contrast-700)"></td>
+		<td style="background:var(--color-contrast-800)"></td>
+		<td style="background:var(--color-contrast-900)"></td>
+		<td style="background:var(--color-contrast-950)"></td>
+	</tr>
+	<tr>
+		<th><code>--color-dark-contrast-</code></th>
+		<td style="background:var(--color-dark-contrast-50)"></td>
+		<td style="background:var(--color-dark-contrast-100)"></td>
+		<td style="background:var(--color-dark-contrast-200)"></td>
+		<td style="background:var(--color-dark-contrast-300)"></td>
+		<td style="background:var(--color-dark-contrast-400)"></td>
+		<td style="background:var(--color-dark-contrast-500)"></td>
+		<td style="background:var(--color-dark-contrast-600)"></td>
+		<td style="background:var(--color-dark-contrast-700)"></td>
+		<td style="background:var(--color-dark-contrast-800)"></td>
+		<td style="background:var(--color-dark-contrast-900)"></td>
+		<td style="background:var(--color-dark-contrast-950)"></td>
+	</tr>
+	<tr>
+		<th><code>--color-primary-</code></th>
+		<td style="background:var(--color-primary-50)"></td>
+		<td style="background:var(--color-primary-100)"></td>
+		<td style="background:var(--color-primary-200)"></td>
+		<td style="background:var(--color-primary-300)"></td>
+		<td style="background:var(--color-primary-400)"></td>
+		<td style="background:var(--color-primary-500)"></td>
+		<td style="background:var(--color-primary-600)"></td>
+		<td style="background:var(--color-primary-700)"></td>
+		<td style="background:var(--color-primary-800)"></td>
+		<td style="background:var(--color-primary-900)"></td>
+		<td style="background:var(--color-primary-950)"></td>
+	</tr>
+	<tr>
+		<th><code>--color-dark-primary-</code></th>
+		<td style="background:var(--color-dark-primary-50)"></td>
+		<td style="background:var(--color-dark-primary-100)"></td>
+		<td style="background:var(--color-dark-primary-200)"></td>
+		<td style="background:var(--color-dark-primary-300)"></td>
+		<td style="background:var(--color-dark-primary-400)"></td>
+		<td style="background:var(--color-dark-primary-500)"></td>
+		<td style="background:var(--color-dark-primary-600)"></td>
+		<td style="background:var(--color-dark-primary-700)"></td>
+		<td style="background:var(--color-dark-primary-800)"></td>
+		<td style="background:var(--color-dark-primary-900)"></td>
+		<td style="background:var(--color-dark-primary-950)"></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+ZORALab's Hestia heavily rely on CSS to style this component and offering its
+css variables for customizations. See HTML page for list of variables.
+'''
+Code = '''
+'''
+
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+[[ZH-HANS.List.SubList]]
+Title = '颜色系统'
+HTML = '''
+这元件有供应自己的颜色系统如下（例子：第 1 行 第 2 列是
+<code>--color-typography-100</code>）：
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>类型</th>
+		<th><code>50</code></th>
+		<th><code>100</code></th>
+		<th><code>200</code></th>
+		<th><code>300</code></th>
+		<th><code>400</code></th>
+		<th><code>500</code></th>
+		<th><code>600</code></th>
+		<th><code>700</code></th>
+		<th><code>800</code></th>
+		<th><code>900</code></th>
+		<th><code>950</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--color-typography-</code></th>
+		<td style="background:var(--color-typography-50)"></td>
+		<td style="background:var(--color-typography-100)"></td>
+		<td style="background:var(--color-typography-200)"></td>
+		<td style="background:var(--color-typography-300)"></td>
+		<td style="background:var(--color-typography-400)"></td>
+		<td style="background:var(--color-typography-500)"></td>
+		<td style="background:var(--color-typography-600)"></td>
+		<td style="background:var(--color-typography-700)"></td>
+		<td style="background:var(--color-typography-800)"></td>
+		<td style="background:var(--color-typography-900)"></td>
+		<td style="background:var(--color-typography-950)"></td>
+	</tr>
+	<tr>
+		<th><code>--color-dark-typography-</code></th>
+		<td style="background:var(--color-dark-typography-50)"></td>
+		<td style="background:var(--color-dark-typography-100)"></td>
+		<td style="background:var(--color-dark-typography-200)"></td>
+		<td style="background:var(--color-dark-typography-300)"></td>
+		<td style="background:var(--color-dark-typography-400)"></td>
+		<td style="background:var(--color-dark-typography-500)"></td>
+		<td style="background:var(--color-dark-typography-600)"></td>
+		<td style="background:var(--color-dark-typography-700)"></td>
+		<td style="background:var(--color-dark-typography-800)"></td>
+		<td style="background:var(--color-dark-typography-900)"></td>
+		<td style="background:var(--color-dark-typography-950)"></td>
+	</tr>
+	<tr>
+		<th><code>--color-contrast-</code></th>
+		<td style="background:var(--color-contrast-50)"></td>
+		<td style="background:var(--color-contrast-100)"></td>
+		<td style="background:var(--color-contrast-200)"></td>
+		<td style="background:var(--color-contrast-300)"></td>
+		<td style="background:var(--color-contrast-400)"></td>
+		<td style="background:var(--color-contrast-500)"></td>
+		<td style="background:var(--color-contrast-600)"></td>
+		<td style="background:var(--color-contrast-700)"></td>
+		<td style="background:var(--color-contrast-800)"></td>
+		<td style="background:var(--color-contrast-900)"></td>
+		<td style="background:var(--color-contrast-950)"></td>
+	</tr>
+	<tr>
+		<th><code>--color-dark-contrast-</code></th>
+		<td style="background:var(--color-dark-contrast-50)"></td>
+		<td style="background:var(--color-dark-contrast-100)"></td>
+		<td style="background:var(--color-dark-contrast-200)"></td>
+		<td style="background:var(--color-dark-contrast-300)"></td>
+		<td style="background:var(--color-dark-contrast-400)"></td>
+		<td style="background:var(--color-dark-contrast-500)"></td>
+		<td style="background:var(--color-dark-contrast-600)"></td>
+		<td style="background:var(--color-dark-contrast-700)"></td>
+		<td style="background:var(--color-dark-contrast-800)"></td>
+		<td style="background:var(--color-dark-contrast-900)"></td>
+		<td style="background:var(--color-dark-contrast-950)"></td>
+	</tr>
+	<tr>
+		<th><code>--color-primary-</code></th>
+		<td style="background:var(--color-primary-50)"></td>
+		<td style="background:var(--color-primary-100)"></td>
+		<td style="background:var(--color-primary-200)"></td>
+		<td style="background:var(--color-primary-300)"></td>
+		<td style="background:var(--color-primary-400)"></td>
+		<td style="background:var(--color-primary-500)"></td>
+		<td style="background:var(--color-primary-600)"></td>
+		<td style="background:var(--color-primary-700)"></td>
+		<td style="background:var(--color-primary-800)"></td>
+		<td style="background:var(--color-primary-900)"></td>
+		<td style="background:var(--color-primary-950)"></td>
+	</tr>
+	<tr>
+		<th><code>--color-dark-primary-</code></th>
+		<td style="background:var(--color-dark-primary-50)"></td>
+		<td style="background:var(--color-dark-primary-100)"></td>
+		<td style="background:var(--color-dark-primary-200)"></td>
+		<td style="background:var(--color-dark-primary-300)"></td>
+		<td style="background:var(--color-dark-primary-400)"></td>
+		<td style="background:var(--color-dark-primary-500)"></td>
+		<td style="background:var(--color-dark-primary-600)"></td>
+		<td style="background:var(--color-dark-primary-700)"></td>
+		<td style="background:var(--color-dark-primary-800)"></td>
+		<td style="background:var(--color-dark-primary-900)"></td>
+		<td style="background:var(--color-dark-primary-950)"></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+这元件有供应自己的颜色系统。请详寻HTML网页查询数码值。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Indicator Color System'
+HTML = '''
+The standard engineering indication system are also supplied for safety use.
+The are shown as follows (E.g. row 1 column 2 is
+<code>--body-color-indicator-yellow</code>):
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>Variant</th>
+		<th><code>red</code></th>
+		<th><code>yellow</code></th>
+		<th><code>green</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--body-color-indicator-</code></th>
+		<td style="background:var(--body-color-indicator-red)"></td>
+		<td style="background:var(--body-color-indicator-yellow)"></td>
+		<td style="background:var(--body-color-indicator-green)"></td>
+	</tr>
+	<tr>
+		<th><code>--body-background-indicator-</code></th>
+		<td style="background:var(--body-background-indicator-red)"></td>
+		<td style="background:var(--body-background-indicator-yellow)"></td>
+		<td style="background:var(--body-background-indicator-green)"></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+The standard engineering indication system are also supplied for safety use.
+See HTML page for list of variables.
+'''
+Code = '''
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '标准工程颜色系统'
+HTML = '''
+这元件有供应标准工程颜色系统如下（例子：第 1 行 第 2 列是
+<code>--body-color-indicator-yellow</code>）：
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>类型</th>
+		<th><code>red</code></th>
+		<th><code>yellow</code></th>
+		<th><code>green</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--body-color-indicator-</code></th>
+		<th style="background:var(--body-color-indicator-red)"></th>
+		<th style="background:var(--body-color-indicator-yellow)"></th>
+		<th style="background:var(--body-color-indicator-green)"></th>
+	</tr>
+	<tr>
+		<th><code>--body-background-indicator-</code></th>
+		<th style="background:var(--body-background-indicator-red)"></th>
+		<th style="background:var(--body-background-indicator-yellow)"></th>
+		<th style="background:var(--body-background-indicator-green)"></th>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+这元件有供应标准工程颜色系统。请详寻HTML网页查询数码值。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Unified Typography Color System'
+HTML = '''
+The unified typography color system are also supplied for common readability.
+The are shown as follows (E.g. row 1 column 2 is
+<code>--body-color-inverted</code>):
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>Variant</th>
+		<th><code>color</code></th>
+		<th><code>color-inverted</code></th>
+		<th><code>color-print</code></th>
+		<th><code>background</code></th>
+		<th><code>background-inverted</code></th>
+		<th><code>background-print</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--body-</code></th>
+		<td style="background:var(--body-color)"></td>
+		<td style="background:var(--body-color-inverted)"></td>
+		<td style="background:var(--body-color-print)"></td>
+		<td style="background:var(--body-background)"></td>
+		<td style="background:var(--body-background-inverted)"></td>
+		<td style="background:var(--body-background-print)"></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+The unified typography color system are also supplied for readability.
+See HTML page for list of variables.
+'''
+Code = '''
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '统一字形颜色系统'
+HTML = '''
+这元件有供应统一字形颜色系统如下（例子：第 1 行 第 2 列是
+<code>--body-color-inverted</code>）：
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>类型</th>
+		<th><code>color</code></th>
+		<th><code>color-inverted</code></th>
+		<th><code>color-print</code></th>
+		<th><code>background</code></th>
+		<th><code>background-inverted</code></th>
+		<th><code>background-print</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--body-</code></th>
+		<td style="background:var(--body-color)"></td>
+		<td style="background:var(--body-color-inverted)"></td>
+		<td style="background:var(--body-color-print)"></td>
+		<td style="background:var(--body-background)"></td>
+		<td style="background:var(--body-background-inverted)"></td>
+		<td style="background:var(--body-background-print)"></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+这元件有供应统一字形颜色系统。请详寻HTML网页查询数码值。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Animation Timing System'
+HTML = '''
+This component also supplies consistent animation timing system.
+The are shown as follows (E.g. row 1 column 2 is
+<code>--timing-fast</code>):
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>Variant</th>
+		<th><code>rapid</code></th>
+		<th><code>fast</code></th>
+		<th><code>normal</code></th>
+		<th><code>slow</code></th>
+		<th><code>slowest</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--timing-</code></th>
+		<td><code>.2s</code></td>
+		<td><code>.3s</code></td>
+		<td><code>.4s</code></td>
+		<td><code>.5s</code></td>
+		<td><code>.8s</code></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+This component also supplies consistent animation timing system.
+See HTML page for list of variables.
+'''
+Code = '''
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '动画定时系统'
+HTML = '''
+这元件有供应动画定时系统如下（例子：第 1 行 第 2 列是
+<code>--timing-fast</code>）：
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>类型</th>
+		<th><code>rapid</code></th>
+		<th><code>fast</code></th>
+		<th><code>normal</code></th>
+		<th><code>slow</code></th>
+		<th><code>slowest</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--timing-</code></th>
+		<td><code>.2s</code></td>
+		<td><code>.3s</code></td>
+		<td><code>.4s</code></td>
+		<td><code>.5s</code></td>
+		<td><code>.8s</code></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+
+这元件有供应动画定时系统。请详寻HTML网页查询数码值。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Base Font System'
+HTML = '''
+The base font system are supplied for basic use. The are shown as follows
+(E.g. row 1 column 2 is <code>--body-font-size</code>):
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>Variant</th>
+		<th><code>font-family</code></th>
+		<th><code>font-size</code></th>
+		<th><code>font-size-print</code></th>
+		<th><code>font-weight</code></th>
+		<th><code>letter-spacing</code></th>
+		<th><code>line-height</code></th>
+		<th><code>text-align</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--body-</code></th>
+		<td><code>"Roboto", "Helvetica Neue", "sans-serif"</code></td>
+		<td><code>1.8rem</code></td>
+		<td><code>12pt</code></td>
+		<td><code>normal</code></td>
+		<td><code>.01rem</code></td>
+		<td><code>1.6</code></td>
+		<td><code>center</code></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+The base font system are supplied for basic use.
+See HTML page for list of variables.
+'''
+Code = '''
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '基本字体系统'
+HTML = '''
+这元件有供应基本字体系统如下（例子：第 1 行 第 2 列是
+<code>--body-font-size</code>）：
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>类型</th>
+		<th><code>font-family</code></th>
+		<th><code>font-size</code></th>
+		<th><code>font-size-print</code></th>
+		<th><code>font-weight</code></th>
+		<th><code>letter-spacing</code></th>
+		<th><code>line-height</code></th>
+		<th><code>text-align</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--body-</code></th>
+		<td><code>\"Roboto\", \"Helvetica Neue\", \"sans-serif\"</code></td>
+		<td><code>1.8rem</code></td>
+		<td><code>12pt</code></td>
+		<td><code>normal</code></td>
+		<td><code>.01rem</code></td>
+		<td><code>1.6</code></td>
+		<td><code>center</code></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+这元件有供应基本字体系统。请详寻HTML网页查询数码值。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Typography System'
+HTML = '''
+This component also supplies a consistent typography system.
+They are shown as follows (E.g. row 1 column 2 is
+<code>--h1-font-style</code>):
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>Variant</th>
+		<th><code>font-size</code></th>
+		<th><code>font-style</code></th>
+		<th><code>line-height</code></th>
+		<th><code>letter-spacing</code></th>
+		<th><code>margin</code></th>
+		<th><code>padding</code></th>
+		<th><code>text-decoration</code></th>
+		<th><code>text-align</code></th>
+		<th><code>word-wrap</code></th>
+		<th><code>decoration-color</code></th>
+		<th><code>border-bottom</code></th>
+		<th><code>border-bottom-inverted</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--h1-</code></th>
+		<td><code>4rem</code></td>
+		<td><code>normal</code></td>
+		<td><code>1.2</code></td>
+		<td><code>-.1rem</code></td>
+		<td><code>2rem 0 0</code></td>
+		<td><code>0</code></td>
+		<td><code>underline</code></td>
+		<td><code>left</code></td>
+		<td><code>break-word</code></td>
+		<td><code>var(--color-primary-300)</code></td>
+		<td><code>none</code></td>
+		<td><code>none</code></td>
+	</tr>
+	<tr>
+		<th><code>--h2-</code></th>
+		<td><code>3.5rem</code></td>
+		<td><code>normal</code></td>
+		<td><code>1.25</code></td>
+		<td><code>-.1rem</code></td>
+		<td><code>10rem 0 2rem</code></td>
+		<td><code>0</code></td>
+		<td><code>none</code></td>
+		<td><code>left</code></td>
+		<td><code>break-word</code></td>
+		<td><code>initial</code></td>
+		<td><code>none</code></td>
+		<td><code>none</code></td>
+	</tr>
+	<tr>
+		<th><code>--h3-</code></th>
+		<td><code>2.5rem</code></td>
+		<td><code>normal</code></td>
+		<td><code>1.3</code></td>
+		<td><code>-.1rem</code></td>
+		<td><code>7rem 0 0</code></td>
+		<td><code>0</code></td>
+		<td><code>none</code></td>
+		<td><code>left</code></td>
+		<td><code>break-word</code></td>
+		<td><code>initial</code></td>
+		<td><code>1px solid var(--color-primary-500)</code></td>
+		<td><code>1px solid var(--color-primary-300)</code></td>
+	</tr>
+	<tr>
+		<th><code>--h4-</code></th>
+		<td><code>2.2rem</code></td>
+		<td><code>normal</code></td>
+		<td><code>1.35</code></td>
+		<td><code>-.08rem</code></td>
+		<td><code>4.5rem 0 0</code></td>
+		<td><code>0</code></td>
+		<td><code>underline</code></td>
+		<td><code>left</code></td>
+		<td><code>normal</code></td>
+		<td><code>initial</code></td>
+		<td><code>none</code></td>
+		<td><code>none</code></td>
+	</tr>
+	<tr>
+		<th><code>--h5-</code></th>
+		<td><code>1.8rem</code></td>
+		<td><code>normal</code></td>
+		<td><code>1.5</code></td>
+		<td><code>-.05rem</code></td>
+		<td><code>4.5rem 0 0</code></td>
+		<td><code>0</code></td>
+		<td><code>none</code></td>
+		<td><code>left</code></td>
+		<td><code>normal</code></td>
+		<td><code>initial</code></td>
+		<td><code>none</code></td>
+		<td><code>none</code></td>
+	</tr>
+	<tr>
+		<th><code>--h6-</code></th>
+		<td><code>1.8rem</code></td>
+		<td><code>italic</code></td>
+		<td><code>1.5</code></td>
+		<td><code>0</code></td>
+		<td><code>4.5rem 0 0</code></td>
+		<td><code>0</code></td>
+		<td><code>none</code></td>
+		<td><code>left</code></td>
+		<td><code>normal</code></td>
+		<td><code>initial</code></td>
+		<td><code>none</code></td>
+		<td><code>none</code></td>
+	</tr>
+	<tr>
+		<th><code>--p-</code></th>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code>0</code></td>
+		<td><code>1rem</code></td>
+		<td><code></code></td>
+		<td><code>left</code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+This component also supplies a consistent typography system.
+See HTML page for list of variables.
+'''
+Code = '''
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '字形系统'
+HTML = '''
+这元件有供应字形系统如下（例子：第 1 行 第 2 列是
+<code>--h1-font-style</code>）：
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>类型</th>
+		<th><code>font-size</code></th>
+		<th><code>font-style</code></th>
+		<th><code>line-height</code></th>
+		<th><code>letter-spacing</code></th>
+		<th><code>margin</code></th>
+		<th><code>padding</code></th>
+		<th><code>text-decoration</code></th>
+		<th><code>text-align</code></th>
+		<th><code>word-wrap</code></th>
+		<th><code>decoration-color</code></th>
+		<th><code>border-bottom</code></th>
+		<th><code>border-bottom-inverted</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--h1-</code></th>
+		<td><code>4rem</code></td>
+		<td><code>normal</code></td>
+		<td><code>1.2</code></td>
+		<td><code>-.1rem</code></td>
+		<td><code>2rem 0 0</code></td>
+		<td><code>0</code></td>
+		<td><code>underline</code></td>
+		<td><code>left</code></td>
+		<td><code>break-word</code></td>
+		<td><code>var(--color-primary-300)</code></td>
+		<td><code>none</code></td>
+		<td><code>none</code></td>
+	</tr>
+	<tr>
+		<th><code>--h2-</code></th>
+		<td><code>3.5rem</code></td>
+		<td><code>normal</code></td>
+		<td><code>1.25</code></td>
+		<td><code>-.1rem</code></td>
+		<td><code>12rem 0 2rem</code></td>
+		<td><code>0</code></td>
+		<td><code>none</code></td>
+		<td><code>left</code></td>
+		<td><code>break-word</code></td>
+		<td><code>initial</code></td>
+		<td><code>none</code></td>
+		<td><code>none</code></td>
+	</tr>
+	<tr>
+		<th><code>--h3-</code></th>
+		<td><code>2.5rem</code></td>
+		<td><code>normal</code></td>
+		<td><code>1.3</code></td>
+		<td><code>-.1rem</code></td>
+		<td><code>7rem 0 0</code></td>
+		<td><code>0</code></td>
+		<td><code>none</code></td>
+		<td><code>left</code></td>
+		<td><code>break-word</code></td>
+		<td><code>initial</code></td>
+		<td><code>1px solid var(--color-primary-500)</code></td>
+		<td><code>1px solid var(--color-primary-300)</code></td>
+	</tr>
+	<tr>
+		<th><code>--h4-</code></th>
+		<td><code>2.2rem</code></td>
+		<td><code>normal</code></td>
+		<td><code>1.35</code></td>
+		<td><code>-.08rem</code></td>
+		<td><code>4.5rem 0 0</code></td>
+		<td><code>0</code></td>
+		<td><code>underline</code></td>
+		<td><code>left</code></td>
+		<td><code>normal</code></td>
+		<td><code>initial</code></td>
+		<td><code>none</code></td>
+		<td><code>none</code></td>
+	</tr>
+	<tr>
+		<th><code>--h5-</code></th>
+		<td><code>1.8rem</code></td>
+		<td><code>normal</code></td>
+		<td><code>1.5</code></td>
+		<td><code>-.05rem</code></td>
+		<td><code>4.5rem 0 0</code></td>
+		<td><code>0</code></td>
+		<td><code>none</code></td>
+		<td><code>left</code></td>
+		<td><code>normal</code></td>
+		<td><code>initial</code></td>
+		<td><code>none</code></td>
+		<td><code>none</code></td>
+	</tr>
+	<tr>
+		<th><code>--h6-</code></th>
+		<td><code>1.8rem</code></td>
+		<td><code>italic</code></td>
+		<td><code>1.5</code></td>
+		<td><code>0</code></td>
+		<td><code>4.5rem 0 0</code></td>
+		<td><code>0</code></td>
+		<td><code>none</code></td>
+		<td><code>left</code></td>
+		<td><code>normal</code></td>
+		<td><code>initial</code></td>
+		<td><code>none</code></td>
+		<td><code>none</code></td>
+	</tr>
+	<tr>
+		<th><code>--p-</code></th>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code>0</code></td>
+		<td><code>1rem</code></td>
+		<td><code></code></td>
+		<td><code>left</code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+这元件有供应字形系统。请详寻HTML网页查询数码值。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Z-Index System'
+HTML = '''
+This component also supplies its own z-index layering system where it is applied
+by default to the page entirely. It is designed to use the uppermost layer and
+subtraction from there (e.g.
+<code>calc(var(--z-index-max) - var(--z-index-content))</code>). The 2
+exceptions are <code>--z-index-hidden</code> and <code>--z-index-max</code>
+where they can be used directly.
+They are shown as follows:
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>Variant</th>
+		<th>Value</th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--z-index-max</code></th>
+		<td><code>2147483647</code></td>
+	</tr>
+	<tr>
+		<th><code>--z-index-max-overlay</code></th>
+		<td><code>1</code></td>
+	</tr>
+	<tr>
+		<th><code>--z-index-nav-top</code></th>
+		<td><code>2</code></td>
+	</tr>
+	<tr>
+		<th><code>--z-index-nav</code></th>
+		<td><code>3</code></td>
+	</tr>
+	<tr>
+		<th><code>--z-index-nav-overlay</code></th>
+		<td><code>4</code></td>
+	</tr>
+	<tr>
+		<th><code>--z-index-content-top</code></th>
+		<td><code>5</code></td>
+	</tr>
+	<tr>
+		<th><code>--z-index-content</code></th>
+		<td><code>6</code></td>
+	</tr>
+	<tr>
+		<th><code>--z-index-content-overlay</code></th>
+		<td><code>7</code></td>
+	</tr>
+	<tr>
+		<th><code>--z-index-hidden</code></th>
+		<td><code>-1</code></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+This component also supplies consistent animation timing system.
+See HTML page for list of variables.
+'''
+Code = '''
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '动画定时系统'
+HTML = '''
+这元件有供应动画定时系统如下（例子：第 1 行 第 2 列是
+<code>--timing-fast</code>）：
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>类型</th>
+		<th><code>rapid</code></th>
+		<th><code>fast</code></th>
+		<th><code>normal</code></th>
+		<th><code>slow</code></th>
+		<th><code>slowest</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--timing-</code></th>
+		<td><code>.2s</code></td>
+		<td><code>.3s</code></td>
+		<td><code>.4s</code></td>
+		<td><code>.5s</code></td>
+		<td><code>.8s</code></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+
+这元件有供应动画定时系统。请详寻HTML网页查询数码值。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Layout System'
+HTML = '''
+This component also supplies some customizable layout system. They are shown as
+follows (e.g. row 1 column 2 is <code>--main-min-width</code>):
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>Variant</th>
+		<th><code>grid-area</code></th>
+		<th><code>min-width</code></th>
+		<th><code>width</code></th>
+		<th><code>max-width</code></th>
+		<th><code>padding-top</code></th>
+		<th><code>padding-left</code></th>
+		<th><code>padding-bottom</code></th>
+		<th><code>padding-right</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--main</code></th>
+		<td><code>content</code></td>
+		<td><code>100%</code></td>
+		<td><code>100%</code></td>
+		<td><code>100%</code></td>
+		<td><code>10rem</code></td>
+		<td><code>10%</code></td>
+		<td><code>10rem</code></td>
+		<td><code>10%</code></td>
+	</tr>
+	<tr>
+		<th><code>--footer</code></th>
+		<td><code>footer</code></td>
+		<td><code>100%</code></td>
+		<td><code>100%</code></td>
+		<td><code>100%</code></td>
+		<td><code>3.5rem</code></td>
+		<td><code>10%</code></td>
+		<td><code>3.5rem</code></td>
+		<td><code>10%</code></td>
+	</tr>
+	<tr>
+		<th><code>--leftnav</code></th>
+		<td><code>leftnav</code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+	</tr>
+	<tr>
+		<th><code>--rightnav</code></th>
+		<td><code>rightnav</code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+	</tr>
+	<tr>
+		<th><code>--topnav</code></th>
+		<td><code>topnav</code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+This component also supplies consistent animation timing system.
+See HTML page for list of variables.
+'''
+Code = '''
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '布局系统'
+HTML = '''
+这元件有供可自定的布局系统如下（例子：第 1 行 第 2 列是
+<code>--main-min-width</code>）：
+<br/><br/>
+<div style="display:flex;justify-content:center"><table>
+<thead>
+	<tr>
+		<th>类型</th>
+		<th><code>grid-area</code></th>
+		<th><code>min-width</code></th>
+		<th><code>width</code></th>
+		<th><code>max-width</code></th>
+		<th><code>padding-top</code></th>
+		<th><code>padding-left</code></th>
+		<th><code>padding-bottom</code></th>
+		<th><code>padding-right</code></th>
+	</tr>
+</thead>
+<tbody>
+	<tr>
+		<th><code>--main</code></th>
+		<td><code>content</code></td>
+		<td><code>100%</code></td>
+		<td><code>100%</code></td>
+		<td><code>100%</code></td>
+		<td><code>10rem</code></td>
+		<td><code>10%</code></td>
+		<td><code>10rem</code></td>
+		<td><code>10%</code></td>
+	</tr>
+	<tr>
+		<th><code>--footer</code></th>
+		<td><code>footer</code></td>
+		<td><code>100%</code></td>
+		<td><code>100%</code></td>
+		<td><code>100%</code></td>
+		<td><code>3.5rem</code></td>
+		<td><code>10%</code></td>
+		<td><code>3.5rem</code></td>
+		<td><code>10%</code></td>
+	</tr>
+	<tr>
+		<th><code>--leftnav</code></th>
+		<td><code>leftnav</code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+	</tr>
+	<tr>
+		<th><code>--rightnav</code></th>
+		<td><code>rightnav</code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+	</tr>
+	<tr>
+		<th><code>--topnav</code></th>
+		<td><code>topnav</code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+		<td><code></code></td>
+	</tr>
+</tbody>
+</table></div>
+'''
+Plain = '''
+
+这元件有供应动画定时系统。请详寻HTML网页查询数码值。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Scroll Behavior'
+HTML = '''
+Affects the scrolling behavior of the page.
+'''
+Plain = '''
+Affects the scrolling behavior of the page.
+'''
+Code = '''
+VARIABLE     : --html-scroll-behavior
+CSS PROPERTY : scroll-behavior
+DEFAULT      : smooth (>= v1.2.0)
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Scroll Behavior'
+HTML = '''
+影响网页的移动反应。
+'''
+Plain = '''
+影响网页的移动反应。
+'''
+Code = '''
+变化值     : --html-scroll-behavior
+CSS属性    : scroll-behavior
+默认数码   : smooth (>= v1.2.0)
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Page Grid'
+HTML = '''
+Affects the base grid layout definition of the page.
+'''
+Plain = '''
+Affects the base grid layout definition of the page.
+'''
+Code = '''
+VARIABLE     : --body-grid
+CSS PROPERTY : grid
+DEFAULT      :
+(>= v1.2.0)
+	"content" auto
+	"footer" minmax(0, max-content)
+	"topnav" minmax(0, auto)
+	"leftnav" minmax(0, auto)
+	"rightnav" minmax(0, auto)
+	/ 100%
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '网页Grid'
+HTML = '''
+影响网页的移动反应。
+'''
+Plain = '''
+影响网页的移动反应。
+'''
+Code = '''
+变化值     : --body-grid
+CSS属性    : grid
+默认数码   :
+(>= v1.2.0)
+	"content" auto
+	"footer" minmax(0, max-content)
+	"topnav" minmax(0, auto)
+	"leftnav" minmax(0, auto)
+	"rightnav" minmax(0, auto)
+	/ 100%
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'JavaScript'
+HTML = '''
+Fortunately, this component does not use any JavaScript. Relax.
+'''
+Plain = '''
+Fortunately, this component does not use any JavaScript. Relax.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'JavaScript'
+HTML = '''
+庆幸的是这个元件没有运用到任何JavaScript。放心吧！
+'''
+Plain = '''
+庆幸的是这个元件没有运用到任何JavaScript。放心吧！
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/data/Specs/hestiaGUI/zoralabCORE/Functions.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabCORE/Functions.toml
@@ -1,0 +1,67 @@
+[[EN.List]]
+Title = 'ToCSS'
+HTML = '''
+Render the CSS output for this UI component.
+'''
+Plain = '''
+Render the CSS output for this UI component.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = 'ToCSS'
+HTML = '''
+渲染呈现CSS的输出数据。
+'''
+Plain = '''
+渲染呈现CSS的输出数据。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+Usage example:
+'''
+Plain = '''
+Usage example:
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabCORE/ToCSS" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = 'Hugo'
+HTML = '''
+用法：
+'''
+Plain = '''
+用法：
+'''
+Code = '''
+{{- $ret := partial "hestiaGUI/zoralabCORE/ToCSS" . -}}
+<pre>{{- printf "%#v\n" $ret -}}</pre>
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/data/Specs/hestiaGUI/zoralabCORE/Metadata.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabCORE/Metadata.toml
@@ -1,0 +1,14 @@
+[EN.Brand]
+ID = 'zoralabcore'
+SKU = 'zoralabCORE'
+Description = '''
+For providing fundamental UI control variables and values.
+'''
+
+
+[ZH-HANS.Brand]
+ID = 'zoralabcore'
+SKU = 'zoralabCORE'
+Description = '''
+来供应需要的基本控制数据值。
+'''

--- a/sites/data/Specs/hestiaGUI/zoralabCORE/Purposes.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabCORE/Purposes.toml
@@ -1,0 +1,78 @@
+[[EN.List]]
+Title = 'Main Purpose'
+HTML = '''
+This package's primary purpose is to provide user interface (UI) styling
+fundamental controls and default values for consistently controlling various
+other compatible UI components.
+'''
+Plain = '''
+This package's primary purpose is to provide user interface (UI) styling
+fundamental controls and default values for consistently controlling various
+other compatible UI components.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = '主要目的'
+HTML = '''
+这个软件包的出生主要是供应需要的基本控制数据值好在统一情况里操着其他有支持的界面
+元件。
+'''
+Plain = '''
+这个软件包的出生主要是供应需要的基本控制数据值好在统一情况里操着其他有支持的界面
+元件。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''
+
+
+
+
+[[EN.List]]
+Title = 'Legacy Recording'
+HTML = '''
+This package was known as <code>core_hestiaUI</code> before ZORALab's Hestia
+<code>v1.2.0</code>. The transformation was due to someone attempting to steal
+the copyrights and makes way for programming package's documentation
+restructuring.
+'''
+Plain = '''
+This package was known as 'core_hestiaUI' before ZORALab's Hestia 'v1.2.0'. The
+transformation was due to someone attempting to steal the design copyrights and
+makes way for programming package's documentation restructuring.
+'''
+Code = '''
+'''
+
+[[EN.List.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List]]
+Title = '历史遗录'
+HTML = '''
+这个软件包在ZORALab赫斯提亚<code>v1.2.0</code>版本之前曾经被名为
+<code>core_hestiaUI</code>。改名的目的是有人要横行强盗设计的版权和为了编程文件
+编写能力而整理过。
+'''
+Plain = '''
+这个软件包在ZORALab赫斯提亚v1.2.0版本之前曾经被名为core_hestiaUI。改名的目的是有
+人要横行强盗设计的版权和为了编程文件编写能力而整理过。
+'''
+Code = '''
+'''
+
+[[ZH-HANS.List.URL]]
+Value = ''
+Label = ''

--- a/sites/data/Specs/hestiaGUI/zoralabNOTE_ERROR/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabNOTE_ERROR/Designs.toml
@@ -203,7 +203,7 @@ Affects the title's border color of the rendered component.
 Code = '''
 VARIABLE     : --note-title-error-border-color
 CSS PROPERTY : border-color
-DEFAULT      : var(--body-color-indicator-red) (>= v1.0.0)
+DEFAULT      : var(--body-color-indicator-red) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -222,7 +222,7 @@ Plain = '''
 Code = '''
 变化值     : --note-title-error-border-color
 CSS属性    : border-color
-默认数码   : var(--body-color-indicator-red) (>= v1.0.0)
+默认数码   : var(--body-color-indicator-red) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -242,7 +242,7 @@ Affects the title's color of the rendered component.
 Code = '''
 VARIABLE     : --note-title-error-color
 CSS PROPERTY : color
-DEFAULT      : #FFF (>= v1.0.0)
+DEFAULT      : #FFF (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -261,7 +261,7 @@ Plain = '''
 Code = '''
 变化值     : --note-title-error-color
 CSS属性    : color
-默认数码   : #FFF (>= v1.0.0)
+默认数码   : #FFF (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -281,7 +281,7 @@ Affects the title indicator's color of the rendered component.
 Code = '''
 VARIABLE     : --note-title-error-indicator-color
 CSS PROPERTY : color
-DEFAULT      : #FFF (>= v1.0.0)
+DEFAULT      : #FFF (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -300,7 +300,7 @@ Plain = '''
 Code = '''
 变化值     : --note-title-error-indicator-color
 CSS属性    : color
-默认数码   : #FFF (>= v1.0.0)
+默认数码   : #FFF (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -320,7 +320,7 @@ Affects the title's background of the rendered component.
 Code = '''
 VARIABLE     : --note-title-error-background
 CSS PROPERTY : background
-DEFAULT      : var(--body-background-indicator-red-inverted) (>= v1.0.0)
+DEFAULT      : var(--body-color-indicator-red) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -339,7 +339,7 @@ Plain = '''
 Code = '''
 变化值     : --note-title-error-background
 CSS属性    : background
-默认数码   : var(--body-background-indicator-red-inverted) (>= v1.0.0)
+默认数码   : var(--body-color-indicator-red) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -359,7 +359,7 @@ Affects the content's color of the rendered component.
 Code = '''
 VARIABLE     : --note-content-error-color
 CSS PROPERTY : color
-DEFAULT      : var(--body-color-indicator-red) (>= v1.0.0)
+DEFAULT      : var(--body-color-indicator-red) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -378,7 +378,7 @@ Plain = '''
 Code = '''
 变化值     : --note-content-error-color
 CSS属性    : color
-默认数码   : var(--body-color-indicator-red) (>= v1.0.0)
+默认数码   : var(--body-color-indicator-red) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -398,7 +398,7 @@ Affects the content's background of the rendered component.
 Code = '''
 VARIABLE     : --note-content-error-background
 CSS PROPERTY : background
-DEFAULT      : var(--body-background-indicator-red) (>= v1.0.0)
+DEFAULT      : var(--body-background-indicator-red) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -417,7 +417,7 @@ Plain = '''
 Code = '''
 变化值     : --note-content-error-background
 CSS属性    : background
-默认数码   : var(--body-background-indicator-red) (>= v1.0.0)
+默认数码   : var(--body-background-indicator-red) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]

--- a/sites/data/Specs/hestiaGUI/zoralabNOTE_SUCCESS/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabNOTE_SUCCESS/Designs.toml
@@ -203,7 +203,7 @@ Affects the title's border color of the rendered component.
 Code = '''
 VARIABLE     : --note-title-success-border-color
 CSS PROPERTY : border-color
-DEFAULT      : var(--body-color-indicator-green-inverted) (>= v1.0.0)
+DEFAULT      : var(--body-color-indicator-green) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -222,7 +222,7 @@ Plain = '''
 Code = '''
 变化值     : --note-title-success-border-color
 CSS属性    : border-color
-默认数码   : var(--body-color-indicator-green-inverted) (>= v1.0.0)
+默认数码   : var(--body-color-indicator-green) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -242,7 +242,7 @@ Affects the title's color of the rendered component.
 Code = '''
 VARIABLE     : --note-title-success-color
 CSS PROPERTY : color
-DEFAULT      : #FFF (>= v1.0.0)
+DEFAULT      : #FFF (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -261,7 +261,7 @@ Plain = '''
 Code = '''
 变化值     : --note-title-success-color
 CSS属性    : color
-默认数码   : #FFF (>= v1.0.0)
+默认数码   : #FFF (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -281,7 +281,7 @@ Affects the title indicator's color of the rendered component.
 Code = '''
 VARIABLE     : --note-title-success-indicator-color
 CSS PROPERTY : color
-DEFAULT      : #FFF (>= v1.0.0)
+DEFAULT      : #FFF (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -300,7 +300,7 @@ Plain = '''
 Code = '''
 变化值     : --note-title-success-indicator-color
 CSS属性    : color
-默认数码   : #FFF (>= v1.0.0)
+默认数码   : #FFF (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -320,7 +320,7 @@ Affects the title's background of the rendered component.
 Code = '''
 VARIABLE     : --note-title-success-background
 CSS PROPERTY : background
-DEFAULT      : var(--body-background-indicator-green-inverted) (>= v1.0.0)
+DEFAULT      : var(--body-color-indicator-green) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -339,7 +339,7 @@ Plain = '''
 Code = '''
 变化值     : --note-title-success-background
 CSS属性    : background
-默认数码   : var(--body-background-indicator-green-inverted) (>= v1.0.0)
+默认数码   : var(--body-color-indicator-green) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -359,7 +359,7 @@ Affects the content's color of the rendered component.
 Code = '''
 VARIABLE     : --note-content-success-color
 CSS PROPERTY : color
-DEFAULT      : var(--body-color-indicator-green-inverted) (>= v1.0.0)
+DEFAULT      : var(--body-color-indicator-green) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -378,7 +378,7 @@ Plain = '''
 Code = '''
 变化值     : --note-content-success-color
 CSS属性    : color
-默认数码   : var(--body-color-indicator-green-inverted) (>= v1.0.0)
+默认数码   : var(--body-color-indicator-green) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -398,7 +398,7 @@ Affects the content's background of the rendered component.
 Code = '''
 VARIABLE     : --note-content-success-background
 CSS PROPERTY : background
-DEFAULT      : var(--body-background-indicator-green) (>= v1.0.0)
+DEFAULT      : var(--body-background-indicator-green) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -417,7 +417,7 @@ Plain = '''
 Code = '''
 变化值     : --note-content-success-background
 CSS属性    : background
-默认数码   : var(--body-background-indicator-green) (>= v1.0.0)
+默认数码   : var(--body-background-indicator-green) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]

--- a/sites/data/Specs/hestiaGUI/zoralabNOTE_WARNING/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabNOTE_WARNING/Designs.toml
@@ -203,7 +203,7 @@ Affects the title's border color of the rendered component.
 Code = '''
 VARIABLE     : --note-title-warning-border-color
 CSS PROPERTY : border-color
-DEFAULT      : var(--body-color-indicator-yellow-inverted) (>= v1.0.0)
+DEFAULT      : var(--body-color-indicator-yellow) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -222,7 +222,7 @@ Plain = '''
 Code = '''
 变化值     : --note-title-warning-border-color
 CSS属性    : border-color
-默认数码   : var(--body-color-indicator-yellow-inverted) (>= v1.0.0)
+默认数码   : var(--body-color-indicator-yellow) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -242,7 +242,7 @@ Affects the title's color of the rendered component.
 Code = '''
 VARIABLE     : --note-title-warning-color
 CSS PROPERTY : color
-DEFAULT      : var(--body-color-indicator-yellow-inverted) (>= v1.0.0)
+DEFAULT      : #FFF (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -261,7 +261,7 @@ Plain = '''
 Code = '''
 变化值     : --note-title-warning-color
 CSS属性    : color
-默认数码   : var(--body-color-indicator-yellow-inverted) (>= v1.0.0)
+默认数码   : #FFF (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -281,7 +281,7 @@ Affects the title indicator's color of the rendered component.
 Code = '''
 VARIABLE     : --note-title-warning-indicator-color
 CSS PROPERTY : color
-DEFAULT      : var(--body-color-indicator-yellow-inverted) (>= v1.0.0)
+DEFAULT      : #FFF (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -300,7 +300,7 @@ Plain = '''
 Code = '''
 变化值     : --note-title-warning-indicator-color
 CSS属性    : color
-默认数码   : var(--body-color-indicator-yellow-inverted) (>= v1.0.0)
+默认数码   : #FFF (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -320,7 +320,7 @@ Affects the title's background of the rendered component.
 Code = '''
 VARIABLE     : --note-title-warning-background
 CSS PROPERTY : background
-DEFAULT      : var(--body-background-indicator-yellow-inverted) (>= v1.0.0)
+DEFAULT      : var(--body-color-indicator-yellow) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -339,7 +339,7 @@ Plain = '''
 Code = '''
 变化值     : --note-title-warning-background
 CSS属性    : background
-默认数码   : var(--body-background-indicator-yellow-inverted) (>= v1.0.0)
+默认数码   : var(--body-color-indicator-yellow) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -359,7 +359,7 @@ Affects the content's color of the rendered component.
 Code = '''
 VARIABLE     : --note-content-warning-color
 CSS PROPERTY : color
-DEFAULT      : var(--body-color-indicator-yellow-inverted) (>= v1.0.0)
+DEFAULT      : var(--body-color-indicator-yellow) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -378,7 +378,7 @@ Plain = '''
 Code = '''
 变化值     : --note-content-warning-color
 CSS属性    : color
-默认数码   : var(--body-color-indicator-yellow-inverted) (>= v1.0.0)
+默认数码   : var(--body-color-indicator-yellow) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -398,7 +398,7 @@ Affects the content's background of the rendered component.
 Code = '''
 VARIABLE     : --note-content-warning-background
 CSS PROPERTY : background
-DEFAULT      : var(--body-background-indicator-yellow) (>= v1.0.0)
+DEFAULT      : var(--body-background-indicator-yellow) (>= v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -417,7 +417,7 @@ Plain = '''
 Code = '''
 变化值     : --note-content-warning-background
 CSS属性    : background
-默认数码   : var(--body-background-indicator-yellow) (>= v1.0.0)
+默认数码   : var(--body-background-indicator-yellow) (>= v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]

--- a/sites/layouts/content/specs/zoralab/components.toml
+++ b/sites/layouts/content/specs/zoralab/components.toml
@@ -50,9 +50,7 @@
 [[List]]
 Name = "zoralabCORE"
 Include = true
-Variables = [
-	{ "--body-scroll-behavior" = "smooth" },
-]
+Variables = []
 
 [[List]]
 Name = "googleFONT_NOTOSANS"
@@ -67,20 +65,17 @@ Variables = []
 [[List]]
 Name = "zoralabDRAWER_LEFT"
 Include = true
-Variables = [
-]
+Variables = []
 
 [[List]]
 Name = "zoralabDRAWER_TOP"
 Include = true
-Variables = [
-]
+Variables = []
 
 [[List]]
 Name = "zoralabDRAWER_RIGHT"
 Include = true
-Variables = [
-]
+Variables = []
 
 [[List]]
 Name = "zoralabANCHOR"


### PR DESCRIPTION
Since the /en/specs/hestiaGUI page is ready, we can proceed to port zoralabCORE spec page. Hence, let's do this.

This patch ports /en/specs/hestiaGUI/zoralabCORE/ spec page into sites/ directory.