### PR TITLE
hestiaHUGO: fixed LD+JSON breadcrumb issue for WebPage data type

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaJSON/schemaorgLDJSON/WebPage
+++ b/hestiaHUGO/layouts/partials/hestiaJSON/schemaorgLDJSON/WebPage
@@ -36,18 +36,22 @@ specific language governing permissions and limitations under the License.
 {{- /* prepare breadcrumb as WebPage has such a field */ -}}
 {{- $breadcrumb = dict -}}
 {{- if len $Page.Nav.Parents -}}
-	{{- $breadcrumb = "" -}}
+	{{- $breadcrumb = slice -}}
 	{{- range $i, $v := $Page.Nav.Parents -}}
-		{{- if $i -}}
-			{{- $breadcrumb = printf "%s, " $breadcrumb -}}
-		{{- end -}}
-
-		{{- $breadcrumb = printf "%s%s" $breadcrumb -}}
+		{{- $breadcrumb = append (dict
+			"@type" "ListItem"
+			"item" (dict
+				"@type" "Thing"
+				"name" $v.Titles.Page
+				"url" (string $v.URL.Current.Absolute)
+			)
+			"position" (add 1 (int $i))
+		) $breadcrumb -}}
 	{{- end -}}
 	{{- $breadcrumb = dict
 		"@type" "BreadcrumbList"
 		"itemListElement" $breadcrumb
-		"itemListOrder" "Descending"
+		"itemListOrder" "Ascending"
 		"numberOfItems" (len $Page.Nav.Parents)
 	-}}
 {{- end -}}


### PR DESCRIPTION
There was a bug rendering the breadcrumb dataset in LD+JSON function for WebPage data type. The existing algorithm was a badly coded placeholder rendering an invalid value. Hence, we need to fix it.

This patch fixes LD+JSON breadcrumb issue for WebPage data type in hestiaHUGO/ directory.