### PR TITLE
sites: increase the blackness of --body-color typography's coloration

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabCORE/ToCSS_VARIABLES
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabCORE/ToCSS_VARIABLES
@@ -165,7 +165,7 @@
 
 
 # typography color system
-"--body-color" = "var(--color-typography-800)"
+"--body-color" = "var(--color-typography-950)"
 "--body-color-inverted" = "var(--color-typography-50)"
 "--body-color-print" = "var(--color-typography-950)"
 "--body-color-indicator-red" = "#ff0000"


### PR DESCRIPTION
Sibert provided feedbacks that on HDR screen, the text is appearing with a very annoying subtle grey. He recommended to stick to black (but not pure). After experimentations, it seems
var(--color-typography-950) is the best. Hence, let's update it.

This patch increases the blackness of --body-color typography's coloration in sites/ directory.

Feedback-by: Sibertius <sibertius@gmail.com>