### PR TITLE
sites: translated /zh-hans/specs/hestiaGUI/zoralabFORM/ page

### DIFF
--- a/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__content.hestiaLDJSON
+++ b/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__content.hestiaLDJSON
@@ -1,0 +1,22 @@
+{{- /*
+Page's HTML's LD+JSON Output Prime Control
+
+This file is your LD+JSON output that will be deployed into your HTML meta page.
+Hugo's and Go's template processors are available at your disposal in case of
+mathematical or logical algorithms development.
+*/ -}}
+{{- /* prepare variables for function */ -}}
+{{- $Page := . -}}
+{{- $dataList := dict -}}
+
+
+
+
+{{- /* execute function */ -}}
+{{- $dataList = merge $dataList (partial "hestiaJSON/schemaorgLDJSON/WebPage" .) -}}
+
+
+
+
+{{- /* render output */ -}}
+{{- jsonify $dataList -}}

--- a/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__contributors.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__contributors.toml
@@ -1,0 +1,78 @@
+# PAGE-SPECIFIC CONTRIBUTORS
+# ==========================
+# QUICK NOTE:
+#   1. Your contributor data shall be supplied in the .Data.Hestia.Creators/
+#      directory. Here, you only list them out using their data filename as the
+#      Key for this page and update their contribution.
+#   2. Example entries:
+#        [[Contributor]]
+#        Key = 'Holloway'
+#
+#        [Contributor.Contribution]
+#        Creation = true
+#        Contact = true
+#        Artwork = false
+#        Knowledge = true
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = false
+#        Sponsor = false
+#
+#        [[Contributor]]
+#        Key = 'CoryGalyna'
+#
+#        [Contributor.Contribution]
+#        Creation = false
+#        Contact = false
+#        Artwork = false
+#        Knowledge = false
+#        Editor = true
+#        Developer = false
+#        Maintainer = false
+#        Producer = false
+#        Provider = false
+#        Publisher = false
+#        Funder = true
+#        Sponsor = false
+#
+#        ...
+[[Contributors]]
+Key = 'ZORALab'
+
+[Contributors.Contribution]
+Creation = true
+Contact = true
+Artwork = false
+Knowledge = false
+Editor = true
+Developer = false
+Maintainer = false
+Producer = true
+Provider = true
+Publisher = true
+Funder = false
+Sponsor = true
+
+
+
+
+[[Contributors]]
+Key = 'HollowayKeanHo'
+
+[Contributors.Contribution]
+Creation = true
+Contact = false
+Artwork = false
+Knowledge = true
+Editor = true
+Developer = false
+Maintainer = false
+Producer = false
+Provider = false
+Publisher = false
+Funder = false
+Sponsor = false

--- a/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__data.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__data.toml
@@ -1,0 +1,2 @@
+[Dataset]
+Path = 'hestiaGUI.zoralabFORM'

--- a/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__languages.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__languages.toml
@@ -1,0 +1,25 @@
+# AVAILABLE TRANSLATION PAGES
+# ===========================
+# Data pattern:
+#                [{[code]}{-[Script]}{-[COUNTRY]}]
+#                URL = "[URL]"
+# Examples:
+#                [en]
+#                URL = "/en/my-page-here/"
+#
+#                [zh-Hans]
+#                URL = "/zh-hans/我的网站这儿/"
+#
+# NOTE:
+#   1. The language code **MUST** be one of the Hestia site-level languages.
+#      Otherwise, error shall be thrown.
+#   2. If you need to use external pages, set the internal page's settings to
+#      redirect immediately towards it.
+#   3. If the URL is left empty (""), that translation page is disabled.
+#   4. Hestia compatible URL (ONLY .Languages data structure is usable) can
+#      be accepted in the .Lang.URL fields (see example above).
+[en]
+URL = '/en/specs/hestiagui/zoralabform'
+
+[zh-Hans]
+URL = '/zh-hans/specs/hestiagui/zoralabform'

