### PR TITLE
sites: upgraded content/en/getting-started/* layout

### DIFF
--- a/sites/content/en/getting-started/create-basic-and-placeholder-hugo-pages/__i18n.toml
+++ b/sites/content/en/getting-started/create-basic-and-placeholder-hugo-pages/__i18n.toml
@@ -1,15 +1,12 @@
 [i18n]
+[i18n.Labels]
 Title = 'Title'
 Description = 'Description'
-
-
-
-
-[i18n.Labels]
 Code = 'Code'
 URL = 'URL'
-Image = 'Image'
-Guides = 'Guides'
+Media = 'Media'
+Content = 'Content'
+Label = 'Label'
 
 
 
@@ -21,57 +18,75 @@ Title = 'Introduction'
 
 
 
-[i18n.Objectives]
+[[i18n.H2]]
 ID = 'learning-objectives'
 Title = 'Learning Objectives'
-Description = '''
+HTML = '''
 At the end of this tutorial, you will learn:
+<ol>
+	<li><p>How hestiaHUGO works with Hugo</p></li>
+	<li><p>How hestiaHUGO governs filesystem pathing and URL</p></li>
+	<li><p>How hestiaHUGO manage all designers' creating freedom via UI components</p></li>
+	<li><p>How hestiaHUGO design to counter the ever-changing W3C changes</p></li>
+	<li><p>How hestiaHUGO design its multiple outputs (HTML & JSON)</p></li>
+	<li><p>How hestiaHUGO handles internationalization by default</p></li>
+</ol>
+'''
+Plain = '''
+At the end of this tutorial, you will learn:
+(1) How hestiaHUGO works with Hugo; AND
+(2) How hestiaHUGO governs filesystem pathing and URL; AND
+(3) How hestiaHUGO manage all designers' creating freedom via UI components; AND
+(4) How hestiaHUGO design to counter the ever-changing W3C changes; AND
+(5) How hestiaHUGO design its multiple outputs (HTML & JSON); AND
+(6) How hestiaHUGO handles internationalization by default.
+'''
+Code = '''
 '''
 
-
-[[i18n.Objectives.Outcomes]]
-Value = 'How hestiaHUGO works with Hugo'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = 'How hestiaHUGO governs filesystem pathing and URL'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = "How hestiaHUGO manage all designers' creating freedom via UI components"
-
-
-[[i18n.Objectives.Outcomes]]
-Value = 'How hestiaHUGO design to counter the ever-changing W3C changes'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = 'How hestiaHUGO design its multiple outputs (HTML & JSON)'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = 'How hestiaHUGO handles internationalization by default'
+[[i18n.H2.URL]]
+Label = ''
+Value = ''
 
 
 
 
-[[i18n.Steps]]
+[[i18n.H2]]
 ID = 'prerequisite'
 Title = 'Prerequisite'
-Description = '''
+HTML = '''
+This tutorial assumes you have a fresh hestiaHUGO equipped Hugo repository ready
+for deployment especially being created from the previous setup tutorial page.
+Otherwise, please complete that lesson and then revert back to this piece:
+'''
+Plain = '''
 This tutorial assumes you have a fresh hestiaHUGO equipped Hugo repository ready
 for deployment especially being created from the previous setup tutorial page.
 Otherwise, please complete that lesson and then revert back to this piece:
 '''
 Code = ''
-URL = '/en/getting-started/setup-hugo/'
+
+[[i18n.H2.URL]]
 Label = 'Setup Hugo Tutorial'
+Value = '/en/getting-started/setup-hugo/'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'understand-how-hestiahugo-manage-url-with-filesystem'
 Title = 'Understand How hestiaHUGO Manage URL with Filesystem'
-Description = '''
+HTML = '''
+hestiaHUGO natively supports its own multi-languages (a.k.a. 'i18n') feature by
+default. <b>IT USES DIRECTORY NAME AS URL PATH</b> and the 1st level is
+<code>ISO639-1, ISO639-2, ISO639-3, ISO15924, and ISO3166 LANGUAGE CODE</code>
+or language independent pages (e.g. usually redirecting shortcuts). The rest are
+the same as Hugo. We advise you to name your directory according to the URL
+pattern (no space, small characters, and no funny symbols) and use it eventhough
+the content is a single language to avoid building broken URL site in the
+future.
+'''
+Plain = '''
 hestiaHUGO natively supports its own multi-languages (a.k.a. 'i18n') feature by
 default. IT USES DIRECTORY NAME AS URL PATH and the 1st level is
 **ISO639-1, ISO639-2, ISO639-3, ISO15924, and ISO3166 LANGUAGE CODE** or
@@ -83,8 +98,8 @@ future.
 '''
 Code = '''
 PATTERN
-File path:          content/[i18n]/url-compatible-pathing/file.extension
-URL      : [http://baseURL]/[i18n]/url-compatible-pathing/file.extension?query=value#tags
+File path :          content/[i18n]/url-compatible-pathing/file.extension
+URL       : [http://baseURL]/[i18n]/url-compatible-pathing/file.extension?query=value#tags
 
 EXAMPLES
 content/ (https://hestia.zoralab.com/)
@@ -102,19 +117,32 @@ content/en/releases/v1-2-0/index.html (https://hestia.zoralab.com/en/releases/v1
 content/en/releases/v1-2-0/index.json (https://hestia.zoralab.com/en/releases/v1-2-0/index.json)
 content/en/releases/v1-2-0/my-file.zip (https://hestia.zoralab.com/en/releases/v1-2-0/my-file.zip)
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'create-hugo-content-directory'
 Title = "Create Hugo's Content Directory"
-Description = '''
+HTML = '''
+We can now start by creating the Hugo's content directory. It is named inside
+your <code>config/_default/config.toml</code> under the field
+<code>contentDir</code> (usually called <code>content</code>). You may alter it
+as per your need. For this tutorial, we will just stick to the default
+<code>content</code>. After creating the directory, you will need to
+restart your hugo server (hint: <code>server.cmd</code> command). A complete
+list of commands would be:
+'''
+Plain = '''
 We can now start by creating the Hugo's content directory. It is named inside
 your 'config/_default/config.toml' under the field 'contentDir' (usually called
 'content'). You may alter it as per your need. For this tutorial, we will just
 stick to the default 'content'. After creating the directory, you will need to
-restart your hugo server (hint: `hugo server ...` command). A complete list of
+restart your hugo server (hint: `server.cmd` command). A complete list of
 commands would be:
 '''
 Code = '''
@@ -122,23 +150,36 @@ Code = '''
 	[ Kill the server with CTRL+C ]
 	$ cd sites/        # your hugo repository if you're not inside it
 	$ mkdir -p content
-	$ hugo server .... # refer pervious tutorial if you had forgotten
+	$ ./server.cmd     # refer pervious tutorial if you had forgotten
 
 
 # WINDOWS
 	[ Kill the server with CTRL+C ]
 	> cd sites/        # your hugo repository if you're not inside it
 	> mkdir content
-	> hugo server .... # refer pervious tutorial if you had forgotten
+	> server.cmd       # refer pervious tutorial if you had forgotten
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'create-placeholder-page'
 Title = 'Create Placeholder Page'
-Description = '''
+HTML = '''
+We will begin by creating a single language placeholder landing page. We won't
+be building this page now but we need it for the page we want to build: the 404
+page. hestiaHUGO is designed in the way to be natively compatible with Hugo.
+Since this is an English language tutorial, we can proceed to create
+<code>content/en</code> page with hugo command. Remember this important step
+because we won't repeat it again and you will be using it a lot. The command is
+as shown below:
+'''
+Plain = '''
 We will begin by creating a single language placeholder landing page. We won't
 be building this page now but we need it for the page we want to build: the 404
 page. hestiaHUGO is designed in the way to be natively compatible with Hugo.
@@ -155,14 +196,31 @@ $ hugo new --kind hestia [filesystem path]
 COMMAND
 $ hugo new --kind hestia content/en
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'understand-how-hestiaHUGO-manages-page-configurations'
 Title = 'Understand How hestiaHUGO Manages Page Configurations'
-Description = '''
+HTML = '''
+Before we continue, let's understand how hestiaHUGO manage page compilations.
+If you take a look at the <code>content/en</code> page, there are a lot of
+double underscore TOML files. Due to the complexities of web connectivities
+across the Internet, we do not have a choice but to split them into various
+pieces of config data. One constant to remember: never touch the Hugo's original
+<code>_index.html</code> file. It is now <b>ONLY USE</b> for hugo to
+discover and map the site directories. The way hestiaHUGO is designed
+will rarely have any conflict with other Hugo themes. You're still
+allowed to place any page associated files (e.g. images only this
+page uses, docs, <code>.csv</code>, etc) in the same directory. Each
+known files' roles and responsibilities are listed below:
+'''
+Plain = '''
 Before we continue, let's understand how hestiaHUGO manage page compilations.
 If you take a look at the `content/en` page, there are a lot of double
 underscore TOML files. Due to the complexities of web connectivities across the
@@ -193,16 +251,23 @@ __thumbnails.toml        ➤ the page's thumbnails used in social media sharing
 __twitter.toml           ➤ the page's Twitter configuration for sharing
 __wasm.toml              ➤ the page's WASM configurations
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
 
 
-[[i18n.Steps]]
+[[i18n.H2]]
 ID = 'update-page-toml'
 Title = 'Update the __page.toml'
-Description = '''
+HTML = '''
+Don't worry, for placeholding page, you only need to deal
+<code>__page.toml</code> file. This is to setup the page's critical metadata.
+A few critical fields you have to update are shown below:
+'''
+Plain = '''
 Don't worry, for placeholding page, you only need to deal __page.toml file.
 This is to setup the page's critical metadata. A few critical fields you have
 to update are shown below:
@@ -234,17 +299,27 @@ Will be back later.
 
 ...
 """
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'git-commit-placeholder-page'
 Title = 'Git Commit Placeholder Page'
-Description = '''
+HTML = '''
 Now that everything is in place, you can proceed to git commit the page and we
-will proceed to deal with the real basic one: /en/404 page. If you need
-assistance with Git, you can check out their offical book in the followin URL.
+will proceed to deal with the real basic one: <code>/en/404</code> page. If you
+need assistance with Git, you can check out their offical book in the following
+URL. Basically, the command is as follows:
+'''
+Plain = '''
+Now that everything is in place, you can proceed to git commit the page and we
+will proceed to deal with the real basic one: '/en/404 page'. If you need
+assistance with Git, you can check out their offical book in the following URL.
 Basically, the command is as follows:
 '''
 Code = '''
@@ -265,14 +340,24 @@ Signed-off-by: Name <EMAIL>
 
 $ git push
 '''
-URL = 'https://git-scm.com/book/en/v2'
+
+[[i18n.H2.URL]]
 Label = 'Git Manual'
+Value = 'https://git-scm.com/book/en/v2'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'repeat-for-404-page'
 Title = 'Repeat Page Creation for 404 Page'
-Description = '''
+HTML = '''
+Now that you get the hang of how to create a hestiaHUGO page and updating the
+critical file, as a re-cap, please create <code>/en/404 page</code> (hint:
+<code>content/en/404</code> path). For this page, please <b>DO NOT commit</b>
+as we will begin this page creation in the next step.
+'''
+Plain = '''
 Now that you get the hang of how to create a hestiaHUGO page and updating the
 critical file, as a re-cap, please create /en/404 page (hint: 'content/en/404'
 path). For this page, please DO NOT commit as we will begin this page creation
@@ -284,14 +369,24 @@ HINT
 (2) $ update __page.toml with the appropriate values for 404 page
 (3) $ git add .
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'update-page-level-twitter-settings'
 Title = 'Update Page-level Twitter Settings'
-Description = '''
+HTML = '''
+Unlike placeholder page, this time, if you have Twitter account, you can update
+the <code>content/en/404/__twitter.toml</code> config file. Since 404 page is
+just a system notice page (and no one insane enough to visit it on purpose),
+you only need to update the following:
+'''
+Plain = '''
 Unlike placeholder page, this time, if you have Twitter account, you can update
 the 'content/en/404/__twitter.toml' config file. Since 404 page is just a system
 notice page (and no one insane enough to visit it on purpose), you only need to
@@ -305,14 +400,24 @@ Handle = 'yourTwitterHandle'    # with or without @ is ok
 
 ...
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'update-page-level-robots-settings'
 Title = 'Update Page-level Robots Settings'
-Description = '''
+HTML = '''
+Due to this page being a 404 page, we do not want any search engine robots to
+index it. Hence, let's update the <code>content/en/404/__robots.toml</code>
+config file. These robot values will be compiled as the page's HTML output's
+meta tags. An example would be as follows:
+'''
+Plain = '''
 Due to this page being a 404 page, we do not want any search engine robots to
 index it. Hence, let's update the 'content/en/404/__robots.toml' config file.
 These robot values will be compiled as the page's HTML output's meta tags. An
@@ -329,14 +434,25 @@ Content = 'noindex, nofollow'
 Name = 'robots'
 Content = 'noindex, nofollow'
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'update-page-level-language-settings'
 Title = 'Update Page-level Languages Settings'
-Description = '''
+HTML = '''
+As a good practice and to prevent massive copy-paste error in the future, it is
+better we update the page-specific language settings in the
+<code>content/en/404/__languages.toml</code> config file. You're strongly
+advised to use <code>RFC3986</code> compliant relative URL. We will explain
+further in the next step. Here's the data to be updated:
+'''
+Plain = '''
 As a good practice and to prevent massive copy-paste error in the future, it is
 better we update the page-specific language settings in the
 'content/en/404/__languages.toml' config file. You're strongly advised to use
@@ -351,14 +467,27 @@ URL = '/en/404'
 
 ...
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'understand-how-hestiahugo-process-url'
 Title = 'Understand How hestiaHUGO Process URL'
-Description = '''
+HTML = '''
+hestiaHUGO deploys its own URL data processor (called
+<code>hestiaURL/Sanitize</code> partial function). We strongly encourage using
+relative URL for pre-compilations (e.g. your page templates and etc) while
+letting hestiaHUGO to compile it to absolute URL as output. Visitor should
+always get the absolute URL in no matter what condition. The function is
+<code>RFC3986</code> compliant so be careful with your relative URL
+construction. Here are the explanation examples:
+'''
+Plain = '''
 hestiaHUGO deploys its own URL data processor (called 'hestiaURL/Sanitize'
 partial function). We strongly encourage using relative URL for pre-compilations
 (e.g. your page templates and etc) while letting hestiaHUGO to compile it to
@@ -387,14 +516,34 @@ IN PAGE  : https://hestia.zoralab.com/default-path/this-page/
 INPUT    : my-page
 OUTPUT   : https://hestia.zoralab.com/default-path/this-page/my-page
 '''
-URL = 'https://www.rfc-editor.org/rfc/rfc3986'
+
+[[i18n.H2.URL]]
 Label = 'RFC3986 URL Specification'
+Value = 'https://www.rfc-editor.org/rfc/rfc3986'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'create-page-html-content'
 Title = 'Create Page HTML Content'
-Description = '''
+HTML = '''
+For hestiaHUGO, the corresponding file is specified in the
+<code>__page.toml</code> control file's <code>Sources.HTML</code> field. The
+default is the relative file <code>__content.hestiaHTML</code> in the same
+directory. Since we're beginner, we should use the default
+<code>__content.hestiaHTML</code> file. Let's open it and take a look. If
+you're a seasoned Hugo developer, you will immediately notice that the Go
+template (and Hugo's partial) functions are used instead of Hugo specific
+Markdown and shortcodes. When using any ZORALab's Hestia product, we strive to
+be as portable and nimble as possible across them with minimal learning cost. If
+you're already familiar with Go template from Go Programming Language, then
+every piece of your rendering knowledge is automatically and fully transferred
+here. For this tutorial, let's update it with the following contents. Once done,
+try visit the URL + /en/404/ web page presented by the Hugo server. You can
+verify the HTML-only rendering of the page.
+'''
+Plain = '''
 For hestiaHUGO, the corresponding file is specified in the __page.toml control
 file's 'Sources.HTML' field. The default is the relative file
 '__content.hestiaHTML' in the same directory. Since we're beginner, we should
@@ -413,26 +562,40 @@ Code = '''
 ...
 
 {{- /* render outputs */ -}}
