### PR TITLE
sites: added responsive HTML for zoralabIFRAME

### DIFF
--- a/sites/data/Specs/hestiaGUI/zoralabIFRAME/Designs.toml
+++ b/sites/data/Specs/hestiaGUI/zoralabIFRAME/Designs.toml
@@ -155,6 +155,52 @@ Label = ''
 
 
 [[EN.List.SubList]]
+Title = 'Responsive HTML'
+HTML = '''
+The responsive HTML codes are shown below:
+'''
+Plain = '''
+The responsive HTML codes are shown below:
+'''
+Code = '''
+<iframe ...
+	width="100%"
+	style="aspect-ratio: [WIDTH]/[HEIGHT];"
+>
+	...
+</iframe>
+'''
+
+[[EN.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+[[ZH-HANS.List.SubList]]
+Title = '环境响应的HTML'
+HTML = '''
+环境响应的HTML代码运用方法如下：
+'''
+Plain = '''
+环境响应的HTML代码运用方法如下：
+'''
+Code = '''
+<iframe ...
+	width="100%"
+	style="aspect-ratio: [WIDTH]/[HEIGHT];"
+	...
+>
+	...
+</iframe>
+'''
+
+[[ZH-HANS.List.SubList.URL]]
+Value = ''
+Label = ''
+
+
+
+[[EN.List.SubList]]
 Title = 'Hidden iFrame HTML'
 HTML = '''
 The hidden iframe HTML codes are shown below:


### PR DESCRIPTION
Usually, iframe has fixed width and height and it's quite impossible to set to for responsive behavior based on windows size. However, after tested and discovered with YouTube iframe embed, we discovered a scalable and managable way to make it responsively. Hence, let's document it.

This patch adds responsive HTML code snippet for zoralabIFRAME GUI component in sites/ directory.