--- a/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__page.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__page.toml
@@ -1,0 +1,124 @@
+# PAGE METADATA
+# =============
+# Date fields.
+#
+# NOTE:
+#   1. You can generate date easily on linux using '$ date' command.
+#   2. If date field is left blank, the current time shall be used instead.
+#   3. Date should ONLY comply to this pattern when manually constructed:
+#                    Thu 21 Jul 2022 14:27:39 PM +08
+[Date]
+Created   = "Fri 16 Dec 2022 06:00:32 PM +08"
+Published = "Fri 16 Dec 2022 06:00:32 PM +08"
+
+
+
+
+# Content fields.
+# NOTE:
+#   1. For .Title, Hestia's string processing using page variables are allowed
+#      and only limited to .Titles sub-fields.
+#   2. For .Keywords, Hestia's string processing using page variables are
+#      allowed but strongly discouraged.
+[Content]
+Title = "zoralabFORM科技规范 - ZORALab赫斯提亚"
+Keywords = [
+	'zoralabFORM',
+	'hestiaGUI',
+	'科技规范',
+	'规范',
+	'网站',
+	'科技',
+	'PWA',
+	'WASM',
+	'代码库',
+	'Hugo',
+	'Go',
+	'TinyGo',
+	'Nim',
+	'ZORALab',
+	'ZORALab赫斯提亚',
+]
+
+
+
+
+# Description fields.
+# NOTE:
+#   1. Hestia's string processing using page variables are allowed.
+#   2. The .Description.Pitch is at maximum 160 characters.
+#   3. The .Description.Summary is at maximum of 250 characters.
+#   4. All fields shall have their whitespace cleansed during the processing.
+[Description]
+Pitch = '''
+当用着这份代码包时所需的科技规范。
+'''
+Summary = '''
+随和、支持离线（通过PWA安装）和非常注重细节的。
+'''
+
+
+
+
+# Redirect fields.
+# NOTE:
+#   1. Hestia's URL processing is allowed for .URL field.
+#   2. .Delay timing sets the delay time before redirect. Setting to '0' means
+#      an immediate redirect is requested.
+#   3. Redirect is only available if .Enabled is set to 'true'.
+#   4. Redirect.Language is to redirect the current page to its
+#      language-specific page when Javascript is made available on client side
+#      or fallback to default language.
+[Redirect]
+Delay = 0 # second
+URL = ''
+Enabled = false
+
+[Redirect.Language]
+Enabled = false
+
+
+
+
+# Content Files' Sourcing Location
+# NOTE:
+#   1. To denote where are the content sources.
+#   2. If you're sourcing from assets directory, prefix 'assets/'.
+#   3. If you're sourcing from layouts directory, prefix 'layouts/'.
+#   2. If you're sourcing from static directory, prefix 'static/'.
+#   3. If you're sourcing from partial directory, prefix 'layouts/partials/'.
+[Sources]
+HTML = 'layouts/content/specs/zoralab/index.html'
+JSON = 'layouts/content/specs/zoralab/index.json'
+CSS = 'layouts/content/specs/zoralab/index.css'
+JS = 'layouts/content/specs/zoralab/index.js'
+LDJSON = '__content.hestiaLDJSON'
+Contributors = '__contributors.toml'
+Thumbnails = '__thumbnails.toml'
+Languages = '__languages.toml'
+Assets = 'layouts/content/specs/zoralab/assets.toml'
+Components = 'layouts/content/specs/zoralab/components.toml'
+
+
+
+
+# Data fields.
+# NOTE:
+#   1. List only the page-level data files. It can be in any of the following
+#      formats: '.json', '.toml', or '.yaml'.
+#   2. Hestia string processing is available and shall be processed prior to
+#      dataset transformation.
+#   3. Sequences of the .Data array dictates sequences of loading and overriding
+#      (the latter shall overwrite the former for the same data fields).
+#   4. The final processed dataset shall be served as main data content in
+#      supported output format (e.g. index.json).
+#   5. Missing data file shall be ignored.
+#   6. To add more data files, simply duplicate and add more .Data array entry.
+#      Example:
+#                             [[data]]
+#                             Filename = 'file1.json'
+#
+#                             [[data]]
+#                             Filename = 'file2.toml'
+[[Data]]
+Filename = '__data.toml'

--- a/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__robots.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__robots.toml
@@ -1,0 +1,7 @@
+# PAGE SPECIFIC ROBOTS INSTRUCTIONS LIST
+# ======================================
+#
+# Example:
+#     [[Meta]]
+#     Name = "googleBot"
+#     Content = "noindex, nofollow"

--- a/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__thumbnails.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__thumbnails.toml
@@ -1,0 +1,91 @@
+# Hestia PAGE-LEVEL thumbnails configurations
+# -------------------------------------------
+[Contents.0]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '630'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.0.Sources]]
+URL = '/thumbnails-1200x630.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.0.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.1]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '1200'
+Height = '1200'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.1.Sources]]
+URL = '/thumbnails-1200x1200.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.1.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false
+
+
+
+
+[Contents.2]
+Name = '{{- .Titles.Page -}}'
+Decorative = false
+Loading = 'lazy'
+Width = '480'
+Height = '480'
+CORS = 'anonymous'
+Relationship = ''
+Design = ''
+Preload = ''
+Control = false
+Autoplay = false
+Loop = false
+Mute = false
+Inline = false
+
+[[Contents.2.Sources]]
+URL = '/thumbnails-480x480.jpg'
+Type = 'image/jpeg'
+Media = 'all'
+Descriptor = '1x'
+
+[Contents.2.Tracks.en]
+URL = ''
+Kind = 'subtitles'
+Label = 'English'
+Default = false

