### PR TITLE
hestiaHUGO: fixed table header <code> and <pre> coloration

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabTABLE/ToCSS
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabTABLE/ToCSS
@@ -39,15 +39,17 @@ table :is(th, td) {
 	padding: var(--table-cell-padding);
 }
 
-table thead th {
+table :is(thead, tbody) :is(th, th code, th pre) {
 	color: var(--table-color-header);
+}
+
+table thead th {
 	background: var(--table-background-header-row);
 }
 
 table tbody th {
 	border: var(--table-cell-border);
 
-	color: var(--table-color-header);
 	background: var(--table-background-header-column);
 }
 


### PR DESCRIPTION
It appears the <code> and <pre> colorations were taken over by their respective components and appear in a very weird way (blue text over blue background). Hence, we need to fix this bug.

This patch fixes table header <code> and <pre> coloration in hestiaHUGO/ directory.