### PR TITLE
hestiaHUGO: added URL data presentation to zoralabDEBUGGER GUI component

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDEBUGGER/ToHTML
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabDEBUGGER/ToHTML
@@ -146,6 +146,9 @@ specific language governing permissions and limitations under the License.
 
 			{{- $ret = dict "DebugKey" ".Descriptions" "DebugValue" .Descriptions -}}
 			{{- template "renderDebugValue" $ret -}}
+
+			{{- $ret = dict "DebugKey" ".URL" "DebugValue" .URL -}}
+			{{- template "renderDebugValue" $ret -}}
 		</div>
 
 


### PR DESCRIPTION
Currently, zoralabDEBUGGER does not display the page URL data. Hence, we need to add it into the main section. Let's do this.

This patch adds URL data presentation to zoralabDEBUGGER GUI component in hestiaHUGO/ directory.