-&lt;main&gt;
-	&lt;section id='introduction' class='banner'&gt;
-		&lt;h1&gt;&#123;&#123;- .Titles.Page -&#125;&#125;&lt;/h1&gt;
-		&lt;p&gt;&#123;&#123;- .Descriptions.Page.Pitch &#125;&#125; &#123;&#123; .Descriptions.Page.Summary -&#125;&#125;&lt;/p&gt;
+<main>
+	<section id='introduction' class='banner'>
+		<h1>{{- .Titles.Page -}}</h1>
+		<p>{{- .Descriptions.Page.Pitch }} {{ .Descriptions.Page.Summary -}}</p>
 
 
-		&#123;&#123;- $ret := merge . (dict "Input" (dict "Data" "/en/")) -&#125;&#125;
-		&#123;&#123;- $ret = partial "hestiaURL/Sanitize" $ret -&#125;&#125;
-		&lt;a class='button' href='&#123;&#123;- $ret -&#125;&#125;'&gt;Back HOME&lt;/a&gt;
-	&lt;/section&gt;
-&lt;/main&gt;
+		{{- $ret := merge . (dict "Input" (dict "Data" "/en/")) -}}
+		{{- $ret = partial "hestiaURL/Sanitize" $ret -}}
+		<a class='button' href='{{- $ret -}}'>Back HOME</a>
+	</section>
+</main>
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'understand-how-hestiahugo-renders-page-data'
 Title = 'Understand How hestiaHUGO Renders Page Data'
-Description = '''
+HTML = '''
+Unlike Hugo requiring designer to guess a data field, hestiaHUGO employs its own
+page data structure for designers to utilize. In fact, we have our some
+design-adaptive debugger that shows the entire page data structure for debugging
+or rendering purposes when Hugo is operating in server mode. Have you notice a
+color button at the bottom right of the page? Try click on it and you can browse
+your current page's entire usable datasets. Example, the rendering part of
+<code>{{- .Titles.Page -}}</code> was rendered as the value of
+<code>.Titles.Page</code> when viewed in the debugger console.
+'''
+Pitch = '''
 Unlike Hugo requiring designer to guess a data field, hestiaHUGO employs its own
 page data structure for designers to utilize. In fact, we have our some
 design-adaptive debugger that shows the entire page data structure for debugging
@@ -444,10 +607,12 @@ in the debugger console.
 '''
 Code = '''
 '''
-URL = ''
-Label = ''
 
-[i18n.Steps.Image]
+[[i18n.H2.URL]]
+Label = ''
+Value = ''
+
+[i18n.H2.Media]
 Name = "The Screenshot of the Debugger Console"
 Decorative = false
 Loading = 'lazy'
@@ -463,65 +628,83 @@ Loop = false
 Mute = false
 Inline = false
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-600x600.avif"
 Type = "image/avif"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-600x600.webp"
 Type = "image/webp"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-600x600.jpg"
 Type = "image/jpeg"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-400x400.avif"
 Type = "image/avif"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-400x400.webp"
 Type = "image/webp"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-400x400.jpg"
 Type = "image/jpeg"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-220x220.avif"
 Type = "image/avif"
 Media = "all"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-220x220.webp"
 Type = "image/webp"
 Media = "all"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-220x220.jpg"
 Type = "image/jpeg"
 Media = "all"
 Descriptor = '1x'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'understand-hestiahugo-data-path'
 Title = 'Understand hestiaHUGO Data Path'
-Description = '''
+HTML = '''
+hestiaHUGO finalized its design by having <code>content</code> directory
+supplying the site URL and having each of its directory delivers the page data.
+Remember the <code>__i18n.toml</code> and <code>__data.toml</code> in the page
+directories? Those data files are listed in <code>__page.toml</code>'s
+<code>[[Data]]</code> array list. hestiaHUGO maintains absolute freedom for
+page designer to construct the Page level data structure. After parsing and
+merging all the data files, all the data can be accessed via
+<code>hestiaHUGO.Page</code> data field. Other config files are obviously
+provide various different values for different data fields. Feel free to
+explore around and check them via the on-screen debugger console. This is
+how you source your data <code>key:value</code> when designing your page.
+The link below is the technical specification of the
+<code>hestiaHUGO.Page</code> data structure (browse when you're free, we
+will move forward for now).
+'''
+Plain = '''
 hestiaHUGO finalized its design by having 'content' directory supplying the
 site URL and having each of its directory delivers the page data. Remember the
 '__i18n.toml' and '__data.toml' in the page directories? Those data files are
@@ -542,14 +725,31 @@ __data.toml + __i18n.toml + ...   (NOTE: follows __page.toml data files list)
              ⤋
      {{- .Field.[...] -}}
 '''
-URL = '/en/specs/hestiaCOMPILERS/hestiaHUGO/'
+
+[[i18n.H2.URL]]
 Label = 'Data Structure & Specs'
+Value = '/en/specs/hestiacompilers/hestiahugo/'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'understand-how-hestiahugo-empowers-hugo'
 Title = 'Understand How hestiaHUGO Empowers Hugo'
-Description = '''
+HTML = '''
+hestiaHUGO supplies its own standard libraries just like other ZORALab's Hestia
+components. Notice the use of <code>hestiaURL.Sanitize</code> partial function
+above? It converts a given ambigious URL into a proper full absolute URL
+consistently in accoradance to hestiaHUGO URL management explained in
+the 1st step. The sole purpose of preparing our own standard libraries
+is to make sure we have absolute consistency as we grow ZORALab's Hestia
+and not Hugo's output inconsitencies AND maintaining inter-operability
+with other components. All ZORALab's Hestia libraries are documented in
+the same context across all components in our specifications section.
+You should explore all available hestiaHUGO API to advance your
+development at your own time. For this tutorial, we will proceed further.
+'''
+Plain = '''
 hestiaHUGO supplies its own standard libraries just like other ZORALab's Hestia
 components. Notice the use of 'hestiaURL.Sanitize' partial function above? It
 converts a given ambigious URL into a proper full absolute URL consistently in
@@ -564,14 +764,27 @@ we will proceed further.
 '''
 Code = '''
 '''
-URL = '/en/spec'
+
+[[i18n.H2.URL]]
 Label = 'Specification'
+Value = '/en/specs'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'create-page-ui-components-styling-list'
 Title = 'Create Page UI Components Styling List'
-Description = '''
+HTML = '''
+Now that we verified the data shown in HTML-only page is correct, we can now
+style it. hestiaHUGO uses the UI components approach to compile all necessary
+proceed to edit <code>/en/404/__components.toml</code> and add the following
+components after the commented guide. Give the server a few moment and refresh
+the web page. You can see it's being compiled with styling (especially the
+call-to-action anchor link). Check out the CSS codes in the CSS.Inline section
+of the debugger console. It's filled with the compiled CSS codes.
+'''
+Plain = '''
 Now that we verified the data shown in HTML-only page is correct, we can now
 style it. hestiaHUGO uses the UI components approach to compile all necessary
 proceed to edit '/en/404/__components.toml' and add the following components
@@ -604,14 +817,31 @@ Name = "zoralabBUTTON"
 Include = true
 Variables = []
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'understand-how-hestiaHUGO-manage-page-styling'
 Title = 'Understand How hestiaHUGO Manage Page Styling'
-Description = '''
+HTML = '''
+Like Backbone, Angular, and React frameworks, hestiaHUGO componentized each UI
+but unlike them, hestiaHUGO only integrate each component's HTML, CSS, and JS
+codes as 1 set rather than split them and overloadingly manage everything via
+JavaScript. That way, via Hugo, hestiaHUGO can compile only the required CSS,
+CSS variables, and JavaScript codes into the assets and then embedded them into
+the HTML output file. This output HTML file is self-contained and not requiring
+external remote framework, fulfilling the vision where AMP project originally
+wants. It also seamlessly support PWA's offline feature as well and simplify the
+UI component designer maintenance workflow by only focusing on applying
+non-backward compatible updates introduced by W3C. 3 birds, 1 stone ⥤ definitely
+worth the effort.
+'''
+Pitch = '''
 Like Backbone, Angular, and React frameworks, hestiaHUGO componentized each UI
 but unlike them, hestiaHUGO only integrate each component's HTML, CSS, and JS
 codes as 1 set rather than split them and overloadingly manage everything via
@@ -626,14 +856,27 @@ worth the effort.
 '''
 Code = '''
 '''
-URL = '/en/specs/hestiaGUI'
+
+[[i18n.H2.URL]]
 Label = 'UI Components Catalog'
+Value = '/en/specs/hestiagui'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'understand-why-hestiaHUGO-containerized-page-styling'
 Title = 'Understand Why hestiaHUGO Containerized Page Styling'
-Description = '''
+HTML = '''
+This is mainly for preventing a site-wide UI update from breaking pages like
+a whack-a-mole nightmare from happening again especially large content website.
+We tested it and find this compilation approach is the most optimized way. So,
+to scale the same UI across other pages, you just have to copy-paste the
+<code>__components.toml</code> config file. For page designer regardless of
+experiences, please feel safe and free to express your creativities and make
+a safer mistake to gain experience with a site development.
+'''
+Pitch = '''
 This is mainly for preventing a site-wide UI update from breaking pages like
 a whack-a-mole nightmare from happening again especially large content website.
 We tested it and find this compilation approach is the most optimized way. So,
@@ -644,14 +887,27 @@ to gain experience with a site development.
 '''
 Code = '''
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'understand-how-hestiaHUGO-ui-component-works'
 Title = 'Understand How hestiaHUGO UI Component Works'
-Description = '''
+HTML = '''
+As stated earlier, the CSS codes are for defining the styling, the CSS variables
+are for UI customziation, and the JS codes are for behavior control. When you
+add an UI component, you are provided with an <code>Include</code> switch for
+design debugging purpose (better then delete large chunk of codes). At the
+same time, you're allowed to overwrite existing CSS variables, making
+hestiaHUGO to only generate 1 list of CSS variables for your HTML output
+will do.
+'''
+Pitch = '''
 As stated earlier, the CSS codes are for defining the styling, the CSS variables
 are for UI customziation, and the JS codes are for behavior control. When you
 add an UI component, you are provided with an 'Include' switch for design
