### PR TITLE
hestiaHUGO: increased timeout to 3 minutes (180 seconds)

### DIFF
--- a/hestiaHUGO/server.cmd
+++ b/hestiaHUGO/server.cmd
@@ -14,7 +14,7 @@ while true; do
                 --port 8080 \
                 --renderToDisk \
                 --gc &
-        sleep 120
+        sleep 180
 done
 ################################################################################
 # Unix Main Codes                                                              #
@@ -36,7 +36,7 @@ hugo server --noBuildLock ^
         --port 8080 ^
         --renderToDisk ^
         --gc &
-timeout /t 120
+timeout /t 180
 goto loop
 ::##############################################################################
 :: Windows Main Codes                                                          #

--- a/sites/server.cmd
+++ b/sites/server.cmd
@@ -14,7 +14,7 @@ while true; do
                 --port 8080 \
                 --renderToDisk \
                 --gc &
-        sleep 120
+        sleep 180
 done
 ################################################################################
 # Unix Main Codes                                                              #
@@ -36,7 +36,7 @@ hugo server --noBuildLock ^
         --port 8080 ^
         --renderToDisk ^
         --gc &
-timeout /t 120
+timeout /t 180
 goto loop
 ::##############################################################################
 :: Windows Main Codes                                                          #


### PR DESCRIPTION
After deploying the entire sites/ directory, it is found that 180 seconds are the optimal reset time. Hence, let's do this.

This patch increases timeout to 3 minutes (180 seconds) in hestiaHUGO/ directory.