### PR TITLE
hestiaHUGO: fixed button not handling overflowing condition bug

### DIFF
--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabANCHOR/ToCSS
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabANCHOR/ToCSS
@@ -41,7 +41,6 @@ a {
 	text-decoration: var(--anchor-text-decoration);
 	text-transform: var(--anchor-text-transform);
 	overflow-wrap: var(--anchor-overflow-wrap);
-	word-break: var(--anchor-word-break);
 	letter-spacing: var(--anchor-letter-spacing);
 	line-height: var(--anchor-line-height);
 	text-align: var(--anchor-text-align);
@@ -86,7 +85,6 @@ a.prestige {
 @media print {
 	a {
 		overflow-wrap: var(--anchor-overflow-wrap-print) !important;
-		word-break: var(--anchor-overflow-word-break) !important;
 
 		color: var(--anchor-color-print) !important;
 		border-color: var(--anchor-color-print) !important;

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabANCHOR/ToCSS_VARIABLES
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabANCHOR/ToCSS_VARIABLES
@@ -25,8 +25,6 @@
 "--anchor-text-transform" = "normal"
 "--anchor-overflow-wrap" = "break-word"
 "--anchor-overflow-wrap-print" = "break-word"
-"--anchor-word-break" = "break-word"
-"--anchor-word-break-print" = "break-word"
 "--anchor-letter-spacing" = "initial"
 "--anchor-line-height" = "var(--body-line-height)"
 "--anchor-text-align" = "initial"

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabBUTTON/ToCSS
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabBUTTON/ToCSS
@@ -32,7 +32,6 @@ button, .button {
 	text-decoration: var(--button-text-decoration);
 	text-transform: var(--button-text-transform);
 	overflow-wrap: var(--button-overflow-wrap);
-	word-break: var(--button-word-break);
 	line-height: var(--button-line-height);
 
 	color: var(--button-color);

--- a/hestiaHUGO/layouts/partials/hestiaGUI/zoralabBUTTON/ToCSS_VARIABLES
+++ b/hestiaHUGO/layouts/partials/hestiaGUI/zoralabBUTTON/ToCSS_VARIABLES
@@ -24,8 +24,7 @@
 "--button-text-align" = "center"
 "--button-text-decoration" = "none"
 "--button-text-transform" = "uppercase"
-"--button-word-break" = "normal"
-"--button-overflow-wrap" = "normal"
+"--button-overflow-wrap" = "break-word"
 "--button-line-height" = "var(--body-line-height)"
 
 

--- a/sites/data/Specs/hestiaGUI/zoralabANCHOR/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabANCHOR/Designs.toml
@@ -1119,7 +1119,7 @@ Affects the word breaking behavior of the rendered component.
 Code = '''
 VARIABLE     : --anchor-word-break
 CSS PROPERTY : word-break
-DEFAULT      : break-word (>= v1.2.0)
+DEFAULT      : REMOVED (>= v1.2.1) break-word (== v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -1138,7 +1138,7 @@ Plain = '''
 Code = '''
 变化值     : --anchor-word-break
 CSS属性    : word-break
-默认数码   : break-word (>= v1.2.0)
+默认数码   : 删除没用了 (>= v1.2.1) break-word (== v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -1158,7 +1158,7 @@ Affects the word breaking behavior of the rendered component.
 Code = '''
 VARIABLE     : --anchor-word-break
 CSS PROPERTY : word-break
-DEFAULT      : break-word (>= v1.2.0)
+DEFAULT      : REMOVED (>= v1.2.1) break-word (== v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -1177,7 +1177,7 @@ Plain = '''
 Code = '''
 变化值     : --anchor-word-break
 CSS属性    : word-break
-默认数码   : break-word (>= v1.2.0)
+默认数码   : 删除没用了 (>= v1.2.1) break-word (== v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]

--- a/sites/data/Specs/hestiaGUI/zoralabBUTTON/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabBUTTON/Designs.toml
@@ -698,7 +698,7 @@ Affects the word breaking behavior of the rendered component.
 Code = '''
 VARIABLE     : --button-word-break
 CSS PROPERTY : word-break
-DEFAULT      : normal (>= v1.2.0)
+DEFAULT      : REMOVED (>= v1.2.1) normal (== v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -717,7 +717,7 @@ Plain = '''
 Code = '''
 变化值     : --button-word-break
 CSS属性    : word-break
-默认数码   : normal (>= v1.2.0)
+默认数码   : 删除没用了 (>= v1.2.1) normal (== v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]
@@ -737,7 +737,7 @@ Affects the overflow wrapping behavior of the rendered component.
 Code = '''
 VARIABLE     : --button-overflow-wrap
 CSS PROPERTY : overflow-wrap
-DEFAULT      : normal (>= v1.2.0)
+DEFAULT      : break-word (>= v1.2.1) normal (== v1.2.0)
 '''
 
 [[EN.List.SubList.URL]]
@@ -756,7 +756,7 @@ Plain = '''
 Code = '''
 变化值     : --button-overflow-wrap
 CSS属性    : overflow-wrap
-默认数码   : normal (>= v1.2.0)
+默认数码   : break-word (>= v1.2.1) normal (== v1.2.0)
 '''
 
 [[ZH-HANS.List.SubList.URL]]


### PR DESCRIPTION
Appearently, the button is not handling the overflowing condition properly due to multiple properties used (overflow-wrap + word-break). Hence, we need to fix it.

This patch fixes button not handling overflowing condition bug in hestiaHUGO/ directory.