@@ -671,19 +927,51 @@ Variables = [
 
 ...
 '''
-URL = ''
+
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'understand-why-zoralab-hestia-only-prioritize-html-and-css'
 Title = "Understand Why ZORALab's Hestia Only Prioritize HTML & CSS"
-Description = '''
+HTML = '''
+<p>For 2 primary reasons:</p>
+<ol>
+	<li><p>
+		Supporting privacy-first content rendering (JS disabled).
+		In year 2022 during the Covid19 pandemic, everyone was
+		concerned about privacy and data leak so having a complete
+		JavaScript disabled use case is totally unsurprising.
+		In that situation, your famous JS Frameworks and our WASM
+		are completely unsable but the site is still expected
+		present correctly; AND
+	</p></li>
+	<li><p>
+		ZORALab's Hestia intend to replace JavaScript entirely
+		with WASM compiled using proper programming languages
+		like Go or Nim in the future. It is a lot easier and
+		seamless to port the HTML+CSS only UI component into
+		the WASM counterpart (as in no JavaScript interference).
+	</p></li>
+</ol>
+<p>
+	That being said, you can still use JavaScript (as shown in later
+	steps). In ZORALab's Hestia, we don't do idiotic and autocratic
+	goverance like some technology's governors did that restrict
+	anyone freedom of use and artistic expression.
+</p>
+'''
+Plain = '''
 For 2 primary reasons: (1) supporting privacy-first content rendering
 (JS disabled). In year 2022 during the Covid19 pandemic, everyone was concerned
 about privacy and data leak so having a complete JavaScript disabled use case is
 totally unsurprising. In that situation, your famous JS Frameworks and our WASM
-are completely unsable but the site is still expected present correctly. (2)
+are completely unsable but the site is still expected present correctly; AND (2)
 ZORALab's Hestia intend to replace JavaScript entirely with WASM compiled
 using proper programming languages like Go or Nim in the future. It is a lot
 easier and seamless to port the HTML+CSS only UI component into the WASM
@@ -694,14 +982,28 @@ restrict anyone freedom of use and artistic expression.
 '''
 Code = '''
 '''
-URL = ''
+
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'understand-zoralab-and-javascript-relationship'
 Title = 'Understand ZORALab and JavaScript Relationship'
-Description = '''
+HTML = '''
+Let's face it: JavaScript is the only programming language for web UI behavior
+packed with weird and inconsistencies. It's problematic weaknesses gave birth to
+various frameworks like Angular and Typescript of itself trying to workaround
+them but introduced their own. With the birth of WASM, ZORALab wants to solve
+the problem heads-on. We do not hate the language but finding development with
+it comes is very risky. A lot of outdated JS frameworks in the past trying to
+replace one another had already proven the point.
+'''
+Plain = '''
 Let's face it: JavaScript is the only programming language for web UI behavior
 packed with weird and inconsistencies. It's problematic weaknesses gave birth to
 various frameworks like Angular and Typescript of itself trying to workaround
@@ -712,14 +1014,36 @@ replace one another had already proven the point.
 '''
 Code = '''
 '''
-URL = ''
+
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'understand-hestiahugo-future'
 Title = 'Understand hestiaHUGO Future'
-Description = '''
+HTML = '''
+<p>
+	In order to realize our ultimate goal for web technologies, there are 3
+	specific use cases:
+</p>
+<ol>
+	<li><p>Discovery page like SEO & SMO</p></li>
+	<li><p>Single App - 1 WASM implements the entire site</p></li>
+	<li><p>Reactive Rendering (each page has its own WASM renderer)</p></li>
+</ol>
+<p>
+	hestiaHUGO fulfills primarily on use case: while facilitating WASM
+	hosting for use cases (2) and (3). That's why we are still facilitating
+	Hugo and so far it is still the best frontend static site generator
+	(and now, a compiler).
+</p>
+'''
+Plain = '''
 In order to realize our ultimate goal for web technologies, there are 3 specific
 use cases: (1) Discovery page like SEO & SMO; (2) Single App - 1 WASM implements
 the entire site; and (3) Reactive Rendering (each page has its own WASM
@@ -730,14 +1054,28 @@ compiler).
 '''
 Code = '''
 '''
-URL = ''
+
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'customizing-page-styling-with-css'
 Title = 'Customize Page Styling with CSS'
-Description = '''
+HTML = '''
+Now that the page is styled (that looks common across all users), you can
+customize on top the currently compiled CSS codes. Simply edit the file
+<code>__content.hestiaCSS</code> and place your page-level CSS codes in it.
+For this tutorial, we will be using the following CSS customization codes.
+hestiaHUGO will recompile your CSS file as the last inline-type asset.
+Once done, refresh the page and you'll observe your 404 page is
+disco-ing with colors.
+'''
+Plain = '''
 Now that the page is styled (that looks common across all users), you can
 customize on top the currently compiled CSS codes. Simply edit the file
 '__content.hestiaCSS' and place your page-level CSS codes in it. For this
@@ -787,14 +1125,26 @@ main {
 	background: rgba(255, 255, 255, .75);
 }
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'customizing-page-with-javascript'
 Title = 'Customize Page with JavaScript'
-Description = '''
+HTML = '''
+Likewise, you can also customize the page with JavaScript. The responsible file
+is <code>__content.hestiaJS</code>. While the page is no longer needing further
+styling, for this education purpose, let's temporarily add the following code
+block in and check out the browser' inspect console (F12 button). You should
+observe a cat meowing. Same case: this JavaScript is the last inline JavaScript
+to be included in the page.
+'''
+Plain = '''
 Likewise, you can also customize the page with JavaScript. The responsible file
 is '__content.hestiaJS'. While the page is no longer needing further styling,
 for this education purpose, let's temporarily add the following code block in
@@ -807,10 +1157,12 @@ window.onload = function() {
 	console.log("\nMeow~~~~ ₍⌯ᴖⱅᴖ⌯ ^₎◞ ̑̑ෆ⃛ \n\n");
 };
 '''
-URL = ''
-Label = ''
 
-[i18n.Steps.Image]
+[[i18n.H2.URL]]
+Label = ''
+Value = ''
+
+[i18n.H2.Image]
 Name = "The Screenshot of a Cat Meowing at the Browser Console"
 Decorative = false
 Loading = 'lazy'
@@ -826,65 +1178,74 @@ Loop = false
 Mute = false
 Inline = false
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-600x600.avif"
 Type = "image/avif"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-600x600.webp"
 Type = "image/webp"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-600x600.jpg"
 Type = "image/jpeg"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-400x400.avif"
 Type = "image/avif"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-400x400.webp"
 Type = "image/webp"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-400x400.jpg"
 Type = "image/jpeg"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-220x220.avif"
 Type = "image/avif"
 Media = "all"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-220x220.webp"
 Type = "image/webp"
 Media = "all"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-220x220.jpg"
 Type = "image/jpeg"
 Media = "all"
 Descriptor = '1x'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'update-ldjson-data-for-seo'
 Title = 'Update LD+JSON Data for SEO'
-Description = '''
+HTML = '''
+hestiaHUGO has a built-in support for Schema.org complex data structuring of
+your page. The responsible file is <code>__content.hestiaLDJSON</code>. Since
+this is a 404 page, we will add the following code block will do. Once the
+Hugo server is fully updated, you can proceed to obtain the output from our
+on-screen debugger console and validate at Schema.org validator site.
+'''
+Plain = '''
 hestiaHUGO has a built-in support for Schema.org complex data structuring of
 your page. The responsible file is '__content.hestiaLDJSON'. Since this is a 404
 page, we will add the following code block will do. Once the Hugo server is fully
@@ -907,14 +1268,33 @@ Code = '''
 {{- /* render output */ -}}
 ...
 '''
-URL = 'https://validator.schema.org/'
+
+[[i18n.H2.URL]]
 Label = 'LD+JSON Validator'
+Value = 'https://validator.schema.org/'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'understand-how-hestiahugo-handles-ldjson'
 Title = 'Understand How hestiaHUGO Handles LD+JSON'
-Description = '''
+HTML = '''
+To maintain balance between freedom of expression and rigidity for consistent
+output, there are 2 things to remember:
+<ol>
+	<li><p>
+		hestiaHUGO can only quickly help you process the base
+		level dataset of known common data types (e.g. authors,
+		page type, etc); and
+	</p></li>
+	<li><p>
+		you need to add in the page context-specific dataset
+		(e.g. recipe steps, etc).
+	</p></li>
+</ol>
+'''
+Plain = '''
 To maintain balance between freedom of expression and rigidity for consistent
 output, there are 2 things to remember: (1) hestiaHUGO can only quickly help you
 process the base level dataset of known common data types (e.g. authors,
@@ -923,14 +1303,22 @@ page type, etc); and (2) you need to add in the page context-specific dataset
 '''
 Code = '''
 '''
-URL = 'https://schema.org/docs/full.html'
+
+[[i18n.H2.URL]]
 Label = 'Schema.org Data Structures'
+Value = 'https://schema.org/docs/full.html'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'stage-the-current-state'
 Title = 'Stage the Current State'
-Description = '''
+HTML = '''
+Now the HTML output is done deal, we should git stage it. However, we are not
+quite done yet. Proceed to next step:
+'''
+Plain = '''
 Now the HTML output is done deal, we should git stage it. However, we are not
 quite done yet. Proceed to next step:
 '''
@@ -938,14 +1326,29 @@ Code = '''
 HINT
 $ git add .
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'create-json-output'
 Title = 'Create JSON Output'
-Description = '''
+HTML = '''
+By default, hestiaHUGO supports JSON output type as secondary output format.
+This is using the hestiaHUGO internal feature; not the Hugo one. Like LD+JSON,
+you can construct a customer usable dataset using the Go template function.
+Unlike LD+JSON, this is a pure JSON output (viewable by appending
+<code>index.json</code> at the end of the page URL) unrestricted by Schema.org
+schematic. The responsible file defined by <code>__page.toml</code>'s
+<code>.Source.JSON</code> value (default is the relative
+<code>__content.hestiaJSON</code>). Since this is 404 page, we can leave
+it as it is. You can study the default codes for educational purposes.
+'''
+Plain = '''
 By default, hestiaHUGO supports JSON output type as secondary output format.
 This is using the hestiaHUGO internal feature; not the Hugo one. Like LD+JSON,
 you can construct a customer usable dataset using the Go template function.
@@ -957,34 +1360,76 @@ is. You can study the default codes for educational purposes.
 '''
 Code = '''
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'understand-why-hestiahugo-natively-supports-json-output'
 Title = 'Understand Why hestiaHUGO Natively Supports JSON Output'
-Description = '''
+HTML = '''
+<p>5 main reasons:</p>
+<ol>
+	<li><p>
+		Allows one to use hestiaHUGO as a CDN-driven open data API
+		server; AND
+	</p></li>
+	<li><p>
+		A backup reason for using Hugo after search engine giants
+		nearly destroyed SEO in the past solely for SMO ad
+		revenues; AND
+	</p></li>
+	<li><p>
+		Provides alternatives and freedom compared to LD+JSON
+		implementations; AND
+	</p></li>
+	<li><p>
+		making sure hestiaHUGO can support multiple output
+		feature natively in a very consistent manner; AND
+	</p></li>
+	<li><p>
+		Facilitate a way to feed AI training data.
+	</p></li>
+<p>
+	The default processor is configured in a way as an option for
+	those who do not want to use it so if you're not using it,
+	don't bother touching <code>__content.hestiaJSON</code> file at all.
+</p>
+'''
+Plain = '''
 5 main reasons: (1) Allows one to use hestiaHUGO as a CDN-driven open data API
-server; (2) A backup reason for using Hugo after search engine giants nearly
-destroyed SEO in the past solely for SMO ad revenues; (3) Provides
-alternatives and freedom compared to LD+JSON implementations; (4) making
-sure hestiaHUGO can support multiple output feature natively in a very
-consistent manner; (5) Facilitate a way to feed AI training data. The default
-processor is configured in a way as an option for those who do not want to use
-it so if you're not using it, don't bother touching '__content.hestiaJSON' file
-at all.
+server; AND (2) A backup reason for using Hugo after search engine giants
+nearly destroyed SEO in the past solely for SMO ad revenues; AND
+(3) Provides alternatives and freedom compared to LD+JSON implementations; AND
+(4) making sure hestiaHUGO can support multiple output feature natively
+in a very consistent manner; AND (5) Facilitate a way to feed AI
+training data. The default processor is configured in a way as an option
+for those who do not want to use it so if you're not using it, don't
+bother touching <code>__content.hestiaJSON</code> file at all.
 '''
 Code = '''
 '''
-URL = ''
+
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'commit-and-push'
 Title = 'Commit and Push'
-Description = '''
+HTML = '''
+At this point, we had completed designing a basic and simple 404 page. You can
+proceed to Git commit and push out.
+'''
+Plain = '''
 At this point, we had completed designing a basic and simple 404 page. You can
 proceed to Git commit and push out.
 '''
@@ -997,14 +1442,28 @@ $ git commit -s
 ----
 $ git push
 '''
-URL = ''
+
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'remember-the-strength-of-hestiaHUGO'
 Title = 'Remember the Strength of hestiaHUGO'
-Description = '''
+HTML = '''
+If you haven't realize, hestiaHUGO only takes 1 set of input dataset and
+generated to various outputs type while supporting multiple languages at the
+same time. In fact, it generates more like page-level 'sitemap.xml' and
+'sitemap-page.xml' as well. This is one of the problem we're trying to solve when
+using Hugo: 1 consistent input dataset to multiple outputs consistently. These
+are just a scratch of the surface. We will explore more as you go through the
+tutorials walkthrough.
+'''
+Plain = '''
 If you haven't realize, hestiaHUGO only takes 1 set of input dataset and
 generated to various outputs type while supporting multiple languages at the
 same time. In fact, it generates more like page-level 'sitemap.xml' and
@@ -1015,8 +1474,11 @@ tutorials walkthrough.
 '''
 Code = '''
 '''
-URL = ''
+
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
 

--- a/sites/content/en/getting-started/setup-hugo/__i18n.toml
+++ b/sites/content/en/getting-started/setup-hugo/__i18n.toml
@@ -1,15 +1,12 @@
 [i18n]
+[i18n.Labels]
 Title = 'Title'
 Description = 'Description'
-
-
-
-
-[i18n.Labels]
 Code = 'Code'
 URL = 'URL'
-Image = 'Image'
-Guides = 'Guides'
+Media = 'Media'
+Content = 'Content'
+Label = 'Label'
 
 
 
@@ -21,36 +18,49 @@ Title = 'Introduction'
 
 
 
-[i18n.Objectives]
+[[i18n.H2]]
 ID = 'learning-objectives'
 Title = 'Learning Objectives'
-Description = '''
+HTML = '''
 At the end of this tutorial, you will learn:
+<ol>
+	<li><p>How to setup Hugo compatible Git Repository</p></li>
+	<li><p>How to download and setup hestiaHUGO</p></li>
+	<li><p>How to start a hugo server for development</p></li>
+	<li><p>How to use git along the way</p></li>
+</ol>
+'''
+Plain = '''
+At the end of this tutorial, you will learn:
+(1) How to setup Hugo compatible Git Repository; AND
+(2) How to download and setup hestiaHUGO; AND
+(3) How to start a hugo server for development; AND
+(4) How to use git along the way.
+'''
+Code = '''
 '''
 
-
-[[i18n.Objectives.Outcomes]]
-Value = 'How to setup Hugo compatible Git Repository'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = 'How to download and setup hestiaHUGO'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = 'How to start a hugo server for development'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = 'How to use git along the way'
+[[i18n.H2.URL]]
+Label = ''
+Value = ''
 
 
 
 
-[[i18n.Steps]]
-ID = 'the-hestiahugo-way'
-Title = 'The hestiaHUGO Way'
-Description = '''
+[[i18n.H2]]
+ID = 'understanding-the-hestiahugo-way'
+Title = 'Understanding The hestiaHUGO Way'
+HTML = '''
+Like any Hugo theme, hestiaHUGO supplies UI in its very unique way. However,
+unlike any other themes, hestiaHUGO comes with its own data processor system and
+rarely use most of Hugo features except its partial functions and image
+processing functions. The main reason is because Hugo has a lot of output
+inconsistences throughout its history. ZORALab been there the hard way and will
+never make the same mistake twice. Along the web development journey, we picked
+a lot of different lessons and values along the way. So, before you decide to
+move forward, let's be clear about some notable non-compromising differences:
+'''
+Plain = '''
 Like any Hugo theme, hestiaHUGO supplies UI in its very unique way. However,
 unlike any other themes, hestiaHUGO comes with its own data processor system and
 rarely use most of Hugo features except its partial functions and image
@@ -67,7 +77,7 @@ Code = '''
 2. Design strongly for writing HTML and Go template functions (equipped with
    Hugo partial functions) for maximum portabilities.
 
-3. HTML, CSS, and JS are treated as 1 single format: **WEB**. we do not split
+3. HTML, CSS, and JS are treated as 1 single format: **WEB**. We do not split
    them like most CSS and JS frameworks did.
 
 4. We are still complying to the browser's end-user rendering degredation rule
@@ -85,27 +95,50 @@ Code = '''
 8. We are extremely data-driven due to multiple languages support and even
    supply our own data type+value sanitization functions.
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
-ID = 'download-latest-package'
+
+
+[[i18n.H2]]
+ID = 'download-the-latest-package'
 Title = 'Download the Latest Package'
-Description = '''
+HTML = '''
 Let's start by downloading the latest package from the ZORALab's Hestia releases
 portal in its offical website via the link below. Keep in mind that you're
-looking for:
+looking for <code>hestiaHUGO</code>.
 '''
-Code = 'hestiaHUGO'
-URL = '/en/releases'
+Plain = '''
+Let's start by downloading the latest package from the ZORALab's Hestia releases
+portal in its offical website via the link below. Keep in mind that you're
+looking for 'hestiaHUGO'.
+'''
+Code = '''
+'''
+
+[[i18n.H2.URL]]
 Label = 'Releases Portal'
+Value = '/en/releases'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'check-package-integrity'
 Title = 'Check the Package Integrity'
-Description = '''
+HTML = '''
+To make sure you had downloaded a proper and correct package, we recommend you
+to check the package integrity before use. The are 2 ways to do this:
+<code>GPG</code> or <code>SHASUM</code>. In this tutorial, we will be using
+<code>SHASUM</code> as shown in the following code snippet. This should generate
+a <b>HASHED_VALUE</b> mathematically. Your job is to make sure the
+<b>HASHED_VALUE</b> is 100% exactly the same as displayed at the releases
+portal.
+'''
+Plain = '''
 To make sure you had downloaded a proper and correct package, we recommend you
 to check the package integrity before use. The are 2 ways to do this: GPG or
 SHASUM. In this tutorial, we will be using SHASUM as shown in the following code
@@ -130,10 +163,12 @@ $ certutil -hashfile hestiaHUGO-vNNNN.zip sha512
 SHA512 hash of hestiaHUGO-vNNNN.zip:
 [HASHED_VALUE]
 '''
-URL = ''
-Label = ''
 
-[i18n.Steps.Image]
+[[i18n.H2.URL]]
+Label = ''
+Value = ''
+
+[i18n.H2.Media]
 Name = "Screenshot of Comparing SHASUM Values"
 Decorative = false
 Loading = 'lazy'
@@ -149,68 +184,78 @@ Loop = false
 Mute = false
 Inline = false
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-600x600.avif"
 Type = "image/avif"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-600x600.webp"
 Type = "image/webp"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-600x600.jpg"
 Type = "image/jpeg"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-400x400.avif"
 Type = "image/avif"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-400x400.webp"
 Type = "image/webp"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-400x400.jpg"
 Type = "image/jpeg"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-220x220.avif"
 Type = "image/avif"
 Media = "(max-width: 299px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-220x220.webp"
 Type = "image/webp"
 Media = "(max-width: 299px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Media.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-220x220.jpg"
 Type = "image/jpeg"
 Media = "(max-width: 299px)"
 Descriptor = '1x'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'setup-git-repository'
 Title = 'Setup Git Repository'
-Description = '''
+HTML = '''
 Now that you the package ready, it's time to setup your git repository. Firstly,
 create and initialize your Git repo directory (for this entire tutorial, we're
-going to call it 'DemoHestia'). In it, you can create your hugo directory (by
+calling it <code>DemoHestia</code>). In it, you can create your hugo directory
+(by default, we recommend <code>sites</code>). Then, proceed to create a
+<code>themes</code> directory inside it. Once done, unzip the hestiaHUGO package
+into the <code>themes</code> directory. The results should be something as such:
+'''
+Plain = '''
+Now that you the package ready, it's time to setup your git repository. Firstly,
+create and initialize your Git repo directory (for this entire tutorial, we're
+calling it 'DemoHestia'). In it, you can create your hugo directory (by
 default, we recommend 'sites'). Then, proceed to create a 'themes' directory
 inside it. Once done, unzip the hestiaHUGO package into the 'themes' directory.
 The results should be something as such:
@@ -225,24 +270,35 @@ DemoHestia/
             ├── ...
             └── ... all other content ...
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'setup-hugo-config-directory'
 Title = 'Setup Hugo Config Directory'
-Description = '''
-Due to the engine design complexities, hestiaHUGO ships its config/ directory by
-default inside the 'hestiaHUGO' directory as part of the package. You will have
-to move it out to hugo directory (sites/) in order to use it. Depending on
-package version, if the 'server.cmd' is shipped together, you have move it out
-to the Hugo directory. The result should be something as such:
+HTML = '''
+Due to the engine design complexities, hestiaHUGO ships its <code>config/</code>
+directory and a Hugo server <code>server.cmd</code> starter script by default
+inside the <code>hestiaHUGO</code> theme directory as part of the package.
+You will have to move it out to the hugo directory (<code>sites/</code>) in
+order to properly use it. The result should be something as such:
+'''
+Plain = '''
+Due to the engine design complexities, hestiaHUGO ships its 'config/'
+directory and a Hugo server 'server.cmd' starter script by default inside the
+'hestiaHUGO' theme directory as part of the package.
+You will have to move it out to the hugo directory ('sites/') in order to
+properly use it. The result should be something as such:
 '''
 Code = '''
 DemoHestia/
 └── sites/
-    ├── server.cmd  (NOTE: if shipped together)
+    ├── server.cmd
     │
     ├── config/
     │   ├── _default/
@@ -257,20 +313,32 @@ DemoHestia/
         └── hestiaHUGO/
             └── ... all theme content ...
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'configure-hugo'
 Title = 'Configure Hugo'
-Description = '''
+HTML = '''
 With Hugo's critical files in-place, it's time to configure Hugo. Generally
 speaking, you only need to edit the 1st section of the
-'__sites/config/_default/config.toml' file. The rest are as it is as noted by
-the comments. You would want to setup 'baseURL' to the output base URL you're
-planning to publish and that's it. You may refer to Hugo's config manual in the
-link below to learn more about each fields.
+<code>__sites/config/_default/config.toml</code> file. The rest are as it is as
+noted by the comments. You would want to setup <code>baseURL</code> to the
+output base URL you're planning to publish and that's it. You may refer to
+Hugo's config manual in the link below to learn more about each fields.
+'''
+Plain = '''
+With Hugo's critical files in-place, it's time to configure Hugo. Generally
+speaking, you only need to edit the 1st section of the
+'__sites/config/_default/config.toml' file. The rest are as it is as
+noted by the comments. You would want to setup **baseURL** to the
+output base URL you're planning to publish and that's it. You may refer to
+Hugo's config manual in the link below to learn more about each fields.
 '''
 Code = '''
 DemoHestia/
@@ -309,68 +377,84 @@ publishDir = "public"
 i18nDir = "i18n"
 
 
-# ╔══════════╗
+# ╔════════════╗
 # ║!!  STOP  !!║
-# ╚══════════╝
+# ╚════════════╝
 !!! That's it. Don't go beyond here. You might break hestiaHUGO. !!!
 ...
 '''
-URL = 'https://gohugo.io/getting-started/configuration/'
+
+[[i18n.H2.URL]]
 Label = 'Hugo Config Manual'
+Value = 'https://gohugo.io/getting-started/configuration/'
 
 
 
 
-[[i18n.Steps]]
+[[i18n.H2]]
 ID = 'start-hugo-server'
 Title = 'Start Hugo Server'
-Description = '''
-Now that everything is configured and ready, we can now try to bring up the
-server. We recommend start the server with the following command. Note that if
-you haven't install hugo yet, you can refer the the URL for its installation
-instruction. You want to observe the URL address for previewing your site.
-If the 'server.cmd' is available, you can run it instead as it wraps the
-commands for ease of use.
+HTML = '''
+With everything setup ready, it's time to start a server. Due to Hugo's
+inconsistency, hestiaHUGO does its optimizations and workaround wrapped under
+a single <code>server.cmd</code> script. While you can start the server as
+guided by Hugo, we <b>strongly discourage you to do so</b>. You can explore and
+read the script we did to learn more.
+'''
+Plain = '''
+With everything setup ready, it's time to start a server. Due to Hugo's
+inconsistency, hestiaHUGO does its optimizations and workaround wrapped under
+a single 'server.cmd' script. While you can start the server as
+guided by Hugo, we **strongly discourage you to do so**. You can explore and
+read the script we did to learn more.
 '''
 Code = '''
-$ hugo server \
-	--buildDrafts \
-	--noBuildLock \
-	--disableFastRender \
-	--bind "localhost" \
-	--baseURL "http://localhost" \
-	--port 8080 \
-	--cleanDestinationDir \
-	--gc
-
-
-Start building sites …
-...
-Web Server is available at http://localhost:8080/ (bind address 127.0.0.1)
-...
+$ cd sites/         # if you haven't do so
+$ ./server.cmd
 '''
-URL = 'https://gohugo.io/installation/'
-Label = 'Hugo Installation Guide'
+
+[[i18n.H2.URL]]
+Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'visit-preview-url'
 Title = 'Visit the Preview URL Site'
-Description = '''
+HTML = '''
 With the server running properly, you can visit the website using your browser
 in the computer. Since we have not build anything, you should expect a blank
 page or a page that keeps on redirecting to the language-specific 404 pages.
 At this stage, you got a working Hugo repo with hestiaHUGO set nicely.
 '''
-Code = ''
-URL = ''
+Plain = '''
+With the server running properly, you can visit the website using your browser
+in the computer. Since we have not build anything, you should expect a blank
+page or a page that keeps on redirecting to the language-specific 404 pages.
+At this stage, you got a working Hugo repo with hestiaHUGO set nicely.
+'''
+Code = '''
+'''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'git-commit'
 Title = 'Git Commit'
-Description = '''
+HTML = '''
+Before starting to create any content, we advise you to git commit at this point
+in case of future revert needs. Now let's be clear: commit the hestiaHUGO theme
+together as opposed to many folks said. This is a rendering UI engine which is
+more than just supplying UI codes. It's not safe to detach it from your Hugo.
+'''
+Plain = '''
 Before starting to create any content, we advise you to git commit at this point
 in case of future revert needs. Now let's be clear: commit the hestiaHUGO theme
 together as opposed to many folks said. This is a rendering UI engine which is
@@ -395,14 +479,26 @@ Signed-off-by: Smith, John ❬john.smith@email.com❭
 
 $ git push
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'about-updating-hestiaHUGO'
 Title = 'About Updating hestiaHUGO'
-Description = '''
+HTML = '''
+In the future, in case you need to update the hestiaHUGO, you just need to
+replace your <code>themes/hestiaHUGO</code> directory with the updated package.
+Hugo reconfiguration is not required unless the release note specify it.
+Remember that updating the engine may break your edge-cases inline customization
+so while we try not to break backward compatibilty, you should allocate some
+times to audit all your content pages' UI are updated with the latest API calls.
+'''
+Plain = '''
 In the future, in case you need to update the hestiaHUGO, you just need to
 replace your 'themes/hestiaHUGO' directory with the updated package. Hugo
 reconfiguration is not required unless the release note specify it. Remember
@@ -420,8 +516,10 @@ DemoHestia/
         └── hestiaHUGO/     🡨 just replace this directory
             └── ...
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
 

--- a/sites/content/zh-hans/getting-started/create-basic-and-placeholder-hugo-pages/__i18n.toml
+++ b/sites/content/zh-hans/getting-started/create-basic-and-placeholder-hugo-pages/__i18n.toml
@@ -1,15 +1,12 @@
 [i18n]
+[i18n.Labels]
 Title = '标题'
 Description = '大纲'
-
-
-
-
-[i18n.Labels]
 Code = '代码'
 URL = 'URL'
-Image = '图面'
-Guides = '指南'
+Media = '多元像'
+Content = '内容'
+Label = '名字'
 
 
 
@@ -21,67 +18,86 @@ Title = '自介'
 
 
 
-[i18n.Objectives]
+[[i18n.H2]]
 ID = '学习目标'
 Title = '学习目标'
-Description = '''
+HTML = '''
 在成功完毕这个指南领导后，您会学到:
+<ol>
+	<li><p>了解hestiaHUGO如何和Hugo一起运作</p></li>
+	<li><p>了解hestiaHUGO如何管理文件和URL链接系统</p></li>
+	<li><p>了解hestiaHUGO如何处理界面元件设计自由</p></li>
+	<li><p>了解hestiaHUGO的设计是如何面对W3C的永久更新</p></li>
+	<li><p>了解hestiaHUGO的设计如何面对多元化的输出成果(HTML & JSON)</p></li>
+	<li><p>了解hestiaHUGO在默认情况下如何处理世界多语言</p></li>
+</ol>
+'''
+Plain = '''
+在成功完毕这个指南领导后，您会学到:
+
+（1）了解hestiaHUGO如何和Hugo一起运作、
+（2）了解hestiaHUGO如何管理文件和URL链接系统、
+（3）了解hestiaHUGO如何处理界面元件设计自由、
+（4）了解hestiaHUGO的设计是如何面对W3C的永久更新、
+（5）了解hestiaHUGO的设计如何面对多元化的输出成果(HTML & JSON)和
+（6）了解hestiaHUGO在默认情况下如何处理世界多语言。
 '''
 
 
-[[i18n.Objectives.Outcomes]]
-Value = '了解hestiaHUGO如何和Hugo一起运作'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = '了解hestiaHUGO如何管理文件和URL链接系统'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = '了解hestiaHUGO如何处理界面元件设计自由'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = '了解hestiaHUGO的设计是如何面对W3C的永久更新'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = '了解hestiaHUGO的设计如何面对多元化的输出成果(HTML & JSON)'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = '了解hestiaHUGO在默认情况下如何处理世界多语言'
+[[i18n.H2.URL]]
+Label = ''
+Value = ''
 
 
 
 
-[[i18n.Steps]]
+[[i18n.H2]]
 ID = '先决条件'
 Title = '先决条件'
-Description = '''
+HTML = '''
+这个指南是先决您已经有一份尤其是通过之前的指南设立随时可以运用拥有hestiaHUGO的
+Hugo代码库。不然的话，那就请先完整之前的指南才会来这点：
+'''
+Plain = '''
 这个指南是先决您已经有一份尤其是通过之前的指南设立随时可以运用拥有hestiaHUGO的
 Hugo代码库。不然的话，那就请先完整之前的指南才会来这点：
 '''
 Code = ''
-URL = '/zh-hans/getting-started/setup-hugo/'
+
+
+[[i18n.H2.URL]]
 Label = '设置拥有hestiaHUGO的Hugo'
+Value = '/zh-hans/getting-started/setup-hugo/'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '了解hestiahugo如何处理URL地址和文件系统'
 Title = '了解hestiahugo如何处理URL地址和文件系统'
-Description = '''
-hestiaHUGO原生是有支持它自己的多语言(‘i18n’）功能：××它是运用第一层的文件夹为
-**ISO639-1, ISO639-2, ISO639-3, ISO15924, and ISO3166 语言代码××或无语言关系的
-网页（如：URL地址重向网页）。其余的是和Hugo一样。我们非常建议您为那文件夹设名时
-一定要遵守URL地址的模式和规则（如：没有空格、一切是小字母和没有古怪的符号等等）。
-即使您是建设语言单一的网站都好，您也为了未来不想垄断网页的链接点得遵守这个名字模
-式。
+HTML = '''
+hestiaHUGO原生是有支持它自己的多语言（i18n）功能：
+<b>它是运用第一层的文件夹为
+<code>ISO639-1、ISO639-2、ISO639-3、ISO15924和ISO3166 </code>语言规范</b>
+或无语言关系的网页（如：URL地址重向网页）。其余的是和Hugo一样。
+我们非常建议您为那文件夹设名时一定要遵守URL地址的模式和规则
+（如：没有空格、一切是小字母和没有古怪的符号等等）。
+即使您是建设语言单一的网站都好，
+您也为了未来不想垄断网页的链接点得遵守这个名字模式。
+'''
+Plain = '''
+hestiaHUGO原生是有支持它自己的多语言(‘i18n’）功能：
+××它是运用第一层的文件夹为**ISO639-1、ISO639-2、ISO639-3、ISO15924和ISO3166语言代码××
+或无语言关系的网页（如：URL地址重向网页）。其余的是和Hugo一样。
+我们非常建议您为那文件夹设名时一定要遵守URL地址的模式和规则（如：没有空格、
+一切是小字母和没有古怪的符号等等）。
+即使您是建设语言单一的网站都好，
+您也为了未来不想垄断网页的链接点得遵守这个名字模式。
 '''
 Code = '''
 **模式**
-文件路线 :          content/[i18n]/url-compatible-pathing/file.extension
-URL地址 : [http://baseURL]/[i18n]/url-compatible-pathing/file.extension?query=value#tags
+文件路线 ：          content/[i18n]/url-compatible-pathing/file.extension
+URL地址  ： [http://baseURL]/[i18n]/url-compatible-pathing/file.extension?query=value#tags
 
 **例子**
 content/ (https://hestia.zoralab.com/)
@@ -99,14 +115,27 @@ content/zh-hans/releases/v1-2-0/index.html (https://hestia.zoralab.com/zh-hans/r
 content/zh-hans/releases/v1-2-0/index.json (https://hestia.zoralab.com/zh-hans/releases/v1-2-0/index.json)
 content/zh-hans/releases/v1-2-0/my-file.zip (https://hestia.zoralab.com/zh-hans/releases/v1-2-0/my-file.zip)
 '''
-URL = ''
+
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '制造hugo的content文件夹'
 Title = '制造Hugo的Content文件夹'
-Description = '''
+HTML = '''
+我们先开始制造<code>Hugo</code>需要的<code>Content</code>文件夹吧。
+它的名字其实在您的<code>config/_default/config.toml</code>文件里的
+<code>contentDir</code>数码价值(常名为<code>content</code>）。
+您可以改成别的名字。在这个指南里，我们还是运用常名<code>content</code>来制造。
+过后呢，您需要重新启动您的
+<code>Hugo Server</code>(提示：<code>server.cmd</code>命令）。全部命令菜单如下：
+'''
+Plain = '''
 我们先开始制造Hugo需要的Content文件夹吧。它的名字其实在您的
 ‘config/_default/config.toml’文件里的‘contentDir’数码价值(常名为‘content’）。
 您可以改成别的名字。在这个指南里，我们还是运用常名‘content’来制造。过后呢，您需
@@ -126,14 +155,29 @@ Code = '''
 	> mkdir content
 	> hugo server .... # 如果忘记，请复习之前的指南
 '''
-URL = ''
+
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '建设占位符性的网页'
 Title = '建设占位符性的网页'
-Description = '''
+HTML = '''
+现在系统需要的文件夹已经有了，
+我们可以开始为<code>/zh-hans</code>登陆网页建设成占位符性网页。
+我们暂时是不会建设这一页。不过呢，
+<code>/zh-hans/404</code>网页是需要它的出现才能开始建设。
+<code>hestiaHUGO</code>原生是和<code>Hugo</code>系统综合的。
+既然这个指南的语言是国际华语，那我们就通过<code>Hugo</code>命令来建出
+<code>content/zh-hans</code>的网页吧。
+切记：这个命令是又重要和又常用的。您最好把它给记得起来。命令模式如下：
+'''
+Plain = '''
 现在系统需要的文件夹已经有了，我们可以开始为’/zh-hans‘登陆网页建设成占位符性
 网页。我们暂时是不会建设这一页。不过呢，’/zh-hans/404‘网页是需要它的出现才能开始
 建设。hestiaHUGO原生是和Hugo系统综合的。既然这个指南的语言是国际华语，那我们就通
@@ -148,14 +192,33 @@ $ hugo new --kind hestia [filesystem path]
 **例子**
 $ hugo new --kind hestia content/zh-hans
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '了解hestiahugo如何处理网页的设置'
 Title = '了解hestiahugo如何处理网页的设置'
-Description = '''
+HTML = '''
+在还未继续建设时，我们先了解<code>hestiahugo</code>如何处理网页的设置。
+如果您现在观光那<code>content/zh-hans/</code>文件夹里，您会找到很多TOML设置文件。
+由于现代的互联网的构造已经变得非常复杂，
+我们也无可奈何只能把那么多的设置分成因该的设置文件。
+有一个固定的思维一定要记住：千万不可碰Hugo原本的<code>_index.html</code>文件。
+它现在只是让Hugo寻找您的网页地图而已。
+我们的hestiaHUGO设计是很少会和其他Hugo界面的模块有冲突的
+而且您还是可以继续在同一个文件夹里放入网页有关而已的文件
+（如：有关图画只有这个网页运用、
+<code>.docx</code>文件、
+<code>.csv</code>文件，
+<code>.pdf</code>文集等等）。
+每个设置TOML文件如：
+'''
+Plain = '''
 在还未继续建设时，我们先了解hestiahugo如何处理网页的设置。如果您现在观光那
 ’content/zh-hans/‘文件夹里，您会找到很多TOML设置文件。由于现代的互联网的构造已经
 变得非常复杂，我们也无可奈何只能把那么多的设置分成因该的设置文件。有一个固定的思
@@ -183,16 +246,22 @@ __thumbnails.toml        ➤ 这网页的是在社交网络运用的展览缩略
 __twitter.toml           ➤ 这网页的推特设置
 __wasm.toml              ➤ 这网页的WASM设置
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
 
 
-[[i18n.Steps]]
+[[i18n.H2]]
 ID = '更新page-toml'
 Title = '更新__page.toml'
-Description = '''
+HTML = '''
+别担心，要处理占位符性的网页只需更新<code>__page.toml</code>设置文件就行了。
+这份文件是网页的最重要的设置数据。一些您需要更新的数据有如：
+'''
+Plain = '''
 别担心，要处理占位符性的网页只需更新__page.toml设置文件就行了。这份文件是网页的
 最重要的设置数据。一些您需要更新的数据有如：
 '''
@@ -223,17 +292,26 @@ Summary = '''
 
 ...
 """
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'git-commit占位符性的网页'
 Title = 'Git Commit占位符性的网页'
-Description = '''
+HTML = '''
 现在全部东西已经设好了，您可以为这占位符性的网页的网页Git Commit掉然后往我们想要
 的/zh-hans/404网页建设。如果您需要Git的帮助，您可以通过以下的URL链接了解他们的官
-方书。大致上的命令菜单是：
+方书。大致上的命令列单是：
+'''
+Plain = '''
+现在全部东西已经设好了，您可以为这占位符性的网页的网页Git Commit掉然后往我们想要
+的/zh-hans/404网页建设。如果您需要Git的帮助，您可以通过以下的URL链接了解他们的官
+方书。大致上的命令列单是：
 '''
 Code = '''
 $ git add .
@@ -253,14 +331,24 @@ Signed-off-by: Name <EMAIL>
 
 $ git push
 '''
-URL = 'https://git-scm.com/book/zh/v2'
+
+[[i18n.H2.URL]]
 Label = 'Git手册书'
+Value = 'https://git-scm.com/book/zh/v2'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '为404网页建设重复所学的技巧'
 Title = '为404网页建设重复所学的技巧'
-Description = '''
+HTML = '''
+现在轮到您表演啦。我们要建设简单的<code>/zh-hans/404</code>网页
+（提示：<code>content/zh-hans/404</code>）。
+请运用您之前所学的技巧先假设需要的网页设置但是不需要Git Commit就行了。
+我们要接下来开发它。
+'''
+Plain = '''
 现在轮到您表演啦。我们要建设简单的/zh-hans/404网页
 （提示：'content/zh-hans/404'）。请运用您之前所学的技巧先假设需要的网页设置但是
 不需要Git Commit就行了。我们要接下来开发它。
@@ -271,14 +359,25 @@ Code = '''
 (2) $ 为404网页的__page.toml更新它需要和合适的数据。
 (3) $ git add .
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '更新网页推特的设置'
 Title = '更新网页推特的设置'
-Description = '''
+HTML = '''
+和之前占位符性的网页不同的是这一轮我们要彻底建设网页了。
+首先，
+如果您有推特的用户您可先更新<code>content/zh-hans/404/__twitter.toml</code>
+的这篇网页有关的设置。由于这是个404网页（因该没有人特地去询问吧），
+您只需要更新以下的数据就行了：
+'''
+Plain = '''
 和之前占位符性的网页不同的是这一轮我们要彻底建设网页了。首先，如果您有推特的用户
 您可先更新'content/zh-hans/404/__twitter.toml'的这篇网页有关的设置。由于这是个
 404网页（因该没有人特地去询问吧），您只需要更新以下的数据就行了：
@@ -291,14 +390,23 @@ Handle = 'yourTwitterHandle'    # 有没有@都可以
 
 ...
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '更新擦寻机械器指南设置'
 Title = '更新擦寻机械器指南设置'
-Description = '''
+HTML = '''
+由于这页是个404网页，我们是不要网络擦寻机械器给放入大众的擦寻菜单里。如此以来，
+我们需要更新那<code>content/zh-hans/404/__robots.toml</code>设置文件了。
+这些网络擦寻机械器的指南数据将会被内嵌进HTML的meta标签里。例子有如：
+'''
+Plain = '''
 由于这页是个404网页，我们是不要网络擦寻机械器给放入大众的擦寻菜单里。如此以来，
 我们需要更新那'content/zh-hans/404/__robots.toml'设置文件了。这些网络擦寻机械器
 的指南数据将会被内嵌进HTML的meta标签里。例子有如：
@@ -314,17 +422,28 @@ Content = 'noindex, nofollow'
 Name = 'robots'
 Content = 'noindex, nofollow'
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '更新网页的语言设置'
 Title = '更新网页的语言设置'
-Description = '''
+HTML = '''
 为了避免在以后制造太多复制粘贴的错误，我们还是最好更新
-'content/zh-hans/404/__languages.toml'语言设置。我们非常建议您运用RFC3986符合的
-URL链接相对型网址。我们会在下一步好好解释让您了解更多。以下是需要的更新工作：
+<code>content/zh-hans/404/__languages.toml</code>语言设置。
+我们非常建议您运用<code>RFC3986</code>符合的URL链接相对型网址。
+我们会在下一步好好解释让您了解更多。以下是需要的更新工作：
+'''
+Plain = '''
+为了避免在以后制造太多复制粘贴的错误，我们还是最好更新
+'content/zh-hans/404/__languages.toml'语言设置。
+我们非常建议您运用<code>RFC3986</code>符合的URL链接相对型网址。
+我们会在下一步好好解释让您了解更多。以下是需要的更新工作：
 '''
 Code = '''
 ...
@@ -332,14 +451,26 @@ Code = '''
 [zh-hans]
 URL = '/zh-hans/404'
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '了解hestiahugo如何处理URL'
 Title = '了解hestiahugo如何处理URL'
-Description = '''
+HTML = '''
+hestiaHUGO运用它自己的URL数据处理器（名为<code>hestiaURL/Sanitize</code>功能）。
+我们非常建议您在编译之前的范围运用相对型网址（如：您的网页模板等等）
+然后让hestiaHUGO把它编译成绝对型网址。
+您的网络游客不管任何原因永远都一定要得到绝对型网址。
+这个功能是<code>RFC3986</code>符合的。
+所以呢，您在建设相对型网址要小心啦。以下的例子可以详细描述它们的不同点：
+'''
+Plain = '''
 hestiaHUGO运用它自己的URL数据处理器（名为'hestiaURL/Sanitize'功能）。我们非常建
 议您在编译之前的范围运用相对型网址（如：您的网页模板等等）然后让hestiaHUGO把它
 编译成绝对型网址。您的网络游客不管任何原因永远都一定要得到绝对型网址。这个功能
@@ -367,14 +498,35 @@ Code = '''
 输入     : my-page
 输出     : https://hestia.zoralab.com/default-path/this-page/my-page
 '''
-URL = 'https://www.rfc-editor.org/rfc/rfc3986'
+
+[[i18n.H2.URL]]
 Label = 'RFC3986 URL规范'
+Value = 'https://www.rfc-editor.org/rfc/rfc3986'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '开发网页的HTML内容模型'
 Title = '开发网页的HTML内容模型'
-Description = '''
+HTML = '''
+给予hestiaHUGO，
+那份HTML内容模型文件其实是在<code>__page.toml</code>
+设置文件里的<code>Sources.HTML</code>所设的数据。
+原型数据其实是在同一个文件夹的<code>__content.hestiaHTML</code>文件。
+在这个指南里，如今我们是初学者，
+那我们就用那原型<code>__content.hestiaHTML</code>文件吧。
+咱们就打开来研究一下。
+如果您是已经上轨的Hugo模型开发者，您会马上发现到我们是运用Go的模型呈现功能
+（包括Hugo的partial功能）而不再是Markdown格式和Hugo的shortcode系统。
+在运用任何ZORALab赫斯提亚的产品时，
+我们是会要把它们开发成统一和越通用越好的。
+如果您已经是Go的开发者，您的Go Template智慧和经验自动和完整无亏损地在这个重用。
+在这个指南里，我们把文件给更新成一下的代码吧。当您完成任务后，
+让那Hugo服务器处理之后，
+您可以询问那服务器给的地址+/zh-hans/404/网页检验内容的准确。
+'''
+Plain = '''
 给予hestiaHUGO,那份HTML内容模型文件其实是在__page.toml设置文件里的'Sources.HTML'
 所设的数据。原型数据其实是在同一个文件夹的'__content.hestiaHTML'文件。在这个指南
 里，如今我们是初学者，那我们就用那原型'__content.hestiaHTML'文件吧。咱们就打开来
@@ -389,26 +541,38 @@ Code = '''
 ...
 
 {{- /* render outputs */ -}}
-&lt;main&gt;
-	&lt;section id='自介' class='banner'&gt;
-		&lt;h1&gt;&#123;&#123;- .Titles.Page -&#125;&#125;&lt;/h1&gt;
-		&lt;p&gt;&#123;&#123;- .Descriptions.Page.Pitch &#125;&#125; &#123;&#123; .Descriptions.Page.Summary -&#125;&#125;&lt;/p&gt;
+<main>
+	<section id='自介' class='banner'>
+		<h1>{{- .Titles.Page -}}</h1>
+		<p>{{- .Descriptions.Page.Pitch }} {{ .Descriptions.Page.Summary -}}</p>
 
 
-		&#123;&#123;- $ret := merge . (dict "Input" (dict "Data" "/en/")) -&#125;&#125;
-		&#123;&#123;- $ret = partial "hestiaURL/Sanitize" $ret -&#125;&#125;
-		&lt;a class='button' href='&#123;&#123;- $ret -&#125;&#125;'&gt;回去主页&lt;/a&gt;
-	&lt;/section&gt;
-&lt;/main&gt;
+		{{- $ret := merge . (dict "Input" (dict "Data" "/en/")) -}}
+		{{- $ret = partial "hestiaURL/Sanitize" $ret -}}
+		<a class='button' href='{{- $ret -}}'>回去主页</a>
+	</section>
+</main>
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '了解hestiahugo如何处理网页数据'
-Title = '了解hestiahugo如何处理网页数据'
-Description = '''
+Title = '了解hestiaHUGO如何处理网页数据'
+HTML = '''
+不像Hugo需要让网页设计师去猜测数据价值，hestiaHUGO处理和运用自己的网页数据结构好
+让设计师容易运用。更好的是，我们还有网页内可设计自适应的调试器控制台让您检验任何
+有关可用的数据。有注意到荧幕右边底下有个非常彩色的按钮吗？按按看就可以看到调试器
+控制台了。
+例如呢，您有注意到<code>{{- .Titles.Page -}}</code>
+被呈现成它的数据<code>.Titles.Page</code>价值了？
+'''
+Plain = '''
 不像Hugo需要让网页设计师去猜测数据价值，hestiaHUGO处理和运用自己的网页数据结构好
 让设计师容易运用。更好的是，我们还有网页内可设计自适应的调试器控制台让您检验任何
 有关可用的数据。有注意到荧幕右边底下有个非常彩色的按钮吗？按按看就可以看到调试器
@@ -417,10 +581,12 @@ Description = '''
 '''
 Code = '''
 '''
-URL = ''
-Label = ''
 
-[i18n.Steps.Image]
+[[i18n.H2.URL]]
+Label = ''
+Value = ''
+
+[i18n.H2.Image]
 Name = "调试器控制台的屏幕截图"
 Decorative = false
 Loading = 'lazy'
@@ -436,65 +602,79 @@ Loop = false
 Mute = false
 Inline = false
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-600x600.avif"
 Type = "image/avif"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-600x600.webp"
 Type = "image/webp"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-600x600.jpg"
 Type = "image/jpeg"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-400x400.avif"
 Type = "image/avif"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-400x400.webp"
 Type = "image/webp"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-400x400.jpg"
 Type = "image/jpeg"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-220x220.avif"
 Type = "image/avif"
 Media = "all"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-220x220.webp"
 Type = "image/webp"
 Media = "all"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/hestiahugo-debugger-console-220x220.jpg"
 Type = "image/jpeg"
 Media = "all"
 Descriptor = '1x'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '了解hestiahugo的数据路径'
 Title = '了解hestiahugo的数据路径'
-Description = '''
+HTML = '''
+hestiaHUGO终于完成设计它对<code>content</code>
+文件夹的控制和设计好让每一个文件夹输入有关网页需要的数码资料。
+还记得<code>__i18n.toml</code>和<code>__data.toml</code>文件吗？
+这些数码文件有在<code>__page.toml</code>的<code>[[Data]]</code>数组菜单里。
+hestiaHUGO维持足够的自由来建设网页的数据架构。
+当它完成解析所有的数据文件后，
+您的数据可以通过<code>hestiaHUGO.Page</code>数据架构来建设您的网页。
+其他的设置文件当然也是会供应不同的数据。请随心通过调试器控制台玩玩研究吧。
+以下的链接是<code>hestiaHUGO.Page</code>数据架构的规范
+（的空时才阅读吧，我们先向前走）。
+'''
+Plain = '''
 hestiaHUGO终于完成设计它对content文件夹的控制和设计好让每一个文件夹输入有关网
 页需要的数码资料。还记得__i18n.toml和__data.toml文件吗？这些数码文件有在
 __page.toml的[[Data]]数组菜单里。hestiaHUGO维持足够的自由来建设网页的数据架
@@ -509,14 +689,28 @@ __data.toml + __i18n.toml + ...   (切记: 跟着__page.toml的[[Data]]数组菜
              ⤋
      {{- .Field.[...] -}}
 '''
-URL = '/zh-hans/specs/hestiaCOMPILERS/hestiaHUGO/'
+
+[[i18n.H2.URL]]
 Label = 'hestiaHUGO.Page数据架构规范'
+Value = '/zh-hans/specs/hestiacompilers/hestiahugo/'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '了解hestiahugo如何授权hugo'
 Title = '了解hestiaHUGO如何授权Hugo'
-Description = '''
+HTML = '''
+hestiaHUGO如其他ZORALab赫斯提亚模块供应自己的标准代码库。刚才有注意到您运用
+<code>hestiaURL.Sanitize</code>吗？那是hestiaHUGO的URL数据检验功能。
+它把URL链接从相像型去稳定的绝对型。
+能供应自己的标准代码库主要是我们可以继续专心发展
+ZORALab赫斯提亚尤其是所有模块通用而不是整天只是忙着寻擦Hugo不稳定的输出成果根源。
+所有ZORALab赫斯提亚元件都是经过同样的上下文写出的。
+以下的链接是ZORALab赫斯提亚全部的API规范官方文件。为了这份指南，我们会向前走。
+待会阅读吧。
+'''
+Plain = '''
 hestiaHUGO如其他ZORALab赫斯提亚模块供应自己的标准代码库。刚才有注意到您运用
 hestiaURL.Sanitize吗？那是hestiaHUGO的URL数据检验功能。它把URL链接从相像型去
 稳定的绝对型。能供应自己的标准代码库主要是我们可以继续专心发展ZORALab赫斯提亚尤
@@ -526,14 +720,26 @@ API规范官方文件。为了这份指南，我们会向前走。待会阅读�
 '''
 Code = '''
 '''
-URL = '/zh-hans/spec'
+
+[[i18n.H2.URL]]
 Label = '规范'
+Value = '/zh-hans/specs'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '开发网页的界面造型元件菜单'
 Title = '开发网页的界面造型元件菜单'
-Description = '''
+HTML = '''
+现在我们已经肯定了呈现HTML而已的网页数据，我们可以开始开发它的造型了。hestiaHUGO
+运用界面元件方式去把网页稳重地造型出来。
+请更新<code>/zh-hans/404/__components.toml</code>的设置数据如以下显示的资料。
+但您做好了后，就让Hugo服务器内部更新一下才再次刷新观看那404网页。
+您会注意到那网页已经美化好（尤其是那按钮）。
+您可以通过调试器控制台寻找<code>.CSS.Inline</code>的编这页制出的CSS代码。
+'''
+Plain = '''
 现在我们已经肯定了呈现HTML而已的网页数据，我们可以开始开发它的造型了。hestiaHUGO
 运用界面元件方式去把网页稳重地造型出来。请更新/zh-hans/404/__components.toml的设
 置数据如以下显示的资料。但您做好了后，就让Hugo服务器内部更新一下才再次刷新观看那
@@ -564,14 +770,27 @@ Name = "zoralabBUTTON"
 Include = true
 Variables = []
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '了解hestiaHUGO如何处理网页造型'
 Title = '了解hestiaHUGO如何处理网页造型'
-Description = '''
+HTML = '''
+hestiaHUGO是像Backbone、Angular和React结构把页造型元件化但与它们不同的是
+hestiaHUGO把每个元件的HTML、CSS、和JS综合起来而不是分开偏向JS单一处理。如此一来，
+通过Hugo，hestiaHUGO可以编制网页只需要的CSS、CSS变化值和JS的代码然后内嵌进它的
+HTML代码里。那编制出的HTML文件是AMP最初设想自给自足而不再需要而外远程架构的网页
+啦。另外呢，这个编制出的HTML文件可以很容易地支持PWA离线情况下继续运用而且还让造
+型元件设计师专住和容易化元件更新W3C的不向后兼容的进展工作。3件事1次性搞定⥤价廉
+物美啊。
+'''
+Plain = '''
 hestiaHUGO是像Backbone、Angular和React结构把页造型元件化但与它们不同的是
 hestiaHUGO把每个元件的HTML、CSS、和JS综合起来而不是分开偏向JS单一处理。如此一来，
 通过Hugo，hestiaHUGO可以编制网页只需要的CSS、CSS变化值和JS的代码然后内嵌进它的
@@ -582,14 +801,25 @@ HTML代码里。那编制出的HTML文件是AMP最初设想自给自足而不再
 '''
 Code = '''
 '''
-URL = '/zh-hans/specs/hestiaGUI'
+
+[[i18n.H2.URL]]
 Label = '界面造型元件规范菜单'
+Value = '/zh-hans/specs/hestiagui'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '了解hestiaHUGO为何集装每个网页的造型'
 Title = '了解hestiaHUGO为何集装每个网页的造型'
-Description = '''
+HTML = '''
+主要是要避免在更新UI时在全站里搞出打鼹鼠游戏类似的网页造型破裂。我们已经实验过很
+多种方式了。
+如今，这个方式是最优化了。若要好像以前一样地在全站里规模化，
+您只需复制那<code>__components.toml</code>就行了。
+这样做也可以让初学设计师可以安全地地去制作网站同时放心地搞错误来学习和进展。
+'''
+Plain = '''
 主要是要避免在更新UI时在全站里搞出打鼹鼠游戏类似的网页造型破裂。我们已经实验过很
 多种方式了。如今，这个方式是最优化了。若要好像以前一样地在全站里规模化，您只需
 复制那__components.toml就行了。这样做也可以让初学设计师可以安全地地去制作网站同时
@@ -597,14 +827,24 @@ Description = '''
 '''
 Code = '''
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '了解hestiaHUGO如何操作界面元件'
 Title = '了解hestiaHUGO如何操作界面元件'
-Description = '''
+HTML = '''
+如同之前所说的：CSS代码是用来造型界面、CSS变化值是用来随环境更改界面定制和JS代码
+用来造型动画和反映设计等等用途。当您加入一份界面元件时，您会有一个Include的开关
+在设计中用来容易寻找问题根点（好过把一大堆的代码给删掉）。您也同时可以同时改写
+界面元件CSS变化值现有的价值，好让hestiaHUGO只需编制一份CSS变化值菜单就足够了。
+'''
+Plain = '''
 如同之前所说的：CSS代码是用来造型界面、CSS变化值是用来随环境更改界面定制和JS代码
 用来造型动画和反映设计等等用途。当您加入一份界面元件时，您会有一个Include的开关
 在设计中用来容易寻找问题根点（好过把一大堆的代码给删掉）。您也同时可以同时改写
@@ -622,14 +862,39 @@ Variables = [
 
 ...
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '了解ZORALab赫斯提亚为何只专注HTML和CSS造型而已'
 Title = "了解ZORALab赫斯提亚为何只专注HTML和CSS造型而已"
-Description = '''
+HTML = '''
+为了2个重要的原因：
+<ol>
+	<li><p>
+		支持隐私优先的呈现（如：完全禁用JS）➤ 在2022新冠疫情时期，
+		每个人对隐私数据泄漏非常敏感所以完全禁用JS的用法是迟早的。
+		在这种情况里，
+		您的出名JS构架和我们的WASM是完全没用但是游客还是要网站可以依然使用。
+	</p></li>
+	<li><p>
+		ZORALab赫斯提亚有目的把JS给一些正常点的代码语言如Go或Nim通过WASM完全代替。
+		如果只是HTML和CSS而已，那界面元件WASM进化工作会非常容易
+		「不需要烦JS的控制骚扰」。
+	</p></li>
+</ol>
+<p>
+	无论如何，您还是可以运用Javascript（我们会迟点教您）。
+	在ZORALab赫斯提亚行政里，
+	我们绝不像某些科技那么狠心霸道来控制任何人的艺术自由发挥和表现。
+</p>
+'''
+Plain = '''
 为了2个重要的原因：(1)支持隐私优先的呈现（如：完全禁用JS）➤ 在2022新冠疫情时期，
 每个人对隐私数据泄漏非常敏感所以完全禁用JS的用法是迟早的。在这种情况里，您的出名
 JS构架和我们的WASM是完全没用但是游客还是要网站可以依然使用。(2)ZORALab赫斯提亚有
@@ -640,14 +905,25 @@ JS构架和我们的WASM是完全没用但是游客还是要网站可以依然�
 '''
 Code = '''
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '了解zoralab和javascript关系'
 Title = '了解zoralab和JavaScript关系'
-Description = '''
+HTML = '''
+咱们面对现实吧：JavaScript虽然在历史至今还是不稳定和唯一可以在网络运用的代码语
+言。它的不定弱点搞出一些架构如Angular和Typescript等等来变通地“解决”问题。由于它
+们本身也是来自Javascript出生，就这样制造了它们本身的问题。如今WASM的诞生，
+ZORALab坚决地要迎面地解决这JavaScript的问题啦。我们不是讨厌JavaScript而是发现它
+还蛮高风险的。很久以前的JavaScript架构出生和淘汰就足够证明一切了。
+'''
+Plain = '''
 咱们面对现实吧：JavaScript虽然在历史至今还是不稳定和唯一可以在网络运用的代码语
 言。它的不定弱点搞出一些架构如Angular和Typescript等等来变通地“解决”问题。由于它
 们本身也是来自Javascript出生，就这样制造了它们本身的问题。如今WASM的诞生，
@@ -656,14 +932,32 @@ ZORALab坚决地要迎面地解决这JavaScript的问题啦。我们不是讨厌
 '''
 Code = '''
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '了解hestiahugo的未来'
 Title = '了解hestiaHUGO的未来'
-Description = '''
+HTML = '''
+如今想要达到我们的网络科技梦想，那就有3个使用案例必须实现：
+<ol>
+	<li><p>可被SEO和SMO发现的网页、</p></li>
+	<li><p>单一APP - 1个WASM操作整个网站和</p></li>
+	<li><p>反应式渲染网页 - 每个网页都有自己的WASM渲染网页内容。</p></li>
+</ol>
+<p>hestiaHUGO将会满足使用案例：</p>
+<ol>
+	<li><p>和供应WASM给使用案例</p></li>
+	<li><p>和使用案例</p></li>
+	<li><p>这也就是为何我们还在支持Hugo（还把它改成内容编译器）。</p></li>
+</ol>
+'''
+Plain = '''
 如今想要达到我们的网络科技梦想，那就有3个使用案例必须实现：（1）可被SEO和SMO发现
 的网页、（2）单一APP - 1个WASM操作整个网站和（3）反应式渲染网页 - 每个网页都有
 自己的WASM渲染网页内容。hestiaHUGO将会满足使用案例（1）和供应WASM给使用案例（2）
@@ -671,14 +965,24 @@ Description = '''
 '''
 Code = '''
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '通过css再更改进化网页造型'
 Title = '通过CSS再更改进化网页造型'
-Description = '''
+HTML = '''
+现在那404网站已经规模化地美化了，您可以通过CSS再更改进化那网页到它独特的造型。
+您只需要在<code>__content.hestiaCSS</code>加入您的CSS代码就行了。
+hestiaHUGO会把它编译为最后一份内嵌的CSS文件。
+当Hugo服务器做好了，您可以回去那网页看看。它因该是在以颜色跳舞吧。
+'''
+Plain = '''
 现在那404网站已经规模化地美化了，您可以通过CSS再更改进化那网页到它独特的造型。您
 只需要在__content.hestiaCSS加入您的CSS代码就行了。hestiaHUGO会把它编译为最后一份
 内嵌的CSS文件。当Hugo服务器做好了，您可以回去那网页看看。它因该是在以颜色跳舞吧。
@@ -725,14 +1029,26 @@ main {
 	background: rgba(255, 255, 255, .75);
 }
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '通过javascript更新进化网页'
 Title = '通过JavaScript更新进化网页'
-Description = '''
+HTML = '''
+同时，您也可以通过JavaScript更新进化网页造型。
+那文件是<code>__content.hestiaJS</code>。虽然那404网页已经不需要在进化造型了，
+为了完整化这份指南，我们就加入以下的JS代码经历一下吧。
+当Hugo处理器搞定好了，
+您可以再次观赏那404网页然后打开浏览器的检查器控制台（F12键盘键)。
+您应该会看到一只喵喵的猫咪。就如CSS一样：这份JS也是编译为最后一份内嵌的JS文件。
+'''
+Plain = '''
 同时，您也可以通过JavaScript更新进化网页造型。那文件是__content.hestiaJS。虽然那
 404网页已经不需要在进化造型了，为了完整化这份指南，我们就加入以下的JS代码经历一
 下吧。当Hugo处理器搞定好了，您可以再次观赏那404网页然后打开浏览器的检查器控制台
@@ -744,10 +1060,12 @@ window.onload = function() {
 	console.log("\nMeow~~~~ ₍⌯ᴖⱅᴖ⌯ ^₎◞ ̑̑ෆ⃛ \n\n");
 };
 '''
-URL = ''
-Label = ''
 
-[i18n.Steps.Image]
+[[i18n.H2.URL]]
+Label = ''
+Value = ''
+
+[i18n.H2.Image]
 Name = "猫喵喵在浏览器的检查器控制台里叫的截图"
 Decorative = false
 Loading = 'lazy'
@@ -763,65 +1081,75 @@ Loop = false
 Mute = false
 Inline = false
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-600x600.avif"
 Type = "image/avif"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-600x600.webp"
 Type = "image/webp"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-600x600.jpg"
 Type = "image/jpeg"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-400x400.avif"
 Type = "image/avif"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-400x400.webp"
 Type = "image/webp"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-400x400.jpg"
 Type = "image/jpeg"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-220x220.avif"
 Type = "image/avif"
 Media = "all"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-220x220.webp"
 Type = "image/webp"
 Media = "all"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/js-output-220x220.jpg"
 Type = "image/jpeg"
 Media = "all"
 Descriptor = '1x'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '为seo更新ldjson数据'
 Title = '为SEO更新LD+JSON数据'
-Description = '''
+HTML = '''
+hestiHUGO有内置支持Schema.org的网页数码构架。
+那有关文件是<code>__content.hestiaLDJSON</code>。
+如今是404网页，我们只需要加入以下的代码程序就行了。
+当Hugo服务器完成它的更新程序之后，
+您可以在网页内通过我们的调试器控制台索取输出的成果然后送去Schema.org
+的验证室检验一下。
+'''
+Plain = '''
 hestiHUGO有内置支持Schema.org的网页数码构架。那有关文件是__content.hestiaLDJSON。
 如今是404网页，我们只需要加入以下的代码程序就行了。当Hugo服务器完成它的更新程序之
 后，您可以在网页内通过我们的调试器控制台索取输出的成果然后送去Schema.org的验证室
@@ -843,28 +1171,51 @@ Code = '''
 {{- /* render output */ -}}
 ...
 '''
-URL = 'https://validator.schema.org/'
+
+[[i18n.H2]]
 Label = 'LD+JSON验证室'
+Value = 'https://validator.schema.org/'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '了解hestiahugo如何处理ldjson'
 Title = '了解hestiaHUGO如何处理LD+JSON'
-Description = '''
+HTML = '''
+为了在自由发挥和稳重输出内保持平衡，两件要记得的是：
+<ol>
+	<li><p>
+		hesitaHUGO只能帮您快速地建设先知常用的数据构架（如作者、页类、等等）。
+	</p></li>
+	<li><p>
+		您需要自己另加网页有关的仔细数据（如：煮法步骤等等类型）。
+	</p></li>
+</ol>
+'''
+Plain = '''
 为了在自由发挥和稳重输出内保持平衡，两件要记得的是：（1）hesitaHUGO只能帮您快速
 地建设先知常用的数据构架（如作者、页类、等等）。（2）您需要自己另加网页有关的仔
 细数据（如：煮法步骤等等类型）。
 '''
 Code = '''
 '''
-URL = 'https://schema.org/docs/full.html'
+
+[[i18n.H2]]
 Label = 'Schema.org Data Structures'
+Value = 'https://schema.org/docs/full.html'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '暂存当前的状态'
 Title = '暂存当前的状态'
-Description = '''
+HTML = '''
+现在HTML的输出成果已经做好了，我们就应该Git暂存目前的状态。我们的目前工作还未做
+完。请继续下一步吧。
+'''
+Plain = '''
 现在HTML的输出成果已经做好了，我们就应该Git暂存目前的状态。我们的目前工作还未做
 完。请继续下一步吧。
 '''
@@ -872,14 +1223,28 @@ Code = '''
 提示：
 $ git add .
 '''
-URL = ''
+
+[[i18n.H2]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '制造json的输出内容'
 Title = '制造JSON的输出内容'
-Description = '''
+HTML = '''
+hestiaHUGO在默认情况下支持JSON为同时第二输出内容。
+这是hestiaHUGO的功能，而不是运用Hugo的。
+有如之前的LD+JSON相似，您可以在这儿建设网页的数据架构。
+但是和LD+JSON不同的是，您是不会被Schema.org的数据架构规范给横行锁住。
+这是纯真JSON（可以在URL地址加上<code>index.json</code>就可以看到）。
+那文件是在<code>__page.toml</code>里被<code>.Sources.JSON</code>规定的
+（常用的是<code>__content.hestiaJSON</code>）。
+既然我们现在是建设404网页，我们可以放着就好。您可以去看看那文件来了解更多。
+'''
+Plain = '''
 hestiaHUGO在默认情况下支持JSON为同时第二输出内容。这是hestiaHUGO的功能，而不是运
 用Hugo的。有如之前的LD+JSON相似，您可以在这儿建设网页的数据架构。但是和LD+JSON不
 同的是，您是不会被Schema.org的数据架构规范给横行锁住。这是纯真JSON（可以在URL地
@@ -889,14 +1254,43 @@ hestiaHUGO在默认情况下支持JSON为同时第二输出内容。这是hestia
 '''
 Code = '''
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '了解hestiaHUGO为何默认情况支持JSON输出内容'
 Title = '了解hestiaHUGO为何默认情况支持JSON输出内容'
-Description = '''
+HTML = '''
+5个原因：
+<ol>
+	<li><p>
+		可以运用hestiaHUGO制作CDN推动的开源数据API的服务网站、
+	</p></li>
+	<li><p>
+		一个在网络搜寻服务工商接近为了广告收入破坏SEO的情况下备份原因来运用Hugo、
+	</p></li>
+	<li><p>
+		供应一个没有被LD+JSON锁控的数据输出、
+	</p></li>
+	<li><p>
+		确定和测试hestiaHUGO可以输出多个一种内容和
+	</p></li>
+	<li><p>
+		准备一个方法为AI输入数据。
+	</p></li>
+</ol>
+<p>
+	在默认情况下的设置是为没有需求而定。
+	如果您不需要运用JSON输出内容，
+	您可以完全不碰那<code>__content.hestiaJSON</code>文件。
+</p>
+'''
+Plain = '''
 5个原因：（1）可以运用hestiaHUGO制作CDN推动的开源数据API的服务网站、（2）一个在
 网络搜寻服务工商接近为了广告收入破坏SEO的情况下备份原因来运用Hugo、（3）供应一个
 没有被LD+JSON锁控的数据输出、（4）确定和测试hestiaHUGO可以输出多个一种内容和（5）
@@ -905,14 +1299,22 @@ JSON输出内容，您可以完全不碰那__content.hestiaJSON文件。
 '''
 Code = '''
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '提交和推送'
 Title = '提交和推送'
-Description = '''
+HTML = '''
+在这检查站，我们已经完整地把一个简单和基本的404网页做好了。您可以Git提交和推送
+了。
+'''
+Plain = '''
 在这检查站，我们已经完整地把一个简单和基本的404网页做好了。您可以Git提交和推送
 了。
 '''
@@ -925,14 +1327,27 @@ $ git commit -s
 ----
 $ git push
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '记得hestiaHUGO的强点'
 Title = '记得hestiaHUGO的强点'
-Description = '''
+HTML = '''
+如果您还未发现，
+hestiaHUGO只需要输入1分网页数据来输出多种内容格式和可以稳重地同时支持多种语言。
+其实，它还私低下为每份网页输出<code>sitemap.xml</code>和
+<code>sitemap-page.xml</code>的文件。
+这也就是我们一路想解决的Hugo问题：1个稳重的输入数据安稳地输出多种内容格式。
+我们目前所学的只是一小部分而已。
+在以后的指南里，我们会继续研究更多hestiaHUGO的功能。
+'''
+Plain = '''
 如果您还未发现，hestiaHUGO只需要输入1分网页数据来输出多种内容格式和可以稳重地同
 时支持多种语言。其实，它还私低下为每份网页输出sitemap.xml和sitemap-page.xml的文
 件。这也就是我们一路想解决的Hugo问题：1个稳重的输入数据安稳地输出多种内容格式。
@@ -941,8 +1356,10 @@ Description = '''
 '''
 Code = '''
 '''
-URL = ''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
 

--- a/sites/content/zh-hans/getting-started/create-basic-and-placeholder-hugo-pages/__page.toml
+++ b/sites/content/zh-hans/getting-started/create-basic-and-placeholder-hugo-pages/__page.toml
@@ -46,10 +46,10 @@ Keywords = [
 #   4. All fields shall have their whitespace cleansed during the processing.
 [Description]
 Pitch = '''
-Through creating simple pages, we learn how hestiaHUGO operates.
+通过建设简单的网页，我们学习hestiaHUGO如何运行。
 '''
 Summary = '''
-A step-by-step guide for hestiaHUGO — ZORALab's Hestia Hugo module from scratch.
+一个一步一步编好的ZORALab赫斯提亚Hugo从新设置指南。
 '''
 
 

--- a/sites/content/zh-hans/getting-started/setup-hugo/__i18n.toml
+++ b/sites/content/zh-hans/getting-started/setup-hugo/__i18n.toml
@@ -1,15 +1,12 @@
 [i18n]
+[i18n.Labels]
 Title = '标题'
 Description = '大纲'
-
-
-
-
-[i18n.Labels]
 Code = '代码'
 URL = 'URL'
-Image = '图面'
-Guides = '指南'
+Media = '多元像'
+Content = '内容'
+Label = '名字'
 
 
 
@@ -21,36 +18,46 @@ Title = '自介'
 
 
 
-[i18n.Objectives]
+[[i18n.H2]]
 ID = '学习目标'
 Title = '学习目标'
-Description = '''
+HTML = '''
 在成功完毕这个指南领导后，您会学到:
+<ol>
+	<li><p>如何设置Hugo的Git代码库</p></li>
+	<li><p>如何下载和设置hestiaHUGO</p></li>
+	<li><p>如何开动Hugo的服务器来编制网页内容和</p></li>
+	<li><p>如何在行程中运用Git。</p></li>
+</ol>
+'''
+Plain = '''
+在成功完毕这个指南领导后，您会学到:
+（1）如何设置Hugo的Git代码库、
+（2）如何下载和设置hestiaHUGO、
+（3）如何开动Hugo的服务器来编制网页内容和
+（4）如何在行程中运用Git。
 '''
 
 
-[[i18n.Objectives.Outcomes]]
-Value = '如何设置Hugo的Git代码库'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = '如何下载和设置hestiaHUGO'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = '如何开动Hugo的服务器来编制网页内容'
-
-
-[[i18n.Objectives.Outcomes]]
-Value = '如何在行程中运用Git'
+[[i18n.H2.URL]]
+Label = ''
+Value = ''
 
 
 
 
-[[i18n.Steps]]
+[[i18n.H2]]
 ID = 'hestiaHUGO方式'
 Title = 'hestiaHUGO方式'
-Description = '''
+HTML = '''
+有如其他的Hugo模型，hestiaHUGO是有通过它的独特方式来供应界面设计。但是呢，不如其
+他的Hugo模型，hestiaHUGO是有它自己的数据处理器而很少运用Hugo本生供应的用具（我们
+只用它的partial功能和图画处理器功能而已）。我们这么做主要原因是Hugo在它的历史里
+有太多的不一致现象。经历过它带来的痛苦，身为ZORALab的我们绝对不会在重复我们的错
+误。加上我们一路的网络开发的经历，我们也在别的领域深深的学上很多不同的哲学。如此
+以来，在还没决定要用hestiaHUGO前，您一定要接受以下不折不扣的分别：
+'''
+Plain = '''
 有如其他的Hugo模型，hestiaHUGO是有通过它的独特方式来供应界面设计。但是呢，不如其
 他的Hugo模型，hestiaHUGO是有它自己的数据处理器而很少运用Hugo本生供应的用具（我们
 只用它的partial功能和图画处理器功能而已）。我们这么做主要原因是Hugo在它的历史里
@@ -80,30 +87,52 @@ Code = '''
 8. 我们是为了支持各种语言和运用干净数据而非常数据优先的。我们做到自己供应自己的
    数据干净话的功能给您统一运用的境界了。
 '''
-URL = ''
+
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '下载最新的包装'
 Title = '下载最新的包装'
-Description = '''
+HTML = '''
 我们先在ZORALab赫斯提亚下载购物中心里下载最新的hesitaHUGO包装。切记：记得只需要
-寻找：
+寻找：<code>hestiaHUGO</code>。
 '''
-Code = 'hestiaHUGO'
-URL = '/zh-hans/releases'
+Plain = '''
+我们先在ZORALab赫斯提亚下载购物中心里下载最新的hesitaHUGO包装。切记：记得只需要
+寻找：’hestiaHUGO‘。
+'''
+Code = '''
+'''
+
+
+[[i18n.H2.URL]]
 Label = '下载购物中心'
+Value = '/zh-hans/releases'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '检查包装完整性'
 Title = '检查包装完整性'
-Description = '''
+HTML = '''
+在还没有开始前，为了安全，我们建议您检查包装完整性。这里有2个方式：
+<code>GPG</code>或<code>SHASUM</code>。在这个指南里，我们在以下的片段运用
+<code>SHASUM</code>来检查包装。当完整执行<code>SHASUM</code>命令后您将会得到一份
+<b>HASHED_VALUE</b>的数据。您的唯一任务就是要确定这份<b>HASHED_VALUE</b>是
+和下载购物中心所展现数据是100%相同的。
+'''
+Plain = '''
 在还没有开始前，为了安全，我们建议您检查包装完整性。这里有2个方式：GPG或SHASUM。
 在这个指南里，我们在以下的片段运用SHASUM来检查包装。当完整执行SHASUM命令后您将会
 得到一份HASHED_VALUE的数据。您的唯一任务就是要确定这份HASHED_VALUE是和下载购物中
-心所展现SHASUM的数据是100%相同的。
+心所展现数据是100%相同的。
 '''
 Code = '''
 # 在 UNIX 系统 (LINUX / MACOS)
@@ -122,10 +151,14 @@ $ certutil -hashfile hestiaHUGO-vNNNN.zip sha512
 SHA512 hash of hestiaHUGO-vNNNN.zip:
 [HASHED_VALUE]
 '''
-URL = ''
-Label = ''
 
-[i18n.Steps.Image]
+
+[[i18n.H2.URL]]
+Label = ''
+Value = ''
+
+
+[i18n.H2.Media]
 Name = "SHASUM数据比较的屏幕截图"
 Decorative = false
 Loading = 'lazy'
@@ -141,65 +174,75 @@ Loop = false
 Mute = false
 Inline = false
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-600x600.avif"
 Type = "image/avif"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-600x600.webp"
 Type = "image/webp"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-600x600.jpg"
 Type = "image/jpeg"
 Media = "(min-width: 600px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-400x400.avif"
 Type = "image/avif"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-400x400.webp"
 Type = "image/webp"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-400x400.jpg"
 Type = "image/jpeg"
 Media = "(min-width: 300px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-220x220.avif"
 Type = "image/avif"
 Media = "(max-width: 299px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-220x220.webp"
 Type = "image/webp"
 Media = "(max-width: 299px)"
 Descriptor = '1x'
 
-[[i18n.Steps.Image.Sources]]
+[[i18n.H2.Image.Sources]]
 URL = "/img/getting-started/setup-hugo/check-package-integrity-220x220.jpg"
 Type = "image/jpeg"
 Media = "(max-width: 299px)"
 Descriptor = '1x'
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '设置git代码库'
 Title = '设置Git代码库'
-Description = '''
+HTML = '''
+当您有了一份检查成功的包装在手时，现在就是时候设置Git代码库。第一步：制造和开始您
+的Git代码库的文件夹（在这整个指南里，我们称它为<code>DemoHestia</code>）。
+在这文件夹里，你再制造新的文件夹（我们推荐名为<code>sites</code>）。
+然后在这最里面的文件夹里制造新的文件夹叫<code>themes</code>。
+最后呢，您就在这个<code>themes</code>的文件夹里打开hestiaHUGO的包装。
+您的成功文件夹有如以下：
+'''
+Plain = '''
 当您有了一份检查成功的包装在手时，现在就是时候设置Git代码库。第一步：制造和开始您
 的Git代码库的文件夹（在这整个指南里，我们称它为“DemoHestia”）。在这文件夹里，你再
 制造新的文件夹（我们推荐名为“sites”）。然后在这最里面的文件夹里制造新的文件夹叫
@@ -216,22 +259,33 @@ DemoHestia/
             ├── ...
             └── ... 其他内容 ...
 '''
-URL = ''
+
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '设置hugo系统文件夹'
 Title = '设置hugo系统文件夹'
-Description = '''
+HTML = '''
+由于hestiaHUGO的引擎的复杂性，hestiaHUGO有运出在自己的文件夹里同时运出
+<code>config/</code>文件夹和<code>server.cmd</code>。
+您需要把它移出来放入<code>sites/</code>文件夹里。
+最后成果有如：
+'''
+Plain = '''
 由于hestiaHUGO的引擎的复杂性，hestiaHUGO有运出在自己的文件夹里同时运出config/文
-件夹。您需要把它移出来放入sites/文件夹里。要凭包装的版本，如果有一份‘server.cmd’
-的文件，您也需要同时移出来。最后成果有如：
+件夹和'server.cmd'。您需要把它移出来放入sites/文件夹里。
+最后成果有如：
 '''
 Code = '''
 DemoHestia/
 └── sites/
-    ├── server.cmd  (注意: 如果有一起包装)
+    ├── server.cmd
     │
     ├── config/
     │   ├── _default/
@@ -246,14 +300,26 @@ DemoHestia/
         └── hestiaHUGO/
             └── ... 所有内容文件 ...
 '''
-URL = ''
+
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '配置hugo'
 Title = '配置Hugo'
-Description = '''
+HTML = '''
+如今所有重要的文件已经归处，现在是时候配置Hugo了。大致上，您只需要配置
+<code>__sites/config/_default/config.toml</code>文件的第一部分就行了。
+其他的部分就跟着附加的注意文字行使就行了。
+没错的话，您只需要配置<code>baseURL</code>为您想要的域名URL地址就够了。
+有空的话，您可以参考Hugo配置指南手册来了解每个数码值的意义。
+'''
+Plain = '''
 如今所有重要的文件已经归处，现在是时候配置Hugo了。大致上，您只需要配置
 '__sites/config/_default/config.toml'文件的第一部分就行了。其他的部分就跟着附加
 的注意文字行使就行了。没错的话，您只需要配置'baseURL'为您想要的域名URL地址就够了
@@ -296,66 +362,82 @@ publishDir = "public"
 i18nDir = "i18n"
 
 
-# ╔══════════╗
+# ╔════════════╗
 # ║!!  STOP  !!║
-# ╚══════════╝
+# ╚════════════╝
 !!! 那就够了。别改任何以下的数据。您可能会搞炸hestiaHUGO的。 !!!
 ...
 '''
-URL = 'https://gohugo.io/getting-started/configuration/'
+
+
+[[i18n.H2.URL]]
 Label = 'Hugo配置指南手册'
+Value = 'https://gohugo.io/getting-started/configuration/'
 
 
 
 
-[[i18n.Steps]]
+[[i18n.H2]]
 ID = '开动Hugo服务器'
 Title = '开动Hugo服务器'
-Description = '''
-如今一却已经设置和配置好了，我们可以开始开动服务器引擎来测试用户。我们建议运用以
-下的命令。切记：如果您还未设置Hugo的话，您可以参考一下的URL链接网站来设置。如果
-'server.cmd'这份文件有同一起准备的话，您可以直接跑动它就行了（它其实是个简单化
-我们的建议命令文件好让您容易开动引擎。当引擎启动时，您要为下一步注意那网站的URL
-链接地址。
+HTML = '''
+如今一却已经设置和配置好了，我们可以开始开动服务器引擎来测试用户。
+由于Hugo的有不定的症状，我们建议运用我们的<code>server.cmd</code>文件来开动它。
+虽然您可以运用Hugo的指令来开动，<b>我们坚持建议您别这么做</b>。
+您可以通过那文件来了解更多。
+'''
+Plain = '''
+如今一却已经设置和配置好了，我们可以开始开动服务器引擎来测试用户。
+由于Hugo的有不定的症状，我们建议运用我们的server.cmd文件来开动它。
+虽然您可以运用Hugo的指令来开动，**我们坚持建议您别这么做**。
+您可以通过那文件来了解更多。
 '''
 Code = '''
-$ hugo server \
-	--buildDrafts \
-	--noBuildLock \
-	--disableFastRender \
-	--bind "localhost" \
-	--baseURL "http://localhost" \
-	--port 8080 \
-	--cleanDestinationDir \
-	--gc
-
-
-Start building sites …
-...
-Web Server is available at http://localhost:8080/ (bind address 127.0.0.1)
-...
+$ cd sites/         # if you haven't do so
+$ ./server.cmd
 '''
-URL = 'https://gohugo.io/installation/'
-Label = 'Hugo设置手册'
 
 
-[[i18n.Steps]]
+[[i18n.H2.URL]]
+Label = ''
+Value = ''
+
+
+
+
+[[i18n.H2]]
 ID = '观光服务器的URL链接地址'
 Title = '观光服务器的URL链接地址'
-Description = '''
+HTML = '''
 当服务器安全无损的运行时，您可以观光展览出的URL链接地址。如今我们还未建设任何网
 页内容，您也只能看到一面白页或一直被送去语言性的404网页。在这阶段呢，您已经有一
 个含有hestiaHUGO可用的Hugo代码库了！
 '''
-Code = ''
-URL = ''
+Plain = '''
+当服务器安全无损的运行时，您可以观光展览出的URL链接地址。如今我们还未建设任何网
+页内容，您也只能看到一面白页或一直被送去语言性的404网页。在这阶段呢，您已经有一
+个含有hestiaHUGO可用的Hugo代码库了！
+'''
+Code = '''
+'''
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = 'git-commit'
 Title = 'Git Commit'
-Description = '''
+HTML = '''
+在还没开始编制任何网页内容前，我们建议您Git Commit掉这个代码库以防未来需要的时间
+穿越会点。有一件事必须搞清楚：把hestiaHUGO一起Git Commit。如今的hestiaHUGO不只是
+供应UI用具了。它其实还是个数据引擎来稳重化您的Hugo。所以呢，把它分开是会不安全
+的。
+'''
+Plain = '''
 在还没开始编制任何网页内容前，我们建议您Git Commit掉这个代码库以防未来需要的时间
 穿越会点。有一件事必须搞清楚：把hestiaHUGO一起Git Commit。如今的hestiaHUGO不只是
 供应UI用具了。它其实还是个数据引擎来稳重化您的Hugo。所以呢，把它分开是会不安全
@@ -379,14 +461,26 @@ Signed-off-by: 周健豪 ❬hollowaykeanho@gmail.com❭
 
 $ git push
 '''
-URL = ''
+
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
-[[i18n.Steps]]
+
+
+[[i18n.H2]]
 ID = '有关更新hestiaHUGO'
 Title = '有关更新hestiaHUGO'
-Description = '''
+HTML = '''
+在以后如果有需要更新hestiaHUGO，
+您只需更换那<code>themes/hestiaHUGO</code>文件夹就可以了。
+Hugo的从新配置如果下载中心手册没有列出是不需要的。
+切记：更新引擎有时会不小心破坏您所建设的边缘案例内容设计的。
+所以呢，您还是预备好时间检查所有的内容完整性。在这儿，我们也尽量会后向兼容。
+'''
+Plain = '''
 在以后如果有需要更新hestiaHUGO，您只需更换那'themes/hestiaHUGO'文件夹就可以了。
 Hugo的从新配置如果下载中心手册没有列出是不需要的。切记：更新引擎有时会不小心破坏
 您所建设的边缘案例内容设计的。所以呢，您还是预备好时间检查所有的内容完整性。在这
@@ -402,8 +496,11 @@ DemoHestia/
         └── hestiaHUGO/     🡨 只需更新这个文件夹就行了
             └── ...
 '''
-URL = ''
+
+
+[[i18n.H2.URL]]
 Label = ''
+Value = ''
 
 
 

--- a/sites/layouts/content/getting-started/common/components.toml
+++ b/sites/layouts/content/getting-started/common/components.toml
@@ -101,3 +101,8 @@ Variables = []
 Name = "zoralabPRE"
 Include = true
 Variables = []
+
+[[List]]
+Name = "zoralabCODE"
+Include = true
+Variables = []

--- a/sites/layouts/content/getting-started/common/index.html
+++ b/sites/layouts/content/getting-started/common/index.html
@@ -20,39 +20,106 @@
 	</section>
 
 
-	{{- $nav = append (dict "ID" $i18n.Objectives.ID "Label" $i18n.Objectives.Title) $nav }}
-	<section id='{{- $i18n.Objectives.ID -}}'>
-		<h2>{{- $i18n.Objectives.Title -}}</h2>
-		<p>{{- $i18n.Objectives.Description -}}</p>
-		<ol>
-			{{- range $i, $v := $i18n.Objectives.Outcomes }}
-			<li><p>{{- $v.Value -}}</p></li>
-			{{- end }}
-		</ol>
-	</section>
+	{{- range $unused, $subjectH2 := $i18n.H2 -}}
+		{{- $nav = append (dict "ID" $subjectH2.ID "Label" $subjectH2.Title) $nav }}
+	<section id='{{- $subjectH2.ID -}}'>
+		<h2>{{- $subjectH2.Title -}}</h2>
+		<p>{{- $subjectH2.HTML -}}</p>
 
+		{{- range $i, $v := $subjectH2.URL }}
+			{{- if and (not $v.Value) (not $v.Label) -}}
+				{{- continue -}}
+			{{- end -}}
 
-	{{- range $i, $v := $i18n.Steps }}
-	{{- $nav = append (dict "ID" $v.ID "Label" $v.Title) $nav }}
-	<section id='{{- $v.ID -}}'>
-		<h2>{{- $v.Title -}}</h2>
-		<p>{{- $v.Description -}}</p>
-
-		{{- if $v.URL }}
-			{{- $ret = merge $Page (dict "Input" (dict "Data" $v.URL)) -}}
+			{{- $ret = merge $Page (dict "Input" (dict "Data" $v.Value)) -}}
 			{{- $ret = partial "hestiaURL/Sanitize" $ret }}
 		<a href='{{- string $ret.Output -}}' class='button'>{{- $v.Label -}}</a>
 		{{- end }}
 
-		{{- if $v.Code }}
-		<pre>{{- $v.Code -}}</pre>
+		{{- if $subjectH2.Code }}
+		<pre>{{- htmlEscape $subjectH2.Code -}}</pre>
 		{{- end }}
 
-		{{- if $v.Image }}
-			{{- $ret = merge $Page (dict "Input" (dict "Data" $v.Image)) -}}
+		{{- if $subjectH2.Media }}
+			{{- $ret = merge $Page (dict "Input" (dict "Data" $subjectH2.Media)) -}}
 			{{- $ret = partial "hestiaMEDIA/Sanitize" $ret -}}
 			{{- $ret = $ret.Output }}
 		{{ partial "hestiaMEDIA/ToHTML" $ret }}
+		{{- end }}
+
+		{{- range $unusedH3, $subjectH3 := $subjectH2.H3 }}
+			{{- $nav = append (dict
+				"ID" $subjectH3.ID
+				"Label" $subjectH2.Title
+			) $nav }}
+		<section id='{{- $subjectH3.ID -}}'>
+			<h3>{{- $subjectH3.Title -}}</h3>
+			<p>{{- $subjectH3.HTML -}}</p>
+
+
+			{{- range $i, $v := $subjectH3.URL }}
+				{{- if and (not $v.Value) (not $v.Label) -}}
+					{{- continue -}}
+				{{- end -}}
+
+				{{- $ret = merge $Page (dict "Input" (dict "Data" $v.Value)) -}}
+				{{- $ret = partial "hestiaURL/Sanitize" $ret }}
+			<a href='{{- string $ret.Output -}}' class='button'>{{- $v.Label -}}</a>
+			{{- end }}
+
+
+			{{- if $subjectH3.Code }}
+			<pre>{{- htmlEscape $subjectH3.Code -}}</pre>
+			{{- end }}
+
+
+			{{- if $subjectH3.Media }}
+				{{- $ret = merge $Page (dict "Input"
+					(dict "Data" $subjectH3.Media)
+				) -}}
+				{{- $ret = partial "hestiaMEDIA/Sanitize" $ret -}}
+				{{- $ret = $ret.Output }}
+			{{ partial "hestiaMEDIA/ToHTML" $ret }}
+			{{- end }}
+		</section>
+
+
+			{{- range $unusedH4, $subjectH4 := $subjectH3.H4 }}
+			<section id='{{- $subjectH4.ID -}}'>
+				<h4>{{- $subjectH4.Title -}}</h3>
+				<p>{{- $subjectH3.HTML -}}</p>
+
+
+				{{- range $i, $v := $subjectH4.URL }}
+					{{- if and (not $v.Value) (not $v.Label) -}}
+						{{- continue -}}
+					{{- end -}}
+
+					{{- $ret = merge $Page (dict
+						"Input" (dict "Data" $v.Value)
+					) -}}
+					{{- $ret = partial "hestiaURL/Sanitize" $ret }}
+				<a href='{{- string $ret.Output -}}' class='button'>
+					{{- $v.Label -}}
+				</a>
+				{{- end }}
+
+
+				{{- if $subjectH4.Code }}
+				<pre>{{- htmlEscape $subjectH4.Code -}}</pre>
+				{{- end }}
+
+
+				{{- if $subjectH4.Media }}
+					{{- $ret = merge $Page (dict "Input"
+						(dict "Data" $subjectH4.Media)
+					) -}}
+					{{- $ret = partial "hestiaMEDIA/Sanitize" $ret -}}
+					{{- $ret = $ret.Output }}
+				{{ partial "hestiaMEDIA/ToHTML" $ret }}
+				{{- end }}
+			</section>
+			{{- end }}
 		{{- end }}
 	</section>
 	{{- end }}

--- a/sites/layouts/content/getting-started/common/index.json
+++ b/sites/layouts/content/getting-started/common/index.json
@@ -10,7 +10,10 @@ algorithms development.
 {{- $dataList := dict -}}
 {{- $i18n := .Data.Page.i18n -}}
 {{- $list := slice -}}
-{{- $data := dict -}}
+{{- $l2 := slice -}}
+{{- $l3 := slice -}}
+{{- $l4 := slice -}}
+{{- $media := false -}}
 {{- $ret := false -}}
 
 
@@ -18,58 +21,118 @@ algorithms development.
 
 {{- /* execute function */ -}}
 {{- $dataList = merge $dataList (dict
-	$i18n.Title .Titles.Page
-	$i18n.Description (printf "%s %s" .Descriptions.Page.Pitch .Descriptions.Page.Summary)
+	$i18n.Labels.Title .Titles.Page
+	$i18n.Labels.Description
+		(printf "%s %s" .Descriptions.Page.Pitch .Descriptions.Page.Summary)
 ) -}}
 
 
 
 
-{{- $list = slice -}}
-{{- range $i, $v := $i18n.Objectives.Outcomes -}}
-	{{- $list = append $v.Value $list -}}
-{{- end -}}
-{{- $dataList = merge $dataList (dict $i18n.Objectives.Title $list) -}}
+{{- /* render content */ -}}
+{{- $l2 = slice -}}
+{{- range $unused2, $h2 := $i18n.H2 -}}
+	{{- $l3 = slice -}}
+	{{- range $unused3, $h3 := $h2.H3 -}}
+		{{- $l4 = slice -}}
+		{{- range $unused4, $h4 := $h3.H4 -}}
+			{{- $list = slice -}}
+			{{- range $i, $v := $h4.URL -}}
+				{{- if and (not $v.Value) (not $v.Label) -}}
+					{{- continue -}}
+				{{- end -}}
+
+				{{- $ret = merge $Page (dict
+					"Input" (dict "Data" $v.Value)
+				) -}}
+				{{- $ret = partial "hestiaURL/Sanitize" $ret -}}
+				{{- $list = append (dict
+					$i18n.Labels.URL (string $ret.Output)
+					$i18n.Labels.Label $v.Label
+				) $list -}}
+			{{- end -}}
 
 
+			{{- $media = merge $Page (dict "Input" (dict "Data" $h4.Media)) -}}
+			{{- $media = partial "hestiaMEDIA/Sanitize" $media -}}
+			{{- $media = $media.Output -}}
 
 
-{{- $list = slice -}}
-{{- range $i, $v := $i18n.Steps -}}
-	{{- $ret = "" -}}
-	{{- if $v.Code -}}
-		{{- $ret = $v.Code -}}
+			{{- $l4 = append (dict
+				$i18n.Labels.Title $h4.Title
+				$i18n.Labels.Description $h4.Plain
+				$i18n.Labels.Code $h4.Code
+				$i18n.Labels.URL $list
+				$i18n.Labels.Media $media
+			) $l4 -}}
+		{{- end -}}
+
+
+		{{- $list = slice -}}
+		{{- range $i, $v := $h3.URL -}}
+			{{- if and (not $v.Value) (not $v.Label) -}}
+				{{- continue -}}
+			{{- end -}}
+
+			{{- $ret = merge $Page (dict
+				"Input" (dict "Data" $v.Value)
+			) -}}
+			{{- $ret = partial "hestiaURL/Sanitize" $ret -}}
+			{{- $list = append (dict
+				$i18n.Labels.URL (string $ret.Output)
+				$i18n.Labels.Label $v.Label
+			) $list -}}
+		{{- end -}}
+
+
+		{{- $media = merge $Page (dict "Input" (dict "Data" $h3.Media)) -}}
+		{{- $media = partial "hestiaMEDIA/Sanitize" $media -}}
+		{{- $media = $media.Output -}}
+
+
+		{{- $l3 = append (dict
+			$i18n.Labels.Title $h3.Title
+			$i18n.Labels.Description $h3.Plain
+			$i18n.Labels.Code $h3.Code
+			$i18n.Labels.URL $list
+			$i18n.Labels.Content $l4
+			$i18n.Labels.Media $media
+		) $l3 -}}
 	{{- end -}}
 
 
-	{{- $data = dict
-		$i18n.Title $v.Title
-		$i18n.Description $v.Description
-		$i18n.Labels.Code $ret
-	-}}
+	{{- $list = slice -}}
+	{{- range $i, $v := $h2.URL -}}
+		{{- if and (not $v.Value) (not $v.Label) -}}
+			{{- continue -}}
+		{{- end -}}
 
-
-	{{- $ret = "" -}}
-	{{- if $v.URL -}}
-		{{- $ret = merge $Page (dict "Input" (dict "Data" $v.URL)) -}}
+		{{- $ret = merge $Page (dict
+			"Input" (dict "Data" $v.Value)
+		) -}}
 		{{- $ret = partial "hestiaURL/Sanitize" $ret -}}
-		{{- $ret = string $ret.Output -}}
+		{{- $list = append (dict
+			$i18n.Labels.URL (string $ret.Output)
+			$i18n.Labels.Label $v.Label
+		) $list -}}
 	{{- end -}}
-	{{- $data = merge $data (dict $i18n.Labels.URL $ret) -}}
 
 
-	{{- $ret = dict -}}
-	{{- if $v.Image -}}
-		{{- $ret = merge $Page (dict "Input" (dict "Data" $v.Image)) -}}
-		{{- $ret = partial "hestiaMEDIA/Sanitize" $ret -}}
-		{{- $ret = $ret.Output -}}
-	{{- end -}}
-	{{- $data = merge $data (dict $i18n.Labels.Image $ret) -}}
+	{{- $media = merge $Page (dict "Input" (dict "Data" $h2.Media)) -}}
+	{{- $media = partial "hestiaMEDIA/Sanitize" $media -}}
+	{{- $media = $media.Output -}}
 
 
-	{{- $list = append $data $list -}}
+	{{- $l2 = append (dict
+		$i18n.Labels.Title $h2.Title
+		$i18n.Labels.Description $h2.Plain
+		$i18n.Labels.Code $h2.Code
+		$i18n.Labels.URL $list
+		$i18n.Labels.Content $l3
+		$i18n.Labels.Media $media
+	) $l2 -}}
 {{- end -}}
-{{- $dataList = merge $dataList (dict $i18n.Labels.Guides $list) -}}
+{{- $dataList = merge $dataList (dict $i18n.Labels.Content $l2) -}}
 
 
 


### PR DESCRIPTION
Currently, the getting-started pages' layout is very limited to plain text which is not suitable for HTML output. Since we have /releases pages layout to reference from, we can upgrade it so that it's viable for both HTML and JSON outputs. Let's do this.

This patch upgrades content/en/getting-started/* layout in sites/ directory.