--- a/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__twitter.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__twitter.toml
@@ -1,0 +1,28 @@
+# PAGE CONTENT CREATOR (OPTIONAL)
+[Creator]
+Handle = 'zoralab_team' # twitter handle (e.g. 'hollowaykeanho')
+
+
+
+
+# APPLE APP STORE & GOOGLE PLAY STORE
+# NOTE:
+#  1) For .ID field, provide the App ID showcase in the public store; NOT the
+#     development app ID (e.g. NOT Apple Store Bundle ID).
+#  2) Leave the fields empty to disable unused ones.
+[Stores.iphone]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.ipad]
+ID = ''
+Name = ''
+URL = ''
+
+
+[Stores.googleplay]
+ID = ''
+Name = ''
+URL = ''

--- a/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__wasm.toml
+++ b/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/__wasm.toml
@@ -1,0 +1,51 @@
+# Page-level WASM Configurations
+# ------------------------------
+[Settings]
+# URL - the WASM source URL location. Recommended place it inside the same
+#       directory. Hestia formatting URL is acceptable. This field shall be
+#       ignored if Embed field is set.
+#
+#       This field is REQUIRED.
+URL = ''
+
+
+
+
+# Dependencies - list of javascript dependencies to be loaded before executing
+#                WASM stream instruction. Hestia formatting URL is acceptable.
+#                This field is OPTIONAL.
+#
+#                When Embed is set, all the dependencies shall be sourced,
+#                concatenated, minified, and inline embed into the HTML file.
+Dependencies = [
+]
+
+
+
+
+# Setup - any Javascript instructions right before the WASM stream instruction.
+#         It is meant for WASM compiled from languages requiring their
+#         respective runtime initialization. Example, for Go, it is:
+#                          'const go = new Go();'
+#         This field is OPTIONAL.
+Setup = """\
+"""
+
+
+
+
+# Import - any WASM object import. It is meant for WASM compiled from languages
+#         requiring their respective runtime import. Example, for Go, it is:
+#                            'go.importObject'
+#         This field is OPTIONAL.
+Import = ''
+
+
+
+
+# Init  - Javascript instruction after a successful WASM stream. A 'result'
+#         object is provided for initializing your page. Example, for Go, it is:
+#                            'go.run(result.instance);'
+#         This field is OPTIONAL.
+Init = """\
+"""

--- a/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/_index.html
+++ b/sites/content/zh-hans/specs/hestiaGUI/zoralabFORM/_index.html
@@ -1,0 +1,5 @@
++++
+# [WARNING]
+# Create your content in the file called "__content.hestiaHTML" when using
+# ZORALab's Hestia theme module. All contents here shall be ignored.
++++

--- a/sites/data/Specs/hestiaGUI/zoralabFORM/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabFORM/Designs.toml
@@ -446,7 +446,7 @@ The placeholder field HTML codes are shown below:
 '''
 Code = '''
 <input ... placeholder='...' />
-<textarea ... placeholder='...'></textarea>
+<textarea ... placeholder='...'>...</textarea>
 '''
 
 [[EN.List.SubList.URL]]
@@ -464,7 +464,7 @@ Plain = '''
 '''
 Code = '''
 <input ... placeholder='...' />
-<textarea ... placeholder='...'></textarea>
+<textarea ... placeholder='...'>...</textarea>
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -732,7 +732,7 @@ Code = '''
 	formtype="...覆盖表格原本的成交类型..."
 	formmethod="...覆盖表格原本的方式 (e.g. GET|POST|dialog|...)"
 	formnovalidate="true"
-	formtarget="...AN IFRAME ID..."
+	formtarget="...一个IFRAME的ID..."
 	disabled
 />
 '''
@@ -1454,7 +1454,7 @@ Code = '''
 	name='...'
 	pattern='^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[\(!@#\$%\^&\*\)]).{33,}'
 	minlength='33'
-	placeholder='Password Here'
+	placeholder='请在这儿填入密码'
 />
 
 
@@ -1466,7 +1466,7 @@ Code = '''
 	pattern='^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[\(!@#\$%\^&\*\)]).{33,}'
 	minlength='33'
 	maxlength='...'
-	placeholder='Password Here'
+	placeholder='...'
 	required
 	disabled
 	autofocus
@@ -1535,14 +1535,14 @@ Code = '''
 <!-- 最少 -->
 <label>
 	<input type='radio' name='...DECISION_A...' value='...CHOICE_1...' />
-	<span>...LABEL SHOWCASE HERE...</span>
+	<span>...字条内容...</span>
 </label>
 
 
 <!-- 最少（默认值：已选择了） -->
 <label>
 	<input type='radio' name='...DECISION_A...' value='...CHOICE_2...' checked />
-	<span>...LABEL SHOWCASE HERE...</span>
+	<span>...字条内容...</span>
 </label>
 
 
@@ -1557,7 +1557,7 @@ Code = '''
 		disabled
 		autofocus
 	/>
-	<span>...LABEL SHOWCASE HERE...</span>
+	<span>...字条内容...</span>
 </label>
 '''
 
@@ -3621,10 +3621,10 @@ Label = ''
 [[ZH-HANS.List.SubList]]
 Title = 'Border Radius（数码格套装）'
 HTML = '''
-影响元件边界线的角落圆形度。
+影响元件数码格套装边界线的角落圆形度。
 '''
 Plain = '''
-影响元件边界线的角落圆形度。
+影响元件数码格套装边界线的角落圆形度。
 '''
 Code = '''
 变化值     : --form-fieldset-border-radius
@@ -3736,7 +3736,7 @@ Label = ''
 
 
 [[ZH-HANS.List.SubList]]
-Title = 'Font Weight（数码格套装标题)'
+Title = 'Font Weight（数码格套装标题）'
 HTML = '''
 影响元件数码格套装标题的字体厚度。
 '''
@@ -3764,8 +3764,8 @@ Plain = '''
 Affects the fieldset's legend's text transformation of the rendered component.
 '''
 Code = '''
-VARIABLE     : --form-fieldset-legend-text-decoration
-CSS PROPERTY : text-decoration
+VARIABLE     : --form-fieldset-legend-text-transform
+CSS PROPERTY : text-transform
 DEFAULT      : uppercase (>= v1.2.0)
 '''
 
@@ -3783,8 +3783,8 @@ Plain = '''
 影响元件数码格套装标题的字体装饰。
 '''
 Code = '''
-变化值     : --form-fieldset-legend-text-decoration
-CSS属性    : text-decoration
+变化值     : --form-fieldset-legend-text-transform
+CSS属性    : text-transform
 默认数码   : uppercase (>= v1.2.0)
 '''
 
@@ -4165,7 +4165,7 @@ Label = ''
 
 
 [[ZH-HANS.List.SubList]]
-Title = 'Padding (字条)'
+Title = 'Padding （字条）'
 HTML = '''
 影响元件字条的内向边距空间。
 '''
@@ -4282,7 +4282,7 @@ Label = ''
 
 
 [[ZH-HANS.List.SubList]]
-Title = 'Font Weight（字条)'
+Title = 'Font Weight（字条）'
 HTML = '''
 影响元件字条的字体厚度。
 '''
@@ -4291,7 +4291,7 @@ Plain = '''
 '''
 Code = '''
 变化值     : ---form-label-font-weight
-CSS属性    : font-family
+CSS属性    : font-weight
 默认数码   : 700 (>= v1.2.0)
 '''
 
@@ -5090,8 +5090,8 @@ Plain = '''
 Affects the field's text transformation of the rendered component.
 '''
 Code = '''
-VARIABLE     : --form-field-text-decoration
-CSS PROPERTY : text-decoration
+VARIABLE     : --form-field-text-transform
+CSS PROPERTY : text-transform
 DEFAULT      : initial (>= v1.2.0)
 '''
 
@@ -5109,8 +5109,8 @@ Plain = '''
 影响元件数据格的字体装饰。
 '''
 Code = '''
-变化值     : --form-field-text-decoration
-CSS属性    : text-decoration
+变化值     : --form-field-text-transform
+CSS属性    : text-transform
 默认数码   : initial (>= v1.2.0)
 '''
 
@@ -6076,7 +6076,7 @@ Label = ''
 
 
 [[ZH-HANS.List.SubList]]
-Title = 'Font Weight（按钮)'
+Title = 'Font Weight（按钮）'
 HTML = '''
 影响元件按钮的字体厚度。
 '''


### PR DESCRIPTION
Since the /en/specs/hestiaGUI/zoralabFORM/ page is ready, we can proceed to translate it. Hence, let's do this.

This patch translates /zh-hans/specs/zoralabFORM/ page in sites/ directory.